### PR TITLE
Phase 4A: curriculum LP path + standardized region gating (UG_LP dropped)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -80,6 +80,12 @@ LLM_MODEL=openai/gpt-4o
 # App URL used for OpenRouter's HTTP-Referer header (optional)
 APP_URL=https://your-app.up.railway.app
 
+# --- Region (optional) -------------------------------------------------------
+# This deployment's region. Per-region behaviour (which LP paths, coaching
+# framework, languages) is driven by the region_features DB table — set a row
+# per region; no code changes needed. Leave as 'default' for the generic setup.
+DEFAULT_REGION=default
+
 # --- ENABLES: Voice notes in (transcription) — Soniox -----------------------
 # Set this to let teachers send voice notes the bot understands (multi-language
 # STT: Urdu, Balochi, Sindhi, Pashto, ...). Also required for reading assessment

--- a/bot/shared/handlers/lesson-plan-v2.handler.js
+++ b/bot/shared/handlers/lesson-plan-v2.handler.js
@@ -1,0 +1,71 @@
+/**
+ * Curriculum Lesson Plan handler — the curriculum/pre-gen serve path.
+ *
+ * Given a topic, tries to match it to a textbook chapter and serve a
+ * pre-generated lesson-plan PDF from R2 instantly. If there's no chapter match
+ * or no pre-generated LP, it returns { source: 'page_prompt' } so the caller
+ * falls through to the normal Gamma generation flow.
+ *
+ * Only invoked for regions whose region_features enable curriculum LPs.
+ */
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const TopicMatchingService = require('../services/topic-matching.service');
+const PreGenLookupService = require('../services/pregen-lookup.service');
+const { downloadFromR2 } = require('../storage/r2');
+const WhatsAppService = require('../services/whatsapp.service');
+const { logToFile } = require('../utils/logger');
+
+/**
+ * @param {object} input
+ * @param {string} input.userId        WhatsApp id to send the document to
+ * @param {string} [input.topic]
+ * @param {number} [input.grade]
+ * @param {string} [input.subject]
+ * @param {string} input.curriculum    region_features.curriculum_key
+ * @param {string} [input.language]    'ur' selects the Urdu PDF, else English
+ * @returns {Promise<{ source: 'pre_generated'|'page_prompt', promptedForPage: boolean }>}
+ */
+async function handleCurriculumLessonPlan({ userId, topic, grade, subject, curriculum, language }) {
+  try {
+    if (!topic || !curriculum) return { source: 'page_prompt', promptedForPage: true };
+
+    const chapter = await TopicMatchingService.findChapterByTopic({ topic, grade, subject, curriculum });
+    if (!chapter) {
+      logToFile('Curriculum LP: no chapter match, falling through to Gamma', { topic, curriculum });
+      return { source: 'page_prompt', promptedForPage: true };
+    }
+
+    const preGen = await PreGenLookupService.findPreGenLP({
+      chapterNumber: chapter.chapter_number, grade, subject, curriculum,
+    });
+    const langCol = language === 'ur' ? 'pdf_r2_key_ur' : 'pdf_r2_key_en';
+    const r2Key = preGen && preGen[langCol];
+    if (!r2Key) {
+      logToFile('Curriculum LP: no pre-generated LP, falling through to Gamma', { chapter: chapter.chapter_number });
+      return { source: 'page_prompt', promptedForPage: true };
+    }
+
+    // OSS sendDocument reads a file path (createReadStream), so write the R2
+    // buffer to a temp file first, then clean it up (guards the bd-1349 trap
+    // where passing a Buffer to a path-expecting sender silently fails).
+    let tmpPath;
+    try {
+      const pdfBuffer = await downloadFromR2(r2Key);
+      tmpPath = path.join(os.tmpdir(), `curriculum_lp_${Date.now()}_${Math.random().toString(36).slice(2)}.pdf`);
+      fs.writeFileSync(tmpPath, pdfBuffer);
+      await WhatsAppService.sendDocument(userId, tmpPath, `${chapter.chapter_title} - Lesson Plan.pdf`);
+      logToFile('Curriculum LP: pre-generated LP served', { chapter: chapter.chapter_number, r2Key });
+      return { source: 'pre_generated', promptedForPage: false };
+    } finally {
+      if (tmpPath) { try { fs.unlinkSync(tmpPath); } catch (_) { /* best-effort cleanup */ } }
+    }
+  } catch (error) {
+    logToFile('Curriculum LP handler error, falling through to Gamma', { error: error.message, userId, topic });
+    return { source: 'page_prompt', promptedForPage: true };
+  }
+}
+
+module.exports = handleCurriculumLessonPlan;

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -15,6 +15,9 @@ const ReadingAssessmentService = require('../services/reading-assessment.service
 const FeatureLinkerService = require('../services/feature-linker.service');
 const FeatureIntroService = require('../services/feature-intro.service');
 const LessonPlanQueueService = require('../services/lesson-plan-queue.service');
+const handleCurriculumLessonPlan = require('./lesson-plan-v2.handler');
+const RegionFeaturesService = require('../services/region-features.service');
+const { getUserRegion } = require('../utils/region');
 const VideoOrchestrator = require('../services/video/video-orchestrator.service');
 const AttendanceDetectorService = require('../services/attendance-detector.service');
 const AttendanceConversationService = require('../services/attendance-conversation.service');
@@ -39,6 +42,34 @@ const {
 } = require('../database/bot-helpers');
 const supabase = require('../config/supabase');
 const fs = require('fs');
+
+/**
+ * Curriculum pre-gen intercept. If the teacher's region enables curriculum LPs
+ * (region_features.curriculum_lp_enabled) and the topic maps to a pre-generated
+ * chapter LP, serve it and return true. Returns false (no-op) for regions
+ * without curriculum LPs — the caller then falls through to the standard Gamma
+ * flow. region_features defaults curriculum_lp_enabled=false, so this is inert
+ * for a default deployment.
+ */
+async function tryCurriculumLessonPlanServe(from, topic, user, language) {
+  try {
+    const features = await RegionFeaturesService.getRegionFeatures(getUserRegion(user));
+    if (!features.curriculum_lp_enabled || !features.curriculum_key) return false;
+    const grade = parseInt(user && user.grade, 10) || (user && user.grade) || undefined;
+    const result = await handleCurriculumLessonPlan({
+      userId: from,
+      topic,
+      grade,
+      subject: user && user.subject,
+      curriculum: features.curriculum_key,
+      language,
+    });
+    return !!(result && result.source === 'pre_generated');
+  } catch (e) {
+    logToFile('Curriculum LP intercept failed, falling through to Gamma', { error: e.message });
+    return false;
+  }
+}
 
 /**
  * Handle text message processing
@@ -1550,6 +1581,11 @@ async function handleTextMessage(message, from, messageBody, user = null) {
       // Clear the state
       await MenuService.clearAwaitingLessonPlanTopic(user.id);
 
+      // Curriculum pre-gen intercept (no-op unless the region enables it)
+      if (await tryCurriculumLessonPlanServe(from, messageBody, user, lessonPlanState.language)) {
+        return; // curriculum pre-generated LP served instantly
+      }
+
       // Route directly to lesson plan handler (skip intent detection)
       await handleLessonPlanRequest(from, messageBody, user, lessonPlanState.sessionId, lessonPlanState.language, typingController);
       return; // Stop further processing
@@ -1571,6 +1607,10 @@ async function handleTextMessage(message, from, messageBody, user = null) {
   }
 
   if (intent.type === 'lesson_plan') {
+    // Curriculum pre-gen intercept (no-op unless the region enables it)
+    if (await tryCurriculumLessonPlanServe(from, messageBody, user, responseLanguage)) {
+      return; // curriculum pre-generated LP served instantly
+    }
     await handleLessonPlanRequest(from, messageBody, user, sessionId, responseLanguage, typingController);
   } else if (intent.type === 'presentation') {
     await handlePresentationRequest(from, messageBody, user, sessionId, responseLanguage, typingController);

--- a/bot/shared/services/lesson-plan-router.service.js
+++ b/bot/shared/services/lesson-plan-router.service.js
@@ -1,0 +1,55 @@
+/**
+ * Lesson Plan Router — decides which LP path a text-based LP request takes.
+ *
+ * Two tracks (the photo path, pic-to-LP, is handled separately by the image
+ * handler, not here):
+ *   - gamma_enriched   : curriculum/textbook-aligned LP. Used only when the
+ *                        teacher's region enables curriculum LPs (region_features),
+ *                        has textbooks for the subject, and a page anchor is given.
+ *                        The handler then serves a pre-generated LP if one exists,
+ *                        else generates an enriched one from textbook content.
+ *   - gamma_standard   : the default — generate a generic Gamma LP from the topic.
+ *
+ * Gating is DB-driven via region_features (no hardcoded regions). There is no
+ * external on-demand service (the old UG_LP path is intentionally gone).
+ */
+
+const { logToFile } = require('../utils/logger');
+const { getRegionFeatures } = require('./region-features.service');
+
+class LessonPlanRouterService {
+  /**
+   * @param {object} params
+   * @param {string} [params.userId]
+   * @param {string} params.region
+   * @param {number} [params.grade]
+   * @param {string} [params.subject]
+   * @param {number|string|null} [params.pageNumber]
+   * @returns {Promise<{ track: 'gamma_enriched'|'gamma_standard', reason: string }>}
+   */
+  static async route({ userId, region, grade, subject, pageNumber }) {
+    const subjectLower = (subject || '').toLowerCase().trim();
+    const gradeNum = Number(grade);
+    const hasPage = pageNumber != null && pageNumber !== '';
+
+    const features = await getRegionFeatures(region);
+    const subjectSupported =
+      !Array.isArray(features.supported_subjects) ||
+      features.supported_subjects.length === 0 ||
+      features.supported_subjects.map((s) => String(s).toLowerCase()).includes(subjectLower);
+
+    if (features.curriculum_lp_enabled && features.has_textbooks && hasPage && subjectSupported) {
+      const reason = `region "${features.region}" curriculum LP enabled — ${subjectLower || 'subject'} grade ${gradeNum} page ${pageNumber}`;
+      logToFile('LP Router: gamma_enriched (curriculum path)', { userId, region: features.region, reason });
+      return { track: 'gamma_enriched', reason };
+    }
+
+    const reason = features.curriculum_lp_enabled
+      ? `region "${features.region}" curriculum enabled but conditions unmet (need page + supported subject) — default Gamma`
+      : `region "${features.region}" curriculum LP not enabled — default Gamma`;
+    logToFile('LP Router: gamma_standard', { userId, region: features.region, reason });
+    return { track: 'gamma_standard', reason };
+  }
+}
+
+module.exports = LessonPlanRouterService;

--- a/bot/shared/services/pregen-lookup.service.js
+++ b/bot/shared/services/pregen-lookup.service.js
@@ -1,0 +1,49 @@
+/**
+ * Pre-Generated LP Lookup Service
+ *
+ * Checks if a pre-generated lesson plan exists for a given chapter.
+ */
+
+const supabase = require('../config/supabase');
+const { logToFile } = require('../utils/logger');
+
+class PreGenLookupService {
+  /**
+   * Find a pre-generated LP for a chapter
+   * @param {Object} input
+   * @param {number} input.chapterNumber
+   * @param {number} input.grade
+   * @param {string} input.subject
+   * @param {string} input.curriculum
+   * @returns {Promise<Object|null>} LP record with pdf_r2_key_en/ur or null
+   */
+  static async findPreGenLP({ chapterNumber, grade, subject, curriculum }) {
+    try {
+      const { data, error } = await supabase
+        .from('pre_generated_lps')
+        .select('pdf_r2_key_en, pdf_r2_key_ur, gamma_url_en, gamma_url_ur, generation_status')
+        .eq('curriculum', curriculum)
+        .eq('grade', grade)
+        .eq('chapter_number', chapterNumber)
+        .single();
+
+      if (error || !data) {
+        logToFile('No pre-gen LP found', { chapterNumber, grade, subject, curriculum });
+        return null;
+      }
+
+      if (data.generation_status !== 'completed') {
+        logToFile('Pre-gen LP not yet completed', { chapterNumber, status: data.generation_status });
+        return null;
+      }
+
+      logToFile('Pre-gen LP found', { chapterNumber, hasEn: !!data.pdf_r2_key_en, hasUr: !!data.pdf_r2_key_ur });
+      return data;
+    } catch (error) {
+      logToFile('Pre-gen lookup error', { error: error.message, chapterNumber });
+      return null;
+    }
+  }
+}
+
+module.exports = PreGenLookupService;

--- a/bot/shared/services/region-features.service.js
+++ b/bot/shared/services/region-features.service.js
@@ -1,0 +1,85 @@
+/**
+ * region-features — the standardized, DB-driven region gating mechanism.
+ *
+ * A deployment can run different LP behaviour per region WITHOUT code edits:
+ * add/edit a row in the `region_features` table and that region's features
+ * change. This replaces hardcoded region checks (no `=== 'punjab'`, no
+ * phone-number-ID dictionaries).
+ *
+ *   curriculum_lp_enabled  -> serve pre-generated curriculum LPs for this region
+ *   pic_lp_enabled         -> allow photo -> LP for this region
+ *   gamma_lp_enabled       -> allow generic Gamma LP (the default path)
+ *   default_framework      -> coaching framework default for this region
+ *   supported_subjects     -> subjects with curriculum textbooks
+ *
+ * Fail-open: if the table is empty/unreachable or a region has no row, we
+ * return DEFAULT_REGION_FEATURES (generic Gamma LP on, curriculum off) so LP
+ * generation never breaks over a missing config row.
+ */
+
+const supabase = require('../config/supabase');
+const { logToFile } = require('../utils/logger');
+
+const DEFAULT_REGION_FEATURES = {
+  region: 'default',
+  curriculum_key: null,
+  supported_subjects: [],
+  has_textbooks: false,
+  curriculum_lp_enabled: false,
+  pic_lp_enabled: true,
+  gamma_lp_enabled: true,
+  default_framework: 'oecd',
+  supported_languages: ['en'],
+};
+
+const _cache = new Map(); // region -> { row, ts }
+const TTL_MS = 5 * 60 * 1000;
+
+function _defaultFor(region) {
+  return { ...DEFAULT_REGION_FEATURES, region };
+}
+
+/**
+ * @param {string} region
+ * @returns {Promise<object>} the region's features (DB row, or code default)
+ */
+async function getRegionFeatures(region) {
+  const key = (region || 'default').toLowerCase().trim() || 'default';
+  const cached = _cache.get(key);
+  if (cached && Date.now() - cached.ts < TTL_MS) return cached.row;
+
+  let row;
+  try {
+    const { data, error } = await supabase
+      .from('region_features')
+      .select('*')
+      .eq('region', key)
+      .maybeSingle();
+    row = !error && data ? data : _defaultFor(key);
+  } catch (e) {
+    logToFile('region-features lookup failed; using default', { region: key, error: e.message });
+    row = _defaultFor(key);
+  }
+  _cache.set(key, { row, ts: Date.now() });
+  return row;
+}
+
+async function isCurriculumLpEnabled(region) {
+  return !!(await getRegionFeatures(region)).curriculum_lp_enabled;
+}
+
+async function isPicLpEnabled(region) {
+  return (await getRegionFeatures(region)).pic_lp_enabled !== false;
+}
+
+function _clearCache() {
+  _cache.clear();
+}
+
+module.exports = {
+  getRegionFeatures,
+  isCurriculumLpEnabled,
+  isPicLpEnabled,
+  DEFAULT_REGION_FEATURES,
+  _clearCache,
+};

--- a/bot/shared/services/toc-loading.service.js
+++ b/bot/shared/services/toc-loading.service.js
@@ -1,0 +1,58 @@
+/**
+ * Table of Contents Loading Service
+ *
+ * Loads manually-curated ToC JSON into the textbook_toc table.
+ */
+
+const supabase = require('../config/supabase');
+const { logToFile } = require('../utils/logger');
+
+class TocLoadingService {
+  /**
+   * Load ToC data into textbook_toc table
+   * @param {string} curriculum - e.g. 'punjab_snc_2020'
+   * @param {number} grade
+   * @param {string} subject
+   * @param {Array<Object>} tocData - Array of chapter objects
+   * @returns {Promise<{chaptersLoaded: number, errors: Array}>}
+   */
+  static async loadToc(curriculum, grade, subject, tocData) {
+    const errors = [];
+    let chaptersLoaded = 0;
+
+    try {
+      for (const chapter of tocData) {
+        const row = {
+          curriculum,
+          grade,
+          subject,
+          chapter_number: chapter.chapter,
+          chapter_title: chapter.title,
+          page_start: chapter.page_start,
+          page_end: chapter.page_end,
+          estimated_days: chapter.days || 5,
+          topic_keywords: chapter.topic_keywords || []
+        };
+
+        const { error } = await supabase
+          .from('textbook_toc')
+          .insert(row);
+
+        if (error) {
+          errors.push({ chapter: chapter.chapter, error: error.message });
+          logToFile('ToC insert error', { chapter: chapter.chapter, error: error.message });
+        } else {
+          chaptersLoaded++;
+        }
+      }
+
+      logToFile('ToC loading complete', { curriculum, grade, subject, chaptersLoaded, errorCount: errors.length });
+      return { chaptersLoaded, errors };
+    } catch (error) {
+      logToFile('ToC loading failed', { error: error.message });
+      return { chaptersLoaded, errors: [...errors, { error: error.message }] };
+    }
+  }
+}
+
+module.exports = TocLoadingService;

--- a/bot/shared/services/topic-matching.service.js
+++ b/bot/shared/services/topic-matching.service.js
@@ -1,0 +1,70 @@
+/**
+ * Topic Matching Service
+ *
+ * Matches a teacher's topic request to a textbook chapter
+ * using keyword lookup in textbook_toc.topic_keywords.
+ */
+
+const supabase = require('../config/supabase');
+const { logToFile } = require('../utils/logger');
+
+class TopicMatchingService {
+  /**
+   * Find a chapter by topic keyword match
+   * @param {Object} input
+   * @param {string} input.topic - Teacher's topic (e.g. 'fractions', 'kasoor')
+   * @param {number} input.grade
+   * @param {string} input.subject
+   * @param {string} input.curriculum
+   * @returns {Promise<Object|null>} Matched chapter or null
+   */
+  static async findChapterByTopic({ topic, grade, subject, curriculum }) {
+    try {
+      const normalizedTopic = topic.toLowerCase().trim();
+
+      // Step 1: Exact keyword match via Postgres contains
+      const { data, error } = await supabase
+        .from('textbook_toc')
+        .select('*')
+        .eq('curriculum', curriculum)
+        .contains('topic_keywords', [normalizedTopic])
+        .limit(1);
+
+      if (error) {
+        logToFile('Topic matching query error', { error: error.message, topic, curriculum });
+        return null;
+      }
+
+      if (data && data.length > 0) {
+        logToFile('Topic matched via keyword', { topic, chapter: data[0].chapter_title });
+        return data[0];
+      }
+
+      // Step 2: ILIKE fallback — partial match
+      const { data: ilikeData, error: ilikeError } = await supabase
+        .from('textbook_toc')
+        .select('*')
+        .eq('curriculum', curriculum)
+        .ilike('chapter_title', `%${normalizedTopic}%`)
+        .limit(1);
+
+      if (ilikeError) {
+        logToFile('Topic ILIKE query error', { error: ilikeError.message, topic });
+        return null;
+      }
+
+      if (ilikeData && ilikeData.length > 0) {
+        logToFile('Topic matched via ILIKE fallback', { topic, chapter: ilikeData[0].chapter_title });
+        return ilikeData[0];
+      }
+
+      logToFile('No topic match found', { topic, grade, subject, curriculum });
+      return null;
+    } catch (error) {
+      logToFile('Topic matching error', { error: error.message, topic });
+      return null;
+    }
+  }
+}
+
+module.exports = TopicMatchingService;

--- a/bot/shared/utils/region.js
+++ b/bot/shared/utils/region.js
@@ -1,0 +1,25 @@
+/**
+ * region — generic, global region resolution.
+ *
+ * Rumi is deployed worldwide, so region handling is config-driven, not
+ * hardcoded to any country. The deployment's region comes from the
+ * DEFAULT_REGION env var; a teacher's region (if known) comes from
+ * `users.region`. Per-region feature behaviour lives in the region_features
+ * table — see region-features.service.js.
+ */
+
+const DEFAULT_REGION = 'default';
+
+/** The deployment's region (set DEFAULT_REGION in .env; falls back to 'default'). */
+function detectRegion() {
+  const r = (process.env.DEFAULT_REGION || '').toLowerCase().trim();
+  return r || DEFAULT_REGION;
+}
+
+/** A teacher's region: their stored region if present, else the deployment default. */
+function getUserRegion(user) {
+  const r = user && typeof user.region === 'string' ? user.region.toLowerCase().trim() : '';
+  return r || detectRegion();
+}
+
+module.exports = { detectRegion, getUserRegion, DEFAULT_REGION };

--- a/infrastructure/supabase/00_complete-schema.sql
+++ b/infrastructure/supabase/00_complete-schema.sql
@@ -3280,3 +3280,105 @@ NOTIFY pgrst, 'reload schema';
 -- =============================================================================
 -- Schema creation complete.
 -- =============================================================================
+-- ============================================================================
+-- Curriculum Lesson Plans + Region Gating (Phase 4A)
+-- Self-contained curriculum-LP path: OCR'd textbooks -> pre-generated LPs
+-- looked up by region/grade/chapter and served from R2. Region gating is
+-- DB-driven via region_features (no hardcoded regions). The external on-demand
+-- UG_LP service is intentionally NOT part of this schema.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS textbooks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    province TEXT,
+    curriculum TEXT,
+    grade INTEGER CHECK (grade BETWEEN 1 AND 12),
+    subject TEXT,
+    filename TEXT,
+    r2_key TEXT,
+    total_pages INTEGER,
+    pdf_page_offset INTEGER DEFAULT 0,
+    ocr_status TEXT DEFAULT 'pending',
+    ocr_completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now(),
+    UNIQUE (province, grade, subject)
+);
+
+CREATE TABLE IF NOT EXISTS textbook_pages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    textbook_id UUID NOT NULL REFERENCES textbooks(id) ON DELETE CASCADE,
+    pdf_page_index INTEGER,
+    textbook_page_number INTEGER,
+    page_content TEXT,
+    page_images JSONB DEFAULT '[]',
+    learning_outcomes JSONB DEFAULT '[]',
+    exercises JSONB DEFAULT '[]',
+    teaching_points JSONB DEFAULT '[]',
+    has_tables BOOLEAN DEFAULT false,
+    has_math BOOLEAN DEFAULT false,
+    has_urdu BOOLEAN DEFAULT false,
+    content_length INTEGER,
+    ocr_confidence DOUBLE PRECISION,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    UNIQUE (textbook_id, pdf_page_index)
+);
+CREATE INDEX IF NOT EXISTS idx_textbook_pages_lookup ON textbook_pages USING btree (textbook_id, textbook_page_number) WHERE page_content IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS textbook_toc (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    textbook_id UUID REFERENCES textbooks(id) ON DELETE CASCADE,
+    chapter_number INTEGER,
+    chapter_title TEXT NOT NULL,
+    page_start INTEGER,
+    page_end INTEGER,
+    topic_keywords TEXT[] DEFAULT '{}',
+    learning_outcomes TEXT[] DEFAULT '{}',
+    estimated_days INTEGER DEFAULT 5,
+    is_manual_override BOOLEAN DEFAULT false,
+    curriculum TEXT,
+    grade INTEGER,
+    subject TEXT,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_textbook_toc_keywords ON textbook_toc USING gin (topic_keywords);
+CREATE INDEX IF NOT EXISTS idx_textbook_toc_lookup ON textbook_toc USING btree (curriculum, grade, subject);
+
+CREATE TABLE IF NOT EXISTS pre_generated_lps (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    textbook_id UUID REFERENCES textbooks(id) ON DELETE SET NULL,
+    chapter_title TEXT,
+    chapter_number INTEGER,
+    page_start INTEGER,
+    page_end INTEGER,
+    days INTEGER DEFAULT 5,
+    gamma_url_en TEXT,
+    gamma_url_ur TEXT,
+    pdf_r2_key_en TEXT,
+    pdf_r2_key_ur TEXT,
+    subject TEXT,
+    curriculum TEXT,
+    grade INTEGER,
+    prompt_version TEXT DEFAULT 'v1',
+    is_current BOOLEAN DEFAULT true,
+    generation_status TEXT DEFAULT 'pending' CHECK (generation_status IN ('pending','generating','completed','failed')),
+    generated_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_pregen_lps_lookup ON pre_generated_lps USING btree (curriculum, grade, chapter_number) WHERE is_current = true;
+
+-- Standardized region gating: a region's features turn on by config, not code.
+CREATE TABLE IF NOT EXISTS region_features (
+    region TEXT PRIMARY KEY,
+    curriculum_key TEXT,
+    supported_subjects TEXT[] DEFAULT '{}',
+    has_textbooks BOOLEAN DEFAULT false,
+    curriculum_lp_enabled BOOLEAN DEFAULT false,
+    pic_lp_enabled BOOLEAN DEFAULT true,
+    gamma_lp_enabled BOOLEAN DEFAULT true,
+    default_framework TEXT DEFAULT 'oecd',
+    supported_languages JSONB DEFAULT '["en"]',
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);

--- a/infrastructure/supabase/02_seed-data.sql
+++ b/infrastructure/supabase/02_seed-data.sql
@@ -73,3 +73,19 @@ ON CONFLICT DO NOTHING;
 INSERT INTO schema_versions (version, description)
 VALUES ('2.0.0', 'Rumi Platform production-parity schema (60 tables, 38 functions)')
 ON CONFLICT (version) DO NOTHING;
+
+-- ============================================================================
+-- Region features (standardized region gating) — Phase 4A
+-- 'default': generic Gamma LP + pic-to-LP on, curriculum LP off. Every region
+-- with no explicit row inherits these defaults (fail-open). Add a row per
+-- region to enable curriculum LPs / change the coaching framework / languages.
+-- 'demo_region' is a SYNTHETIC example (fictional curriculum) showing how a
+-- curriculum-enabled region looks — safe to delete.
+-- ============================================================================
+INSERT INTO region_features (region, gamma_lp_enabled, pic_lp_enabled, curriculum_lp_enabled, default_framework, supported_languages)
+VALUES ('default', true, true, false, 'oecd', '["en"]'::jsonb)
+ON CONFLICT (region) DO NOTHING;
+
+INSERT INTO region_features (region, curriculum_key, supported_subjects, has_textbooks, curriculum_lp_enabled, default_framework, supported_languages)
+VALUES ('demo_region', 'demo_curriculum', ARRAY['maths','english'], true, true, 'hots', '["en"]'::jsonb)
+ON CONFLICT (region) DO NOTHING;

--- a/tests/region/region-features.test.js
+++ b/tests/region/region-features.test.js
@@ -1,0 +1,70 @@
+/**
+ * region-features — the standardized, DB-driven region gating mechanism.
+ *
+ * The contract that matters (requirement #9): a region's LP behaviour is
+ * determined by DATA (a region_features row), not code. Region A with
+ * curriculum_lp_enabled=true routes to the curriculum path; region B with no
+ * row falls back to the safe default (curriculum off) — with NO code change.
+ */
+
+const path = require('path');
+
+function loadWithRows(rowsByRegion) {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/config/supabase', () => ({
+    from: () => ({
+      select: () => ({
+        eq: (col, region) => ({
+          maybeSingle: async () => ({ data: rowsByRegion[region] || null, error: null }),
+        }),
+      }),
+    }),
+  }));
+  return require('../../bot/shared/services/region-features.service');
+}
+
+describe('region-features (standardized region gating)', () => {
+  afterEach(() => jest.resetModules());
+
+  it('curriculum path turns on for a region whose row enables it', async () => {
+    const svc = loadWithRows({
+      demo_region: { region: 'demo_region', curriculum_lp_enabled: true, pic_lp_enabled: true, gamma_lp_enabled: true, default_framework: 'hots' },
+    });
+    svc._clearCache();
+    expect(await svc.isCurriculumLpEnabled('demo_region')).toBe(true);
+    expect((await svc.getRegionFeatures('demo_region')).default_framework).toBe('hots');
+  });
+
+  it('a region with NO row falls back to the safe default (curriculum off) — no code change', async () => {
+    const svc = loadWithRows({}); // table effectively empty for this region
+    svc._clearCache();
+    expect(await svc.isCurriculumLpEnabled('somewhere_new')).toBe(false);
+    const f = await svc.getRegionFeatures('somewhere_new');
+    expect(f.gamma_lp_enabled).toBe(true); // generic Gamma LP still works
+    expect(f.default_framework).toBe('oecd');
+  });
+
+  it('fails open to default when the DB query throws (never blocks LP)', async () => {
+    jest.resetModules();
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/config/supabase', () => ({
+      from: () => ({ select: () => ({ eq: () => ({ maybeSingle: async () => { throw new Error('db down'); } }) }) }),
+    }));
+    const svc = require('../../bot/shared/services/region-features.service');
+    svc._clearCache();
+    const f = await svc.getRegionFeatures('punjab');
+    expect(f.curriculum_lp_enabled).toBe(false);
+    expect(f.gamma_lp_enabled).toBe(true);
+  });
+
+  it('is generic/global — no hardcoded country logic in the region util', () => {
+    const src = require('fs').readFileSync(path.resolve(__dirname, '../../bot/shared/utils/region.js'), 'utf8');
+    expect(src).not.toMatch(/isPakistaniTeacher|PK_REGION_TAGS|punjab|92329|255677/i);
+    const { detectRegion } = require('../../bot/shared/utils/region');
+    const prev = process.env.DEFAULT_REGION;
+    process.env.DEFAULT_REGION = 'tanzania';
+    expect(detectRegion()).toBe('tanzania');
+    if (prev === undefined) delete process.env.DEFAULT_REGION; else process.env.DEFAULT_REGION = prev;
+  });
+});

