### PR TITLE
docs: remove internal note + correct feature-table facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Every feature below lives on WhatsApp. Click any feature for its own page — wh
 
 | Feature | What it does | Switches on when you set |
 |---|---|---|
-| 💬 **[AI Chat](docs/features/ai-chat.md)** | Teachers ask any teaching question by text or voice and get expert, pedagogy-grounded answers | _Always on_ (core) |
+| 💬 **[AI Chat](docs/features/ai-chat.md)** | Teachers ask any teaching question by text or voice and get expert, pedagogy-grounded answers | core (uses `OPENROUTER_API_KEY`); voice questions need `SONIOX_API_KEY` |
 | 📝 **[Registration](docs/features/registration.md)** | Friendly WhatsApp onboarding — name, school, grade, language | _Always on_ (core) |
 | 🎯 **[Classroom Coaching](docs/features/coaching.md)** | Teacher sends a class recording; Rumi transcribes, scores it against a pedagogical framework, has a reflective conversation, and returns a scored PDF report | `SONIOX_API_KEY` |
 | 📖 **[Reading Assessment](docs/features/reading-assessment.md)** | A student reads aloud into WhatsApp; Rumi measures fluency, accuracy, pronunciation, and comprehension against benchmarks | `SONIOX_API_KEY` |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -6,16 +6,14 @@ Run **`npm run doctor`** at any time to see which features are live for your cur
 
 | Feature | Essence | Switches on when you set |
 |---|---|---|
-| 💬 [AI Chat](ai-chat.md) | Ask any teaching question, get a pedagogy-grounded answer | _core — always on_ |
+| 💬 [AI Chat](ai-chat.md) | Ask any teaching question, get a pedagogy-grounded answer | core — powered by `OPENROUTER_API_KEY`; voice questions need `SONIOX_API_KEY` |
 | 📝 [Registration](registration.md) | Friendly WhatsApp onboarding for teachers | _core — always on_ |
 | 🎯 [Classroom Coaching](coaching.md) | Recording → framework-scored report + reflective conversation | `SONIOX_API_KEY` |
 | 📖 [Reading Assessment](reading-assessment.md) | Student reads aloud → fluency, accuracy, comprehension | `SONIOX_API_KEY` |
 | 📋 [Lesson Plans](lesson-plans.md) | Topic + grade → full lesson-plan PDF | `GAMMA_API_KEY` |
 | 🗣️ [Voice Messages](voice.md) | Full spoken interaction in many languages | `SONIOX_API_KEY` + `ELEVENLABS_API_KEY` |
 | 🎬 [Video Generation](video.md) | Topic → short narrated educational video | `VIDEO_GENERATION_ENABLED` + `KIE_API_KEY` |
-| ✅ [Attendance](attendance.md) | Voice/tap attendance via WhatsApp Flows | _core — always on_ |
-| 🧮 [Exam Checker](exam-checker.md) | Photograph answer sheets → OCR + AI grading | `AWS_TEXTRACT_*` |
-
-> The illustrations on these pages are generated with Kie.ai and kept deliberately **global** — Rumi is for teachers everywhere.
+| ✅ [Attendance](attendance.md) | Tap-based attendance via WhatsApp Flows | _core — always on_ |
+| 🧮 [Exam Checker](exam-checker.md) | Photograph answer sheets → vision OCR + AI grading | `MISTRAL_API_KEY` |
 
 For deep customization of any feature (swapping frameworks, changing benchmarks, adding languages or regions), see the [Agent Customization Guide](../agent-customization.md).


### PR DESCRIPTION
Small accuracy fixes to the merged docs: drop an internal-facing Kie/process line from the public feature index; correct AI Chat enablement (OpenRouter core + Soniox for voice); fix attendance (tap-based) and exam-checker (Mistral, not Textract) rows to match the feature pages and the actual code.

Part of a larger doc-accuracy effort — see CLAUDE_IMPLEMENTATION_PLAN.md addendum (2026-05-24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)