--- a/tests/setup/schema-production-parity.test.js
+++ b/tests/setup/schema-production-parity.test.js
@@ -58,6 +58,13 @@ const PRODUCTION_TABLES = [
   'lesson_plans',
   'lesson_plan_requests',
 
+  // Curriculum Lesson Plans + region gating (Phase 4A)
+  'textbooks',
+  'textbook_pages',
+  'textbook_toc',
+  'pre_generated_lps',
+  'region_features',
+
   // Reading Assessment
   'reading_assessments',
   'lcpm_benchmarks',

--- a/tests/textbook-lp-v2/handler-curriculum.test.js
+++ b/tests/textbook-lp-v2/handler-curriculum.test.js
@@ -1,0 +1,75 @@
+/**
+ * Curriculum LP handler — serves a pre-generated LP PDF when topic→chapter→
+ * pre_generated_lps resolves, else returns page_prompt (caller falls through
+ * to Gamma). Guards: never throws; sends a file PATH not a Buffer (bd-1349).
+ */
+
+let sendDocument, downloadFromR2, findChapterByTopic, findPreGenLP;
+
+function load() {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/services/topic-matching.service', () => ({ findChapterByTopic }));
+  jest.doMock('../../bot/shared/services/pregen-lookup.service', () => ({ findPreGenLP }));
+  jest.doMock('../../bot/shared/storage/r2', () => ({ downloadFromR2 }));
+  jest.doMock('../../bot/shared/services/whatsapp.service', () => ({ sendDocument }));
+  return require('../../bot/shared/handlers/lesson-plan-v2.handler');
+}
+
+const base = { userId: '15551230000', topic: 'fractions', grade: 4, subject: 'maths', curriculum: 'demo_curriculum', language: 'en' };
+
+beforeEach(() => {
+  sendDocument = jest.fn().mockResolvedValue({});
+  downloadFromR2 = jest.fn().mockResolvedValue(Buffer.from('%PDF-1.4 fake'));
+  findChapterByTopic = jest.fn().mockResolvedValue({ chapter_number: 3, chapter_title: 'Fractions' });
+  findPreGenLP = jest.fn().mockResolvedValue({ pdf_r2_key_en: 'pre_gen/en.pdf', pdf_r2_key_ur: 'pre_gen/ur.pdf' });
+});
+afterEach(() => jest.resetModules());
+
+describe('handleCurriculumLessonPlan', () => {
+  it('returns page_prompt when no topic or no curriculum', async () => {
+    const h = load();
+    expect((await h({ ...base, topic: '' })).source).toBe('page_prompt');
+    expect((await h({ ...base, curriculum: '' })).source).toBe('page_prompt');
+  });
+
+  it('returns page_prompt when no chapter matches', async () => {
+    findChapterByTopic = jest.fn().mockResolvedValue(null);
+    const h = load();
+    expect((await h(base)).source).toBe('page_prompt');
+    expect(sendDocument).not.toHaveBeenCalled();
+  });
+
+  it('returns page_prompt when no pre-generated LP exists for the language', async () => {
+    findPreGenLP = jest.fn().mockResolvedValue(null);
+    const h = load();
+    expect((await h(base)).source).toBe('page_prompt');
+    expect(sendDocument).not.toHaveBeenCalled();
+  });
+
+  it('serves the pre-generated LP and sends a file PATH (not a Buffer)', async () => {
+    const h = load();
+    const r = await h(base);
+    expect(r.source).toBe('pre_generated');
+    expect(downloadFromR2).toHaveBeenCalledWith('pre_gen/en.pdf');
+    expect(sendDocument).toHaveBeenCalledTimes(1);
+    const [, filePath, filename] = sendDocument.mock.calls[0];
+    expect(typeof filePath).toBe('string');
+    expect(Buffer.isBuffer(filePath)).toBe(false);
+    expect(filePath).toMatch(/\.pdf$/);
+    expect(filename).toMatch(/Fractions/);
+  });
+
+  it('picks the Urdu PDF when language is ur', async () => {
+    const h = load();
+    await h({ ...base, language: 'ur' });
+    expect(downloadFromR2).toHaveBeenCalledWith('pre_gen/ur.pdf');
+  });
+
+  it('falls through to page_prompt (never throws) when R2 download fails', async () => {
+    downloadFromR2 = jest.fn().mockRejectedValue(new Error('R2 down'));
+    const h = load();
+    const r = await h(base);
+    expect(r.source).toBe('page_prompt');
+  });
+});

--- a/tests/textbook-lp-v2/pregen-lookup.test.js
+++ b/tests/textbook-lp-v2/pregen-lookup.test.js
@@ -1,0 +1,45 @@
+/**
+ * Pre-Generated LP Lookup Service tests.
+ * Returns the R2 keys only when a matching pre_generated_lps row exists AND
+ * its generation_status is 'completed'; otherwise null (never throws).
+ */
+
+describe('PreGenLookupService.findPreGenLP', () => {
+  let PreGenLookupService;
+  let single;
+
+  function mockWith(result) {
+    single = jest.fn().mockResolvedValue(result);
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/config/supabase', () => ({
+      from: () => ({
+        select: () => ({
+          eq: () => ({ eq: () => ({ eq: () => ({ single }) }) }),
+        }),
+      }),
+    }));
+    PreGenLookupService = require('../../bot/shared/services/pregen-lookup.service');
+  }
+
+  beforeEach(() => jest.resetModules());
+  afterEach(() => jest.resetModules());
+
+  const input = { chapterNumber: 3, grade: 4, subject: 'maths', curriculum: 'demo_curriculum' };
+
+  it('returns the row when a completed LP exists', async () => {
+    mockWith({ data: { pdf_r2_key_en: 'pre_gen/en.pdf', pdf_r2_key_ur: 'pre_gen/ur.pdf', generation_status: 'completed' }, error: null });
+    const r = await PreGenLookupService.findPreGenLP(input);
+    expect(r).not.toBeNull();
+    expect(r.pdf_r2_key_en).toBe('pre_gen/en.pdf');
+  });
+
+  it('returns null when the LP is not yet completed', async () => {
+    mockWith({ data: { pdf_r2_key_en: 'x', generation_status: 'generating' }, error: null });
+    expect(await PreGenLookupService.findPreGenLP(input)).toBeNull();
+  });
+
+  it('returns null (not throw) when there is no row / a query error', async () => {
+    mockWith({ data: null, error: { message: 'no rows' } });
+    expect(await PreGenLookupService.findPreGenLP(input)).toBeNull();
+  });
+});

--- a/tests/textbook-lp-v2/toc-loading.test.js
+++ b/tests/textbook-lp-v2/toc-loading.test.js
@@ -1,0 +1,41 @@
+/**
+ * ToC Loading Tests (bd-628)
+ *
+ * Scenarios:
+ *   1. loadToc imports JSON and stores chapters in textbook_toc
+ */
+
+describe('ToC Loading Service', () => {
+  let TocService;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    jest.doMock('../../bot/shared/utils/logger', () => ({
+      logToFile: jest.fn()
+    }));
+
+    jest.doMock('../../bot/shared/config/supabase', () => ({
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockResolvedValue({ data: [{}], error: null })
+      })
+    }));
+
+    TocService = require('../../bot/shared/services/toc-loading.service');
+  });
+
+  afterEach(() => jest.resetModules());
+
+  it('loads ToC JSON and stores chapters in textbook_toc', async () => {
+    const tocData = [
+      { chapter: 1, title: 'Whole Numbers', page_start: 1, page_end: 30, days: 5 },
+      { chapter: 2, title: 'Factors and Multiples', page_start: 31, page_end: 49, days: 5 },
+      { chapter: 3, title: 'Fractions', page_start: 50, page_end: 68, days: 5 }
+    ];
+
+    const result = await TocService.loadToc('punjab_snc_2020', 4, 'maths', tocData);
+
+    expect(result.chaptersLoaded).toBe(3);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/tests/textbook-lp-v2/topic-matching.test.js
+++ b/tests/textbook-lp-v2/topic-matching.test.js
@@ -1,0 +1,154 @@
+/**
+ * Topic Matching Service Tests (bd-632)
+ *
+ * Scenarios:
+ *   1. "fractions" → matches Unit 3 (exact keyword)
+ *   2. "like fractions" → matches Unit 3 (keyword containment)
+ *   3. "kasoor" (Urdu) → matches Unit 3 (Urdu keyword in topic_keywords)
+ *   4. "geometry" → matches Unit 7, NOT Unit 3
+ *   5. "xyz nonsense" → returns null (no match)
+ */
+
+describe('TopicMatchingService', () => {
+  let TopicMatchingService;
+  let mockSupabase;
+
+  const mockTocData = [
+    {
+      chapter_number: 1, chapter_title: 'Whole Numbers',
+      topic_keywords: ['whole numbers', 'place value', 'addition', 'subtraction'],
+      page_start: 1, page_end: 30
+    },
+    {
+      chapter_number: 3, chapter_title: 'Fractions',
+      topic_keywords: ['fractions', 'like fractions', 'unlike fractions', 'equivalent fractions', 'kasoor', 'کسر'],
+      page_start: 50, page_end: 68
+    },
+    {
+      chapter_number: 7, chapter_title: 'Geometry',
+      topic_keywords: ['geometry', 'shapes', 'angles', 'triangle', 'rectangle'],
+      page_start: 120, page_end: 145
+    }
+  ];
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    jest.doMock('../../bot/shared/utils/logger', () => ({
+      logToFile: jest.fn()
+    }));
+
+    // Mock supabase to return chapters based on keyword match
+    mockSupabase = {
+      from: jest.fn().mockImplementation((table) => {
+        if (table === 'textbook_toc') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                contains: jest.fn().mockImplementation((col, keywords) => {
+                  const keyword = keywords[0];
+                  const match = mockTocData.find(c =>
+                    c.topic_keywords.some(k => k === keyword || k.includes(keyword))
+                  );
+                  return {
+                    limit: jest.fn().mockResolvedValue({
+                      data: match ? [match] : [],
+                      error: null
+                    })
+                  };
+                })
+              })
+            })
+          };
+        }
+        if (table === 'pre_generated_lps') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockReturnValue({
+                    single: jest.fn().mockResolvedValue({
+                      data: { pdf_r2_key_en: 'pre_gen_lps/test.pdf', pdf_r2_key_ur: 'pre_gen_lps/test_ur.pdf' },
+                      error: null
+                    })
+                  })
+                })
+              })
+            })
+          };
+        }
+      })
+    };
+    jest.doMock('../../bot/shared/config/supabase', () => mockSupabase);
+
+    TopicMatchingService = require('../../bot/shared/services/topic-matching.service');
+  });
+
+  afterEach(() => jest.resetModules());
+
+  // --- Scenario 1: exact keyword match ---
+  it('"fractions" matches Unit 3', async () => {
+    const result = await TopicMatchingService.findChapterByTopic({
+      topic: 'fractions',
+      grade: 4,
+      subject: 'maths',
+      curriculum: 'punjab_snc_2020'
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.chapter_title).toBe('Fractions');
+    expect(result.chapter_number).toBe(3);
+  });
+
+  // --- Scenario 2: keyword containment ---
+  it('"like fractions" matches Unit 3', async () => {
+    const result = await TopicMatchingService.findChapterByTopic({
+      topic: 'like fractions',
+      grade: 4,
+      subject: 'maths',
+      curriculum: 'punjab_snc_2020'
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.chapter_number).toBe(3);
+  });
+
+  // --- Scenario 3: Urdu keyword ---
+  it('"kasoor" (Urdu) matches Unit 3', async () => {
+    const result = await TopicMatchingService.findChapterByTopic({
+      topic: 'kasoor',
+      grade: 4,
+      subject: 'maths',
+      curriculum: 'punjab_snc_2020'
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.chapter_number).toBe(3);
+  });
+
+  // --- Scenario 4: different chapter ---
+  it('"geometry" matches Unit 7, not Unit 3', async () => {
+    const result = await TopicMatchingService.findChapterByTopic({
+      topic: 'geometry',
+      grade: 4,
+      subject: 'maths',
+      curriculum: 'punjab_snc_2020'
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.chapter_number).toBe(7);
+    expect(result.chapter_title).toBe('Geometry');
+  });
+
+  // --- Scenario 5: no match ---
+  it('"xyz nonsense" returns null', async () => {
+    const result = await TopicMatchingService.findChapterByTopic({
+      topic: 'xyz nonsense',
+      grade: 4,
+      subject: 'maths',
+      curriculum: 'punjab_snc_2020'
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/textbook-lp/lp-router.test.js
+++ b/tests/textbook-lp/lp-router.test.js
@@ -1,0 +1,64 @@
+/**
+ * LP Router — region_features-driven, two-track (gamma_enriched / gamma_standard).
+ * Guards: curriculum path only when the region enables it + has textbooks +
+ * supported subject + a page anchor; NEVER routes to the removed ug_lp path.
+ */
+
+function loadRouterWithRegion(features) {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/services/region-features.service', () => ({
+    getRegionFeatures: async () => features,
+  }));
+  return require('../../bot/shared/services/lesson-plan-router.service');
+}
+
+const curriculumRegion = {
+  region: 'demo_region', curriculum_lp_enabled: true, has_textbooks: true,
+  supported_subjects: ['maths', 'english'], gamma_lp_enabled: true,
+};
+const plainRegion = {
+  region: 'default', curriculum_lp_enabled: false, has_textbooks: false,
+  supported_subjects: [], gamma_lp_enabled: true,
+};
+
+describe('LessonPlanRouterService.route', () => {
+  afterEach(() => jest.resetModules());
+
+  it('routes to gamma_enriched when region enables curriculum + supported subject + page', async () => {
+    const Router = loadRouterWithRegion(curriculumRegion);
+    const r = await Router.route({ region: 'demo_region', grade: 4, subject: 'maths', pageNumber: 50 });
+    expect(r.track).toBe('gamma_enriched');
+  });
+
+  it('routes to gamma_standard when no page anchor is given', async () => {
+    const Router = loadRouterWithRegion(curriculumRegion);
+    const r = await Router.route({ region: 'demo_region', grade: 4, subject: 'maths', pageNumber: null });
+    expect(r.track).toBe('gamma_standard');
+  });
+
+  it('routes to gamma_standard for an unsupported subject', async () => {
+    const Router = loadRouterWithRegion(curriculumRegion);
+    const r = await Router.route({ region: 'demo_region', grade: 4, subject: 'science', pageNumber: 50 });
+    expect(r.track).toBe('gamma_standard');
+  });
+
+  it('routes to gamma_standard for a region with curriculum LP disabled', async () => {
+    const Router = loadRouterWithRegion(plainRegion);
+    const r = await Router.route({ region: 'anywhere', grade: 4, subject: 'maths', pageNumber: 50 });
+    expect(r.track).toBe('gamma_standard');
+  });
+
+  it('NEVER returns the removed ug_lp track', async () => {
+    const Router = loadRouterWithRegion(curriculumRegion);
+    for (const args of [
+      { region: 'demo_region', grade: 3, subject: 'maths', pageNumber: 10 },
+      { region: 'demo_region', grade: 9, subject: 'english', pageNumber: 99 },
+      { region: 'default', grade: 2, subject: 'urdu', pageNumber: 5 },
+    ]) {
+      const r = await Router.route(args);
+      expect(['gamma_enriched', 'gamma_standard']).toContain(r.track);
+      expect(r.track).not.toBe('ug_lp');
+    }
+  });
+});


### PR DESCRIPTION
Requirement #9's headline: a **separate curriculum-based LP path** + a **standardized, DB-driven mechanism for gating features to regions**. The external on-demand UG_LP service is dropped (inaccessible to cloners); the curriculum path is self-contained (DB lookup + R2).

**5 commits, each tested + gitleaks-clean (full suite 768 green):**
1. Schema — `textbooks`/`textbook_pages`/`textbook_toc`/`pre_generated_lps` + `region_features`.
2. Lookup services — `topic-matching`, `pregen-lookup`, `toc-loading` (ported clean).
3. Region gating — `region-features.service` (DB-driven, fail-open default) + generic/global `region.js` (no country hardcoding, no phone numbers) + seed + contract test.
4. LP router — region_features-driven, two-track (`gamma_enriched`/`gamma_standard`); UG_LP never returned (asserted).
5. Wiring — `lesson-plan-v2.handler` (topic→chapter→pre-gen→R2→WhatsApp; writes buffer to temp file for the path-based sendDocument) + a guarded intercept in `text-message.handler`.

**Default-safe:** `region_features.curriculum_lp_enabled` defaults false, so the intercept is a no-op for a default deployment — zero behavior change. A region enables the curriculum path purely via a DB row (the standardized gating).

Docs for this feature come in the final docs pass (Phase 8), against shipped code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)