### PR TITLE
Phase 4A.2 — pic-to-LP (photo → illustrated lesson plan via Kie.ai)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -415,6 +415,30 @@ GITHUB_BRANCH_BOT=main
 # with VIDEO_GENERATION_ENABLED=true above and a TTS key for narration.
 KIE_API_KEY=
 
+# --- ENABLES: Pic-to-LP (photo → illustrated lesson plan) --------------------
+# A teacher photographs a textbook page and Rumi generates a 2-page illustrated
+# lesson-plan PDF via Kie.ai image generation. Requires KIE_API_KEY (above);
+# leave the keys below blank to use defaults / skip the optional pieces.
+#
+# Optional dedicated Kie.ai key for pic-to-LP (rate-limit isolation from the
+# video feature). Falls back to KIE_API_KEY when unset.
+KIE_API_KEY_PIC_LP=
+# WhatsApp Flow ID for the pic-to-LP confirmation form. Leave blank to fall
+# back to a plain-text confirmation message instead of the Flow.
+PIC_LP_FLOW_ID=
+# Optional teacher-facing WhatsApp number shown in the lesson-plan Coaching
+# Corner ("WhatsApp Rumi · <number>"). Leave blank to omit the contact line.
+COACHING_WHATSAPP_NUMBER=
+# Optional R2 object key for the brand-mark logo rendered in the LP header
+# (defaults to brand/rumi-white-smile-v1.png when unset).
+RUMI_LOGO_R2_KEY=
+# Optional model overrides (default to gpt-4o-mini when unset).
+PIC_LP_CLASSIFIER_MODEL=
+PIC_LP_EXTRACTOR_MODEL=
+# Optional debug overrides to force a specific image backend ('true' to enable).
+PIC_LP_FORCE_GAMMA=
+PIC_LP_FORCE_KIEAI=
+
 # --- Optional: Phone Number ---------------------------------------------------
 # Bot's phone number in international format (without +)
 

--- a/bot/shared/handlers/image-message.handler.js
+++ b/bot/shared/handlers/image-message.handler.js
@@ -5,6 +5,12 @@
  * Teachers can send classroom photos, worksheets, student work, etc.
  * for analysis and feedback.
  *
+ * Routing order (each gate falls through to the next):
+ *   1. Coaching classroom-photo collection (active coaching session)
+ *   2. Exam checker (active exam session)
+ *   3. Pic-to-LP: a textbook-page photo → illustrated lesson-plan PDF
+ *   4. Generic vision analysis (fallback — feedback on any image)
+ *
  * Features:
  * - Idempotency via Redis (prevents duplicate processing)
  * - R2 storage with retry (image persists for retry capability)
@@ -200,210 +206,48 @@ async function handleImageMessage(message, from, user = null) {
         // Continue with regular image analysis
       }
 
-      // Get or create session for conversation history
-      const sessionId = await getOrCreateSession(user.id);
-
-      // Atomic idempotency check — SET NX ensures only one handler proceeds (bd-690)
-      const idempotencyKey = `image:${user.id}:${imageId}`;
-      idempotencyAcquired = await redisService.setNX(
-        idempotencyKey,
-        JSON.stringify({ status: 'processing', startedAt: Date.now() }),
-        IDEMPOTENCY_TTL_SECONDS
-      );
-
-      if (!idempotencyAcquired) {
-        // Another handler already has this image — check for cached result
-        const existingResult = await redisService.get(idempotencyKey);
-        if (existingResult) {
-          try {
-            const cached = JSON.parse(existingResult);
-            if (cached.response) {
-              logToFile('🔄 Duplicate image, returning cached result', { imageId, userId: user.id });
-              typingController.stop();
-              await WhatsAppService.sendMessage(from, cached.response);
-              return;
-            }
-          } catch (parseErr) {
-            // Result still processing or invalid — just bail
-          }
-        }
-        logToFile('🔄 Duplicate image detected, skipping (another handler active)', { imageId, userId: user.id });
-        typingController.stop();
-        return;
-      }
-
-      // Get user's language preference
-      const userLanguage = await getUserLanguage(user.id) || user.preferred_language || 'en';
-
-      // Create database record for tracking
-      const { data: analysisRequest, error: dbError } = await supabase
-        .from('image_analysis_requests')
-        .insert({
-          user_id: user.id,
-          image_url: 'pending', // Will update after R2 upload
-          image_metadata: {
-            whatsappMediaId: imageId,
-            mimeType,
-            caption,
-            uploadedAt: new Date().toISOString()
-          },
-          status: 'processing',
-          started_at: new Date().toISOString(),
-          correlation_id: correlationId
-        })
-        .select()
-        .single();
-
-      if (dbError) {
-        logToFile('⚠️ Failed to create analysis request record', {
-          error: dbError.message,
-          userId: user.id
-        });
-        // Continue anyway - database tracking is nice-to-have
-      }
-
-      const requestId = analysisRequest?.id;
-
-      // Step 1: Download image from WhatsApp
-      logToFile('Step 1: Downloading image from WhatsApp...', { imageId });
-      const imageBuffer = await WhatsAppService.downloadMedia(imageId);
-      logToFile('Image downloaded', { sizeBytes: imageBuffer.length });
-
-      // Step 2: Upload to R2 with retry
-      logToFile('Step 2: Uploading image to R2 storage...');
-      let imageUrl;
+      // ============================================================
+      // PIC-TO-LP DETECTION: book-page → illustrated lesson plan
+      // Slots AFTER coaching + exam-checker so neither flow is regressed.
+      // tryPicLpRoute returns true once the image is enqueued to the batch
+      // coalescer (which classifies once per batch and either starts an LP
+      // session or falls back to generic vision analysis).
+      // ============================================================
       try {
-        imageUrl = await uploadImageWithRetry(imageBuffer, user.id, imageId, mimeType);
-        logToFile('✅ Image uploaded to R2', { imageUrl });
-
-        // Update database record with R2 URL
-        if (requestId) {
-          await supabase
-            .from('image_analysis_requests')
-            .update({ image_url: imageUrl })
-            .eq('id', requestId);
-        }
-      } catch (uploadError) {
-        logToFile('❌ R2 upload failed', { error: uploadError.message });
-        // Continue with base64 fallback - analysis still possible
-        imageUrl = null;
-      }
-
-      // Step 3: Analyze image with Vision service
-      logToFile('Step 3: Analyzing image with GPT-4.1-mini...');
-
-      // Build analysis prompt based on context
-      let analysisPrompt = caption
-        ? `The teacher sent this image with the following context: "${caption}". Analyze the image and provide helpful feedback.`
-        : 'Analyze this classroom-related image. It could be student work, a worksheet, whiteboard content, or classroom setup. Provide constructive feedback.';
-
-      // Add language instruction
-      if (userLanguage === 'ur') {
-        analysisPrompt += '\n\nPlease respond in Urdu (اردو) with some English technical terms where appropriate.';
-      } else if (userLanguage === 'ar') {
-        analysisPrompt += '\n\nPlease respond in Arabic (العربية).';
-      } else if (userLanguage === 'es') {
-        analysisPrompt += '\n\nPlease respond in Spanish (Español).';
-      }
-
-      // Analyze with vision service - always use buffer (service handles base64 conversion)
-      const analysisResult = await VisionService.analyzeWithRetry(
-        imageBuffer,
-        mimeType,
-        {
-          prompt: analysisPrompt,
-          language: userLanguage
-        }
-      );
-
-      logEvent('image.analysis.completed', {
-        requestId,
-        userId: user.id,
-        durationMs: Date.now() - startTime,
-        tokensUsed: analysisResult.usage?.totalTokens || 0,
-        success: analysisResult.success
-      });
-
-      // Handle analysis result
-      let responseMessage;
-      if (analysisResult.success) {
-        responseMessage = analysisResult.analysis;
-
-        // Update database with success
-        if (requestId) {
-          await supabase
-            .from('image_analysis_requests')
-            .update({
-              status: 'completed',
-              completed_at: new Date().toISOString(),
-              analysis_result: {
-                success: true,
-                analysis: analysisResult.analysis,
-                usage: analysisResult.usage,
-                model: analysisResult.model,
-                detail: analysisResult.detail
-              },
-              tokens_used: analysisResult.usage?.totalTokens || 0
-            })
-            .eq('id', requestId);
-        }
-
-        // Cache successful result for idempotency
-        await redisService.set(
-          idempotencyKey,
-          JSON.stringify({ response: responseMessage, timestamp: Date.now() }),
-          IDEMPOTENCY_TTL_SECONDS
-        );
-
-        // Store in conversation history for follow-up context
-        try {
-          await storeConversation(user.id, 'user', `[Sent image${caption ? `: "${caption}"` : ''}]`, 'image', sessionId);
-          await storeConversation(user.id, 'assistant', responseMessage, 'text', sessionId);
-          logToFile('✅ Image conversation stored for context', { userId: user.id, sessionId });
-        } catch (storeError) {
-          logToFile('⚠️ Failed to store image conversation', { error: storeError.message });
-        }
-      } else {
-        // Analysis failed
-        logToFile('❌ Image analysis failed', {
-          error: analysisResult.error,
-          requestId
+        const handled = await tryPicLpRoute({
+          user,
+          from,
+          imageId,
+          mimeType,
+          caption,
+          typingController,
         });
-
-        // Update database with failure
-        if (requestId) {
-          await supabase
-            .from('image_analysis_requests')
-            .update({
-              status: 'failed',
-              completed_at: new Date().toISOString(),
-              last_error: analysisResult.error,
-              retry_count: (analysisRequest?.retry_count || 0) + 1
-            })
-            .eq('id', requestId);
+        if (handled) {
+          // Tag idempotency so repeat sends don't fall through to vision analysis
+          await redisService.set(
+            `image:${user.id}:${imageId}`,
+            JSON.stringify({ status: 'pic_lp_handled', timestamp: Date.now() }),
+            IDEMPOTENCY_TTL_SECONDS
+          );
+          return;
         }
-
-        // Send error message in user's language
-        const errorMessages = {
-          en: "Sorry, I couldn't analyze this image. Please try again with a clearer photo.\n\nTip: Make sure the image is well-lit and not blurry.",
-          ur: "معذرت، میں اس تصویر کا تجزیہ نہیں کر سکی۔ براہ کرم ایک صاف تصویر کے ساتھ دوبارہ کوشش کریں۔\n\nمشورہ: یقینی بنائیں کہ تصویر روشن اور واضح ہو۔",
-          ar: "عذرًا، لم أتمكن من تحليل هذه الصورة. يرجى المحاولة مرة أخرى بصورة أوضح.\n\nنصيحة: تأكد من أن الصورة مضاءة جيدًا وغير ضبابية.",
-          es: "Lo siento, no pude analizar esta imagen. Por favor intenta de nuevo con una foto más clara.\n\nConsejo: Asegúrate de que la imagen esté bien iluminada y no borrosa."
-        };
-
-        responseMessage = errorMessages[userLanguage] || errorMessages.en;
+      } catch (picLpError) {
+        logToFile('⚠️ Error in pic-to-LP routing (non-critical)', {
+          error: picLpError.message,
+          stack: picLpError.stack,
+        });
+        // Fall through to generic vision analysis
       }
 
-      // Stop typing and send response
-      typingController.stop();
-      await WhatsAppService.sendMessage(from, responseMessage);
-
-      logToFile('✅ Image analysis response sent', {
-        userId: user.id,
-        requestId,
-        durationMs: Date.now() - startTime
+      // Generic vision-feedback path. Extracted into runImageAnalysis so the
+      // pic-LP batch coalescer can reuse it for non-textbook images (one reply
+      // per batch).
+      const result = await runImageAnalysis({
+        user, from, imageId, mimeType, caption,
+        typingController, correlationId, startTime,
       });
-
+      idempotencyAcquired = result.idempotencyAcquired;
+      return;
     } catch (error) {
       logEvent('image.analysis.failed', {
         userId: user?.id,
@@ -440,6 +284,474 @@ async function handleImageMessage(message, from, user = null) {
   });
 }
 
+/**
+ * Generic vision-feedback path (extracted from handleImageMessage so the
+ * pic-LP batch coalescer can reuse it for non-textbook images).
+ *
+ * Steps: Redis idempotency lock → DB record (image_analysis_requests) → R2
+ * upload → VisionService.analyzeWithRetry → send reply → cache result → store
+ * conversation history.
+ *
+ * Throws on unexpected errors so the caller's outer try/catch can send the
+ * localized generic error message (gated by idempotencyAcquired). Returns
+ * `{ idempotencyAcquired }` so the caller can update its own flag for that guard.
+ */
+async function runImageAnalysis({ user, from, imageId, mimeType, caption, typingController, correlationId, startTime }) {
+  // Get or create session for conversation history
+  const sessionId = await getOrCreateSession(user.id);
+
+  // Atomic idempotency check — SET NX ensures only one handler proceeds (bd-690)
+  const idempotencyKey = `image:${user.id}:${imageId}`;
+  const idempotencyAcquired = await redisService.setNX(
+    idempotencyKey,
+    JSON.stringify({ status: 'processing', startedAt: Date.now() }),
+    IDEMPOTENCY_TTL_SECONDS
+  );
+
+  if (!idempotencyAcquired) {
+    // Another handler already has this image — check for cached result
+    const existingResult = await redisService.get(idempotencyKey);
+    if (existingResult) {
+      try {
+        const cached = JSON.parse(existingResult);
+        if (cached.response) {
+          logToFile('🔄 Duplicate image, returning cached result', { imageId, userId: user.id });
+          typingController.stop();
+          await WhatsAppService.sendMessage(from, cached.response);
+          return { idempotencyAcquired: false };
+        }
+      } catch (parseErr) {
+        // Result still processing or invalid — just bail
+      }
+    }
+    logToFile('🔄 Duplicate image detected, skipping (another handler active)', { imageId, userId: user.id });
+    typingController.stop();
+    return { idempotencyAcquired: false };
+  }
+
+  // Get user's language preference
+  const userLanguage = await getUserLanguage(user.id) || user.preferred_language || 'en';
+
+  // Create database record for tracking
+  const { data: analysisRequest, error: dbError } = await supabase
+    .from('image_analysis_requests')
+    .insert({
+      user_id: user.id,
+      image_url: 'pending', // Will update after R2 upload
+      image_metadata: {
+        whatsappMediaId: imageId,
+        mimeType,
+        caption,
+        uploadedAt: new Date().toISOString()
+      },
+      status: 'processing',
+      started_at: new Date().toISOString(),
+      correlation_id: correlationId
+    })
+    .select()
+    .single();
+
+  if (dbError) {
+    logToFile('⚠️ Failed to create analysis request record', {
+      error: dbError.message,
+      userId: user.id
+    });
+    // Continue anyway - database tracking is nice-to-have
+  }
+
+  const requestId = analysisRequest?.id;
+
+  // Step 1: Download image from WhatsApp
+  logToFile('Step 1: Downloading image from WhatsApp...', { imageId });
+  const imageBuffer = await WhatsAppService.downloadMedia(imageId);
+  logToFile('Image downloaded', { sizeBytes: imageBuffer.length });
+
+  // Step 2: Upload to R2 with retry
+  logToFile('Step 2: Uploading image to R2 storage...');
+  let imageUrl;
+  try {
+    imageUrl = await uploadImageWithRetry(imageBuffer, user.id, imageId, mimeType);
+    logToFile('✅ Image uploaded to R2', { imageUrl });
+
+    // Update database record with R2 URL
+    if (requestId) {
+      await supabase
+        .from('image_analysis_requests')
+        .update({ image_url: imageUrl })
+        .eq('id', requestId);
+    }
+  } catch (uploadError) {
+    logToFile('❌ R2 upload failed', { error: uploadError.message });
+    // Continue with base64 fallback - analysis still possible
+    imageUrl = null;
+  }
+
+  // Step 3: Analyze image with Vision service
+  logToFile('Step 3: Analyzing image with GPT-4.1-mini...');
+
+  // Build analysis prompt based on context
+  let analysisPrompt = caption
+    ? `The teacher sent this image with the following context: "${caption}". Analyze the image and provide helpful feedback.`
+    : 'Analyze this classroom-related image. It could be student work, a worksheet, whiteboard content, or classroom setup. Provide constructive feedback.';
+
+  // Add language instruction
+  if (userLanguage === 'ur') {
+    analysisPrompt += '\n\nPlease respond in Urdu (اردو) with some English technical terms where appropriate.';
+  } else if (userLanguage === 'ar') {
+    analysisPrompt += '\n\nPlease respond in Arabic (العربية).';
+  } else if (userLanguage === 'es') {
+    analysisPrompt += '\n\nPlease respond in Spanish (Español).';
+  }
+
+  // Analyze with vision service - always use buffer (service handles base64 conversion)
+  const analysisResult = await VisionService.analyzeWithRetry(
+    imageBuffer,
+    mimeType,
+    {
+      prompt: analysisPrompt,
+      language: userLanguage
+    }
+  );
+
+  logEvent('image.analysis.completed', {
+    requestId,
+    userId: user.id,
+    durationMs: Date.now() - startTime,
+    tokensUsed: analysisResult.usage?.totalTokens || 0,
+    success: analysisResult.success
+  });
+
+  // Handle analysis result
+  let responseMessage;
+  if (analysisResult.success) {
+    responseMessage = analysisResult.analysis;
+
+    // Update database with success
+    if (requestId) {
+      await supabase
+        .from('image_analysis_requests')
+        .update({
+          status: 'completed',
+          completed_at: new Date().toISOString(),
+          analysis_result: {
+            success: true,
+            analysis: analysisResult.analysis,
+            usage: analysisResult.usage,
+            model: analysisResult.model,
+            detail: analysisResult.detail
+          },
+          tokens_used: analysisResult.usage?.totalTokens || 0
+        })
+        .eq('id', requestId);
+    }
+
+    // Cache successful result for idempotency
+    await redisService.set(
+      idempotencyKey,
+      JSON.stringify({ response: responseMessage, timestamp: Date.now() }),
+      IDEMPOTENCY_TTL_SECONDS
+    );
+
+    // Store in conversation history for follow-up context
+    try {
+      await storeConversation(user.id, 'user', `[Sent image${caption ? `: "${caption}"` : ''}]`, 'image', sessionId);
+      await storeConversation(user.id, 'assistant', responseMessage, 'text', sessionId);
+      logToFile('✅ Image conversation stored for context', { userId: user.id, sessionId });
+    } catch (storeError) {
+      logToFile('⚠️ Failed to store image conversation', { error: storeError.message });
+    }
+  } else {
+    // Analysis failed
+    logToFile('❌ Image analysis failed', {
+      error: analysisResult.error,
+      requestId
+    });
+
+    // Update database with failure
+    if (requestId) {
+      await supabase
+        .from('image_analysis_requests')
+        .update({
+          status: 'failed',
+          completed_at: new Date().toISOString(),
+          last_error: analysisResult.error,
+          retry_count: (analysisRequest?.retry_count || 0) + 1
+        })
+        .eq('id', requestId);
+    }
+
+    // Send error message in user's language
+    const errorMessages = {
+      en: "Sorry, I couldn't analyze this image. Please try again with a clearer photo.\n\nTip: Make sure the image is well-lit and not blurry.",
+      ur: "معذرت، میں اس تصویر کا تجزیہ نہیں کر سکی۔ براہ کرم ایک صاف تصویر کے ساتھ دوبارہ کوشش کریں۔\n\nمشورہ: یقینی بنائیں کہ تصویر روشن اور واضح ہو۔",
+      ar: "عذرًا، لم أتمكن من تحليل هذه الصورة. يرجى المحاولة مرة أخرى بصورة أوضح.\n\nنصيحة: تأكد من أن الصورة مضاءة جيدًا وغير ضبابية.",
+      es: "Lo siento, no pude analizar esta imagen. Por favor intenta de nuevo con una foto más clara.\n\nConsejo: Asegúrate de que la imagen esté bien iluminada y no borrosa."
+    };
+
+    responseMessage = errorMessages[userLanguage] || errorMessages.en;
+  }
+
+  // Stop typing and send response
+  typingController.stop();
+  await WhatsAppService.sendMessage(from, responseMessage);
+
+  logToFile('✅ Image analysis response sent', {
+    userId: user.id,
+    requestId,
+    durationMs: Date.now() - startTime
+  });
+
+  return { idempotencyAcquired };
+}
+
+/**
+ * Pic-to-LP routing. Decides whether an incoming image belongs to the pic-LP
+ * flow and, if so, routes it (appending to an active page-collection session,
+ * or enqueueing to the batch coalescer for fresh classification).
+ *
+ * Returns true if this image was handled by the pic-LP flow (and the caller
+ * should stop). Returns false if the image should fall through to the generic
+ * vision analysis path.
+ *
+ * Two paths inside:
+ *   A) Active session in 'collecting_pages' → append page, prompt for more.
+ *   B) Fresh image → enqueue to the batch coalescer (which classifies once per
+ *      batch; BOOK_PAGE starts an LP session, otherwise falls back to vision).
+ */
+async function tryPicLpRoute({ user, from, imageId, mimeType, caption, typingController }) {
+  // Lazy-require to keep startup cheap and avoid circular imports
+  const PicLpSession = require('../services/pic-to-lp/pic-lp-session.service');
+  const PageCollector = require('../services/pic-to-lp/page-collector.service');
+  const ImageBatchCoalescer = require('../services/pic-to-lp/image-batch-coalescer.service');
+  const { uploadImageWithRetry } = require('../storage/r2');
+
+  // ---- Path A: active collecting_pages session for this user ----
+  const activeSession = await PicLpSession.getActiveSession(user.id);
+  if (activeSession && activeSession.status === 'collecting_pages') {
+    const language = await getUserLanguage(user.id) || user.preferred_language || 'en';
+    const imageBuffer = await WhatsAppService.downloadMedia(imageId);
+    const url = await uploadImageWithRetry(imageBuffer, user.id, imageId, mimeType);
+    const page = { url, mime: mimeType, uploaded_at: new Date().toISOString() };
+
+    typingController.stop();
+    const result = await PageCollector.appendPageAndPrompt({
+      sessionId: activeSession.id,
+      from,
+      language,
+      page,
+    });
+
+    if (result.autoComplete) {
+      await PageCollector.onComplete({
+        sessionId: activeSession.id,
+        from,
+        language,
+        trigger: 'max_reached',
+      });
+    }
+    return true;
+  }
+
+  // If a session is in a non-collecting active status, treat it per-status:
+  //
+  //   - awaiting_form_submit / awaiting_intent: the teacher already pre-attached
+  //     pages and opened the form. If they're sending MORE photos now, they're
+  //     abandoning the prior batch and starting fresh — auto-cancel and route
+  //     the new batch through the coalescer normally.
+  //
+  //   - generating / handed_off / failed: keep the 10-min STALE protection —
+  //     the teacher may have accidentally re-sent while their LP is being
+  //     produced, and we don't want to clobber the in-flight job.
+  //
+  // The "old, stale" cleanup (>10 min) still fires for any status.
+  if (activeSession) {
+    const STALE_AFTER_MS = 10 * 60 * 1000;
+    const ageMs = Date.now() - new Date(activeSession.updated_at || activeSession.created_at).getTime();
+    const isAwaitingForm = activeSession.status === 'awaiting_form_submit'
+      || activeSession.status === 'awaiting_intent';
+
+    if (ageMs > STALE_AFTER_MS) {
+      logToFile('📚 Pic-LP session stale — auto-cancelling and starting fresh', {
+        sessionId: activeSession.id,
+        status: activeSession.status,
+        ageMinutes: Math.round(ageMs / 60000),
+      });
+      await PicLpSession.cancelActiveForUser(user.id, 'timed_out');
+      // fall through to fresh classification
+    } else if (isAwaitingForm) {
+      // Teacher is in the form-open state and is sending new photos. Read that
+      // as "abandoning the prior submission" — cancel and start fresh.
+      logToFile('📚 Pic-LP awaiting-form session + new photo — auto-cancelling for fresh batch', {
+        sessionId: activeSession.id,
+        status: activeSession.status,
+        ageMinutes: Math.round(ageMs / 60000),
+      });
+      await PicLpSession.cancelActiveForUser(user.id, 'cancelled');
+      // fall through to fresh classification (coalescer enqueue below)
+    } else {
+      // generating / handed_off / failed within 10 min → skip
+      logToFile('📚 Pic-LP session active but not collecting — skipping', {
+        sessionId: activeSession.id,
+        status: activeSession.status,
+        ageMinutes: Math.round(ageMs / 60000),
+      });
+      return false;
+    }
+  }
+
+  // NOTE: production also gates here on an active quiz session (so a parent who
+  // snaps a quiz screenshot mid-quiz doesn't get an LP). That gate is omitted
+  // until the quiz subsystem (and its quiz_sessions table) is part of this
+  // bundle — restore it alongside the quiz port.
+
+  // ---- Path B: enqueue to batch coalescer ----
+  //
+  // WhatsApp delivers album-batch sends as N separate concurrent webhooks.
+  // Without coalescing, each one races the classifier + session create — N
+  // duplicate sessions, or N-1 falling through to generic vision-feedback. The
+  // coalescer buffers per-user webhooks for ~2.5 s and fires onFlush once with
+  // the deduped batch. Caption-carrying photo (if any) is picked as primary.
+  ImageBatchCoalescer.enqueue({
+    userId: user.id,
+    image: { mediaId: imageId, mimeType, caption, typingController },
+    onFlush: (batch) => {
+      // Fire-and-forget; the coalescer logs any throws.
+      handleCoalescedBatch({ user, from, batch }).catch((err) => {
+        logToFile('⚠️ Pic-LP batch handler failed', { error: err.message, userId: user.id });
+      });
+    },
+  });
+
+  // Stop the typing indicator for this individual webhook. The coalescer
+  // stops each webhook's controller on flush — but stopping early is harmless
+  // and prevents the wheel from spinning if the coalescer takes longer.
+  typingController.stop();
+  return true;
+}
+
+/**
+ * Process a coalesced batch of images from one user.
+ *
+ * The coalescer has already deduped by mediaId and picked a `primary` image
+ * (the caption-carrying one, or the first arrival). We classify ONCE on the
+ * primary; if BOOK_PAGE, we upload all images to R2, create one session with
+ * the primary's caption, append the rest as pages, and send a single intent
+ * prompt. If NOT_BOOK_PAGE we run generic vision analysis on the primary (one
+ * content-aware reply per batch).
+ */
+async function handleCoalescedBatch({ user, from, batch }) {
+  const PicLpSession = require('../services/pic-to-lp/pic-lp-session.service');
+  const PageCollector = require('../services/pic-to-lp/page-collector.service');
+  const Classifier = require('../services/pic-to-lp/classifier.service');
+  const { uploadImageWithRetry } = require('../storage/r2');
+  const { generateCorrelationId } = require('../utils/structured-logger');
+
+  // Best-effort: stop every webhook's typing indicator now that we're processing.
+  for (const img of batch.images) {
+    try { img.typingController?.stop(); } catch (e) { /* swallow */ }
+  }
+
+  const language = await getUserLanguage(user.id) || user.preferred_language || 'en';
+  const isUrdu = language === 'ur';
+
+  // Download + classify the primary (caption-carrier or first arrival).
+  const primaryBuffer = await WhatsAppService.downloadMedia(batch.primary.mediaId);
+  const classification = await Classifier.classifyImageType(
+    primaryBuffer,
+    batch.primary.mimeType,
+    batch.caption
+  );
+
+  logEvent('pic_lp.classified', {
+    userId: user.id,
+    type: classification.type,
+    confidence: classification.confidence,
+    batchSize: batch.images.length,
+    captionPreview: (batch.caption || '').substring(0, 60),
+  });
+
+  // Threshold 0.5 to catch borderline textbook pages (poorly lit, partially
+  // obscured) that would otherwise fall to the fallback.
+  if (classification.type !== 'BOOK_PAGE' || classification.confidence < 0.5) {
+    // Restore vision-feedback for the primary image only. For a 4-classroom-
+    // photo batch the user gets ONE content-aware reply. Call into
+    // runImageAnalysis with a synthetic correlationId + startTime since the
+    // coalescer's onFlush runs outside the original webhook scope.
+    const correlationId = generateCorrelationId();
+    const startTime = Date.now();
+    const primaryTypingController = batch.primary.typingController || { stop: () => {} };
+    try {
+      await runImageAnalysis({
+        user,
+        from,
+        imageId: batch.primary.mediaId,
+        mimeType: batch.primary.mimeType,
+        caption: batch.caption,
+        typingController: primaryTypingController,
+        correlationId,
+        startTime,
+      });
+    } catch (visionErr) {
+      logToFile('⚠️ runImageAnalysis from coalescer threw', {
+        error: visionErr.message,
+        userId: user.id,
+        batchSize: batch.images.length,
+      });
+      // Fall back to a polite single message if vision-feedback also failed.
+      const fallback = isUrdu
+        ? '📷 آپ کی تصاویر مل گئیں۔ اگر آپ لیسن پلان چاہتی ہیں، براہ کرم کسی نصابی کتاب کے صفحے کی واضح تصویر بھیجیں۔ مدد کے لیے "menu" لکھیں۔'
+        : "📷 Got your image(s). For a lesson plan, please send a clear photo of a textbook page. Type \"menu\" to see other things I can help with.";
+      await WhatsAppService.sendMessage(from, fallback);
+    }
+    return;
+  }
+
+  // BOOK_PAGE: upload every image in the batch to R2.
+  const uploaded = [];
+  for (const img of batch.images) {
+    const buffer = (img.mediaId === batch.primary.mediaId)
+      ? primaryBuffer
+      : await WhatsAppService.downloadMedia(img.mediaId);
+    const url = await uploadImageWithRetry(buffer, user.id, img.mediaId, img.mimeType);
+    uploaded.push({ url, mime: img.mimeType, uploaded_at: new Date().toISOString() });
+  }
+
+  // Create the session with the first page; append the rest.
+  const correlationId = generateCorrelationId();
+  const session = await PicLpSession.create({
+    userId: user.id,
+    correlationId,
+    caption: batch.caption,
+    firstPage: uploaded[0],
+  });
+
+  for (let i = 1; i < uploaded.length; i++) {
+    await PicLpSession.appendPage(session.id, uploaded[i]);
+  }
+
+  const captionAlreadyHasIntent = /\b(lesson\s*plan|sabaq|sabaq plan|سبق|لیسن پلان)\b/i.test(batch.caption || '');
+
+  if (captionAlreadyHasIntent) {
+    logEvent('pic_lp.intent_chosen', {
+      sessionId: session.id,
+      intent: 'auto_from_caption',
+      pagesAtStart: uploaded.length,
+    });
+    await PageCollector.startCollectingFromIntent({ sessionId: session.id, from, language });
+  } else {
+    await PageCollector.promptIntent({
+      sessionId: session.id,
+      from,
+      language,
+      captionAlreadyHasIntent: false,
+    });
+  }
+}
+
 module.exports = {
-  handleImageMessage
+  handleImageMessage,
+  // Exported for testing the coalesced-batch flow
+  handleCoalescedBatch,
+  // Exported for testing tryPicLpRoute's status-routing branches
+  __test_only_tryPicLpRoute: tryPicLpRoute,
 };

--- a/bot/shared/routes/flow-endpoint.routes.js
+++ b/bot/shared/routes/flow-endpoint.routes.js
@@ -30,6 +30,11 @@ const {
   handleRegistrationDataExchange,
   handleRegistrationBack
 } = require('./registration-endpoint');
+const {
+  handlePicLpInit,
+  handlePicLpDataExchange,
+  handlePicLpBack
+} = require('./pic-lp-endpoint');
 
 /**
  * Handle attendance marking flow data requests
@@ -497,6 +502,68 @@ async function handleRegistrationRequest(data) {
   }
 
   // Unknown action
+  logToFile('Unknown flow action', { action });
+  return FlowEncryptionService.createErrorResponse('Unknown action');
+}
+
+/**
+ * POST /api/flows/pic-lp — Pic-to-LP confirmation Flow data endpoint.
+ * Single-screen form (PIC_LP_FORM → SUCCESS); the teacher confirms
+ * grade/subject/topic/language and LP generation fires in the background.
+ */
+router.post('/pic-lp', async (req, res) => {
+  try {
+    if (!FlowEncryptionService.isConfigured()) {
+      logToFile('Flow encryption not configured', { endpoint: 'pic-lp' });
+      return res.status(500).json({ error: 'Flow encryption not configured' });
+    }
+
+    const encryptedResponse = await FlowEncryptionService.processEncryptedRequest(
+      req.body,
+      async (decryptedData) => {
+        return await handlePicLpRequest(decryptedData);
+      }
+    );
+
+    res.set('Content-Type', 'text/plain');
+    res.send(encryptedResponse);
+  } catch (error) {
+    logToFile('Flow endpoint error', {
+      endpoint: 'pic-lp',
+      error: error.message,
+      stack: error.stack,
+    });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * Handle decrypted pic-LP flow request. Routes by action; the flow_token
+ * (format "pic_lp_form_<sessionId>") is passed straight through to the
+ * endpoint handlers, which resolve the session via getByFlowToken.
+ */
+async function handlePicLpRequest(data) {
+  const { action, flow_token, screen, data: screenData } = data;
+
+  logToFile('Handling pic-LP flow request', {
+    action,
+    screen,
+    hasFlowToken: !!flow_token,
+  });
+
+  if (action === 'ping') {
+    return FlowEncryptionService.handlePing();
+  }
+  if (action === 'INIT' || action === 'init') {
+    return await handlePicLpInit(flow_token);
+  }
+  if (action === 'data_exchange') {
+    return await handlePicLpDataExchange(flow_token, screen, screenData);
+  }
+  if (action === 'BACK') {
+    return await handlePicLpBack(flow_token);
+  }
+
   logToFile('Unknown flow action', { action });
   return FlowEncryptionService.createErrorResponse('Unknown action');
 }

--- a/bot/shared/routes/pic-lp-endpoint.js
+++ b/bot/shared/routes/pic-lp-endpoint.js
@@ -1,0 +1,166 @@
+/**
+ * Pic-to-LP Flow Endpoint
+ *
+ * Handles WhatsApp Flow data exchange for the single-screen confirmation
+ * form (PIC_LP_FORM → SUCCESS). On data_exchange the teacher's
+ * grade/subject/topic/language values come back. We:
+ *   1. Look up the matching pic_lp_session via flow_token.
+ *   2. Hand off to LP generation.
+ *   3. Return SUCCESS screen with a "generating now" message.
+ *
+ * The actual generation runs in the background — Flow returns immediately
+ * so the teacher's WhatsApp UI doesn't time out (Meta's data_exchange has a
+ * ~10s budget).
+ */
+
+const FlowEncryptionService = require('../services/flow-encryption.service');
+const PicLpSession = require('../services/pic-to-lp/pic-lp-session.service');
+const LpHandoff = require('../services/pic-to-lp/lp-handoff.service');
+const {
+  buildGrades,
+  buildSubjects,
+  buildLanguages,
+  buildLessonPlanFormats,
+  DEFAULT_LP_FORMAT,
+} = require('../services/pic-to-lp/flow-options');
+const { detectRegion } = require('../utils/region');
+const { logToFile } = require('../utils/logger');
+const { logEvent } = require('../utils/structured-logger');
+
+const VALID_LANGUAGES = ['en', 'ur', 'sd', 'sw'];
+const VALID_LP_FORMATS = ['concise', 'detailed'];
+
+/**
+ * INIT — Flow opens. Teacher already has pre-fill from flow_action_payload.data,
+ * so we just acknowledge and return the same screen so the form renders.
+ */
+async function handlePicLpInit(flow_token) {
+  logToFile('Pic-LP Flow INIT', { flowToken: flow_token });
+  const session = flow_token ? await PicLpSession.getByFlowToken(flow_token) : null;
+  if (!session) {
+    return FlowEncryptionService.createErrorResponse('Session expired');
+  }
+  // Pre-fill data is also passed via navigateData when the Flow is sent — this
+  // INIT response is mostly a fallback if Meta re-fetches.
+  return {
+    screen: 'PIC_LP_FORM',
+    data: buildPrefillData(session),
+  };
+}
+
+/**
+ * data_exchange — teacher hit "Generate Lesson Plan" on the form.
+ */
+async function handlePicLpDataExchange(flow_token, screen, screenData = {}) {
+  logToFile('Pic-LP Flow data_exchange', {
+    flowToken: flow_token,
+    screen,
+    keys: Object.keys(screenData),
+  });
+
+  const session = flow_token ? await PicLpSession.getByFlowToken(flow_token) : null;
+  if (!session) {
+    return FlowEncryptionService.createErrorResponse('Session expired');
+  }
+
+  // Extract + validate form values
+  const grade = parseInt(screenData.grade, 10);
+  const subject = String(screenData.subject || '').trim();
+  const topic = String(screenData.topic || '').trim();
+  const language = VALID_LANGUAGES.includes(screenData.language) ? screenData.language : 'en';
+  // Teacher-picked LP format ('concise' | 'detailed'). Default to 'concise' for
+  // legacy back-compat — a mid-flight session whose Flow JSON was rendered
+  // before the format field existed won't include it, and we must still deliver
+  // an LP rather than failing validation.
+  const rawFormat = String(screenData.lesson_plan_format || '').trim().toLowerCase();
+  const lesson_plan_format = VALID_LP_FORMATS.includes(rawFormat) ? rawFormat : DEFAULT_LP_FORMAT;
+
+  if (!grade || grade < 1 || grade > 12 || !subject || !topic) {
+    logToFile('⚠️ Pic-LP form validation failed', { grade, subject, topic, language });
+    return FlowEncryptionService.createErrorResponse('Please complete all fields');
+  }
+
+  const formData = { grade, subject, topic, language, lesson_plan_format };
+
+  // Look up phone number for delivery — pic_lp_sessions is keyed by user_id;
+  // we need to fetch the user's phone separately.
+  const supabase = require('../config/supabase');
+  const { data: userRow } = await supabase
+    .from('users')
+    .select('phone_number')
+    .eq('id', session.user_id)
+    .maybeSingle();
+  const from = userRow?.phone_number;
+
+  if (!from) {
+    logToFile('❌ Pic-LP: no phone for user', { userId: session.user_id });
+    return FlowEncryptionService.createErrorResponse('User lookup failed');
+  }
+
+  logEvent('pic_lp.form_submitted', {
+    sessionId: session.id,
+    grade,
+    subject,
+    topic: topic.substring(0, 60),
+    language,
+    lesson_plan_format,
+  });
+
+  // Fire-and-forget — generation takes 30-90s, way over Meta's data_exchange window.
+  setImmediate(() => {
+    LpHandoff.generateAndDeliver({ session, formData, from }).catch((err) => {
+      logToFile('❌ Pic-LP background handoff threw', { error: err.message, sessionId: session.id });
+    });
+  });
+
+  // Return SUCCESS terminal screen
+  return {
+    screen: 'SUCCESS',
+    data: {
+      message: language === 'ur'
+        ? 'لیسن پلان بنایا جا رہا ہے — 1-2 منٹ میں آپ کے چیٹ میں آ جائے گا۔'
+        : "Generating your lesson plan — it'll arrive in this chat in 1-2 minutes.",
+    },
+  };
+}
+
+/**
+ * BACK is a no-op for a single-screen flow but Meta may still send it.
+ */
+async function handlePicLpBack(flow_token /*, screen */) {
+  const session = flow_token ? await PicLpSession.getByFlowToken(flow_token) : null;
+  if (!session) {
+    return FlowEncryptionService.createErrorResponse('Session expired');
+  }
+  return {
+    screen: 'PIC_LP_FORM',
+    data: buildPrefillData(session),
+  };
+}
+
+function buildPrefillData(session) {
+  const detected = session?.detected || {};
+  const pages = Array.isArray(session?.pages) ? session.pages : [];
+  return {
+    grades: buildGrades(),
+    // Same source-of-truth as completion-handler
+    subjects: buildSubjects(detectRegion()),
+    languages: buildLanguages(),
+    // format options + default for the radio toggle
+    lesson_plan_formats: buildLessonPlanFormats(),
+    default_lp_format: DEFAULT_LP_FORMAT,
+    detected_grade: detected.grade != null ? String(detected.grade) : '',
+    detected_subject: detected.subject || '',
+    detected_topic: detected.topic || '',
+    // Caption-derived language pre-fill (Flow re-fetch fallback path).
+    ui_language: detected.language || 'en',
+    page_count: String(pages.length),
+    session_id: session.id,
+  };
+}
+
+module.exports = {
+  handlePicLpInit,
+  handlePicLpDataExchange,
+  handlePicLpBack,
+};

--- a/bot/shared/services/pedagogy/grade-calibration.service.js
+++ b/bot/shared/services/pedagogy/grade-calibration.service.js
@@ -1,0 +1,203 @@
+/**
+ * Universal Grade Calibration Framework
+ *
+ * Drives how LP content density, vocabulary load, pacing, and differentiation
+ * adapt across grades — without changing the LP's visual sections (Hook, Big
+ * Idea, I-Do, We-Do, You-Do, Board Work, Exit Ticket, Coaching).
+ *
+ * Universal: works for any market on a K-10-style scale. No country-specific
+ * assumptions.
+ *
+ * 15-axis per-band rubric injected as a prompt block.
+ *
+ * Pedagogical grounding:
+ *   - Anderson & Krathwohl 2001 — Bloom's Revised Taxonomy
+ *   - Webb 1997 — Depth of Knowledge (DOK 1-4)
+ *   - Piaget cognitive stages — concrete operational → formal operational
+ *   - Tomlinson differentiation — content × process × product × environment
+ */
+
+const REQUIRED_AXES = [
+  'label',
+  'grades',
+  'pacingMin',
+  'vocabLoad',
+  'sentenceLength',
+  'hookRegister',
+  'bigIdeaShape',
+  'iDoExamples',
+  'iDoStyle',
+  'weDoFormat',
+  'youDoCount',
+  'youDoDOK',
+  'boardWork',
+  'exitTicket',
+  'diffLow',
+  'diffHigh',
+  'cfuCadence',
+  'eslSupport',
+  'coachingTipFocus',
+  'bloomCeiling',
+  'dokRange',
+];
+
+const CALIBRATION_BANDS = {
+  foundation: {
+    label: 'Foundation',
+    grades: [1, 2],
+    bloomCeiling: 'Understand',
+    dokRange: '1-2',
+    pacingMin: { hook: 5, goal: 1, bigIdea: 3, iDo: 5, weDo: 8, youDo: 6, exit: 2, wrap: 5 },
+    vocabLoad: '2-3 new words per lesson, mostly Tier 1 (everyday)',
+    sentenceLength: '4-6 words, simple subject-verb-object',
+    hookRegister: 'Curiosity question in 1 short clause, concrete object referent (no abstractions)',
+    bigIdeaShape: '1-2 sentences each, picture-anchored, no abstract concepts',
+    iDoExamples: 5,
+    iDoStyle: 'Explicit, fully-scaffolded examples. Teacher reads each aloud and demonstrates.',
+    weDoFormat: 'Choral response with manipulatives in hand, call-and-response chants',
+    youDoCount: 3,
+    youDoDOK: 'DOK 1 only (recall, identify) with picture cues attached',
+    boardWork: '3 fully worked examples (no blanks), pictures next to each',
+    exitTicket: '1 factual question with picture cue, answer in 3 words or fewer',
+    diffLow: 'Visual + verbal cue, partner support, manipulative in hand',
+    diffHigh: '1 extension problem with slightly harder context (bigger numbers, more objects)',
+    cfuCadence: 'Every 2-3 min: choral response, thumbs up/down, point-to-answer',
+    eslSupport: 'Heavy L1 (mother tongue) scaffolding. Bilingual labels. Picture-text matching. Code-switching to L1 is encouraged.',
+    coachingTipFocus: 'Phonics, concept of print, read-aloud techniques',
+  },
+
+  building: {
+    label: 'Building',
+    grades: [3, 4, 5],
+    bloomCeiling: 'Apply',
+    dokRange: '1-3',
+    pacingMin: { hook: 4, goal: 1, bigIdea: 3, iDo: 6, weDo: 8, youDo: 7, exit: 1, wrap: 5 },
+    vocabLoad: '4-6 new words per lesson, Tier 1 + early Tier 2 academic',
+    sentenceLength: '8-12 words, one subordinate clause OK',
+    hookRegister: 'Curiosity question linked to a familiar real-world situation',
+    bigIdeaShape: '2-3 sentences each, one abstract concept introduced',
+    iDoExamples: 3,
+    iDoStyle: 'Explicit examples with teacher narrating the reasoning out loud',
+    weDoFormat: 'Partner-talk + mini-whiteboard responses, anchor-chart reference',
+    youDoCount: 5,
+    youDoDOK: 'Mix of DOK 1-2 (apply a familiar procedure, identify, classify)',
+    boardWork: '3 worked examples — last one has a "your turn" prompt',
+    exitTicket: '1 factual + 1 simple-reasoning question, full-sentence answers',
+    diffLow: 'Sentence frames + word bank, anchor-chart reference, partner pairing',
+    diffHigh: '1 multi-step problem requiring synthesis of two skills',
+    cfuCadence: 'Every 4 min: think-pair-share, mini-whiteboard, exit poll',
+    eslSupport: 'Sentence frames in L2 with L1 support available. Code-switching OK for clarification. Vocabulary preview at lesson start.',
+    coachingTipFocus: 'Vocabulary instruction routines, comprehension monitoring',
+  },
+
+  deepening: {
+    label: 'Deepening',
+    grades: [6, 7, 8],
+    bloomCeiling: 'Evaluate',
+    dokRange: '2-3',
+    pacingMin: { hook: 3, goal: 1, bigIdea: 4, iDo: 7, weDo: 8, youDo: 6, exit: 1, wrap: 5 },
+    vocabLoad: '6-8 new words per lesson, Tier 2 + content-specific Tier 3',
+    sentenceLength: '12-15 words, multiple clauses, transition words',
+    hookRegister: 'Provocative question that surfaces a common misconception',
+    bigIdeaShape: '3-4 sentences each, names the cognitive obstacle (what kids get wrong, why)',
+    iDoExamples: 2,
+    iDoStyle: 'Examples with guided questioning ("What do we do next? Why?")',
+    weDoFormat: 'Think-pair-share + cold call + written responses on small boards',
+    youDoCount: 6,
+    youDoDOK: 'Mix of DOK 2-3 (multi-step problems + reasoning + comparison)',
+    boardWork: '3 examples graded by complexity: 1 worked, 1 guided, 1 challenge',
+    exitTicket: '1 application + 1 analysis question, short-paragraph answers',
+    diffLow: 'Worked-example reference card, vocabulary preview list',
+    diffHigh: '1 problem requiring justification beyond procedure (defend your answer)',
+    cfuCadence: 'Every 5 min: cold call, written response, peer check',
+    eslSupport: 'Academic vocabulary made explicit. L1 used only for clarification of content-specific terms. Note-taking modeled.',
+    coachingTipFocus: 'Discourse-based learning, academic language scaffolds',
+  },
+
+  application: {
+    label: 'Application',
+    grades: [9, 10],
+    bloomCeiling: 'Create',
+    dokRange: '2-4',
+    pacingMin: { hook: 3, goal: 1, bigIdea: 4, iDo: 6, weDo: 8, youDo: 7, exit: 1, wrap: 5 },
+    vocabLoad: '8-10 new words per lesson, Tier 3 academic register dominant',
+    sentenceLength: '15+ words, complex sentences, conditional and hypothetical structures',
+    hookRegister: 'Open-ended question demanding a hypothesis, evaluation, or original take',
+    bigIdeaShape: '4-5 sentences each, framed within a broader principle or domain context',
+    iDoExamples: 1,
+    iDoStyle: '1-2 examples, focus on reasoning not procedure ("Why this approach over the alternative?")',
+    weDoFormat: 'Socratic dialogue + written justification + peer feedback',
+    youDoCount: 7,
+    youDoDOK: 'Mix of DOK 2-4 (multi-step + justification + open-ended + synthesis)',
+    boardWork: '3 examples graded by difficulty, 1 marked "stretch" (open-ended)',
+    exitTicket: '1 evaluation + 1 justification question, paragraph answer with cited evidence',
+    diffLow: 'Step-by-step problem-solving template, scaffolded reasoning prompts',
+    diffHigh: '1 open-ended problem with multiple valid approaches, asked to compare',
+    cfuCadence: 'Every 5-7 min: cold call with justification, written paragraph, peer feedback',
+    eslSupport: 'L2 dominant. Academic register expected. L1 used only for highly content-specific Tier-3 terms.',
+    coachingTipFocus: 'Inquiry-based facilitation, debate moderation, real-world application',
+  },
+};
+
+/**
+ * @param {number|string} grade
+ * @returns {'foundation' | 'building' | 'deepening' | 'application'}
+ */
+function gradeBandFor(grade) {
+  const g = typeof grade === 'string' ? parseInt(grade, 10) : grade;
+  if (!Number.isFinite(g) || g < 3) return 'foundation';
+  if (g <= 5) return 'building';
+  if (g <= 8) return 'deepening';
+  return 'application'; // 9+ including grades above 10 (defensive)
+}
+
+/**
+ * @param {number|string} grade
+ * @returns {object} The full calibration block for the band that contains this grade.
+ */
+function gradeCalibration(grade) {
+  return CALIBRATION_BANDS[gradeBandFor(grade)];
+}
+
+/**
+ * Render the calibration block as a string for direct injection into LP prompts.
+ * Used by both the pic-LP image-gen prompt and the text-LP (Gamma) prompt.
+ *
+ * Token budget: <= ~350 tokens (~1500 chars).
+ *
+ * @param {number|string} grade
+ * @returns {string}
+ */
+function renderCalibrationBlock(grade) {
+  const c = gradeCalibration(grade);
+  const p = c.pacingMin;
+  const pacingLine = `Hook ${p.hook} / Goal ${p.goal} / Big Idea ${p.bigIdea} / I-Do ${p.iDo} / We-Do ${p.weDo} / You-Do ${p.youDo} / Exit ${p.exit} / Wrap ${p.wrap} (35 min total)`;
+
+  return [
+    `GRADE CALIBRATION (${c.label} band, Grade ${grade}):`,
+    `Cognitive: Bloom's ceiling = ${c.bloomCeiling}. Webb's DOK ${c.dokRange}.`,
+    `Pacing (minutes per section): ${pacingLine}.`,
+    `Vocab load: ${c.vocabLoad}.`,
+    `Sentence length in LP body: ${c.sentenceLength}.`,
+    `Hook speech-bubble register: ${c.hookRegister}.`,
+    `Big Idea paragraphs: ${c.bigIdeaShape}.`,
+    `I-Do worked examples: ${c.iDoExamples}. ${c.iDoStyle}`,
+    `We-Do format: ${c.weDoFormat}.`,
+    `You-Do practice: ${c.youDoCount} problems. ${c.youDoDOK}.`,
+    `Board Work: ${c.boardWork}.`,
+    `Exit Ticket: ${c.exitTicket}.`,
+    `Differentiation for struggling students: ${c.diffLow}.`,
+    `Differentiation for advanced students: ${c.diffHigh}.`,
+    `CFU cadence: ${c.cfuCadence}.`,
+    `ESL/EAL language demand (where the lesson language is a second language for the class): ${c.eslSupport}.`,
+    `Coaching Corner tip emphasis: ${c.coachingTipFocus}.`,
+  ].join('\n');
+}
+
+module.exports = {
+  gradeBandFor,
+  gradeCalibration,
+  renderCalibrationBlock,
+  CALIBRATION_BANDS,
+  REQUIRED_AXES,
+};

--- a/bot/shared/services/pedagogy/lp-localization.service.js
+++ b/bot/shared/services/pedagogy/lp-localization.service.js
@@ -1,0 +1,93 @@
+/**
+ * LP Localization Service
+ *
+ * Single source of truth for the cultural-context table shared by BOTH
+ * lesson-plan generation paths:
+ *   - the pic-LP image builder (shared/services/pic-to-lp/kieai-prompt-builder.service.js)
+ *   - the Gamma text-LP builder
+ *
+ * `characterCastFor` + `classroomContextFor` were lifted out of the pic-LP
+ * builder (which now re-exports them from here) so the two paths can never
+ * drift.
+ *
+ * The cultural context is keyed by LANGUAGE, not by deployment region — the
+ * script/language a teacher chose for the lesson plan implies the cultural
+ * cast (e.g. Kiswahili → East African, Arabic → MENA, Urdu/Sindhi/Punjabi →
+ * Pakistani). English is script-ambiguous, so it gets a neutral, region-free
+ * classroom cast.
+ */
+
+// Per-language character cast used in the HOOK section.
+function characterCastFor(language) {
+  switch (language) {
+    case 'sw':
+      return { region: 'East African (Kenyan/Tanzanian/Ugandan)', boy: 'Juma', girl: 'Amina', girlDress: 'colorful kanga or simple uniform' };
+    case 'ar':
+      return { region: 'Arab (Levantine/Gulf-style)', boy: 'Ahmad', girl: 'Layla', girlDress: 'modest school uniform with hijab' };
+    case 'ur':
+    case 'sd':
+    case 'pa':
+      // Urdu / Sindhi / Punjabi are Pakistani languages — language-implied cast.
+      return { region: 'Pakistani', boy: 'Ali', girl: 'Sara', girlDress: 'white dupatta' };
+    default:
+      // en (script-ambiguous) — a neutral, region-free classroom cast.
+      return { region: 'local primary-school', boy: 'Sam', girl: 'Mia', girlDress: 'school uniform' };
+  }
+}
+
+// Cultural context per language. Kept language-keyed (not region-keyed) so no
+// single country is hardcoded as a global default.
+function classroomContextFor(language) {
+  if (language === 'sw') return 'East African (Kenya/Tanzania/Uganda)';
+  if (language === 'ar') return 'MENA region';
+  if (language === 'ur' || language === 'sd' || language === 'pa') return 'Pakistani';
+  return 'local'; // en — script-ambiguous, region-neutral
+}
+
+// Local currency for money word-problems, keyed by language.
+function currencyFor(language) {
+  if (language === 'sw') return 'Tanzanian Shilling (TSh)';
+  if (language === 'ar') return 'local currency (e.g. dirham/riyal as appropriate)';
+  if (language === 'ur' || language === 'sd' || language === 'pa') return 'Pakistani Rupee (PKR)';
+  return 'the local currency'; // en — region-neutral
+}
+
+// Callout-prefix translations. The text-LP prompt's additionalInstructions used
+// to hardcode English "Teacher says:" / "MODEL ANSWER:" / "Watch out:" which
+// leaked English into non-English output. en + the PK regional languages
+// (ur/sd/pa) keep the English prefixes (they already mix English structural
+// labels by design); sw + ar translate.
+function calloutPrefixesFor(language) {
+  switch (language) {
+    case 'sw':
+      return { teacherSays: 'Mwalimu anasema:', modelAnswer: 'JIBU MFANO:', watchOut: 'Angalia:' };
+    case 'ar':
+      return { teacherSays: 'يقول المعلّم:', modelAnswer: 'إجابة نموذجية:', watchOut: 'انتبه:' };
+    default:
+      // en, ur, sd, pa
+      return { teacherSays: 'Teacher says:', modelAnswer: 'MODEL ANSWER:', watchOut: 'Watch out:' };
+  }
+}
+
+// One composed instruction line for the Gamma prompt — names the region,
+// currency, and the two-student cast so worked examples are culturally
+// grounded for the teacher's chosen language.
+function buildRegionContextLine(language) {
+  const context = classroomContextFor(language);
+  const cast = characterCastFor(language);
+  const currency = currencyFor(language);
+  const marketWord = language === 'sw'
+    ? 'local market/duka'
+    : language === 'ar'
+      ? 'local market/souq'
+      : 'local market';
+  return `CULTURAL CONTEXT: Ground every example, name, and word problem in a ${context} classroom. Use ${currency} for money problems and the ${marketWord} for shopping/measurement contexts. Name the two recurring students "${cast.boy}" and "${cast.girl}". Use locally familiar foods, places, and situations — never foreign or out-of-region references.`;
+}
+
+module.exports = {
+  characterCastFor,
+  classroomContextFor,
+  currencyFor,
+  calloutPrefixesFor,
+  buildRegionContextLine,
+};

--- a/bot/shared/services/pic-to-lp/caption-prefill.js
+++ b/bot/shared/services/pic-to-lp/caption-prefill.js
@@ -1,0 +1,257 @@
+/**
+ * Pic-LP Caption Pre-fill
+ *
+ * Regex-extract grade / subject / topic / language from the WhatsApp caption
+ * a teacher attaches to their textbook photo. Runs BEFORE the LLM extractor —
+ * the values it finds flow into the form pre-fill, so even when the LLM call
+ * times out the form opens with what the teacher explicitly told us.
+ *
+ * Example captions (test fixtures live in tests/pic-to-lp/caption-prefill.test.js):
+ *   - "Create lesson plan for Class Five, subject Math, topic Adad aur
+ *      hisabi awamil, exercise 1.2"
+ *   - "Class: Four / Subject: General Science / Topic: Requirement of
+ *      energy for life / Medium: Sindhi"
+ *   - "Class 6 chapter cellular organization ka lesson plan bnadain"
+ *   - "جماعت: پنجم / مضمون: اردو / سبق کا عنوان: حمد"
+ *
+ * Design choices:
+ *   - Conservative — return null when uncertain. The form's existing
+ *     pre-fill flow handles missing fields gracefully (teacher fills
+ *     them in). False-positive extractions are worse than misses.
+ *   - No LLM call — runs locally in <1ms. Belt-and-braces with the LLM
+ *     extractor.
+ *   - Caption-derived values WIN over LLM when both produce a value:
+ *     the teacher's explicit ask outranks our inference from the page.
+ */
+
+const SUBJECT_CANONICAL = {
+  // English subject names → canonical form (matches the form's dropdown labels
+  // in shared/services/pic-to-lp/flow-options.js).
+  math: 'Math',
+  maths: 'Math',
+  mathematics: 'Math',
+  english: 'English',
+  urdu: 'Urdu',
+  science: 'Science',
+  'general science': 'Science',
+  'social studies': 'Social Studies',
+  sindhi: 'Sindhi',
+  islamiat: 'Islamiat',
+  'general knowledge': 'General Knowledge',
+  gk: 'General Knowledge',
+  // Urdu subject names
+  ریاضی: 'Math',
+  انگلش: 'English',
+  انگریزی: 'English',
+  اردو: 'Urdu',
+  سائنس: 'Science',
+  معاشرتی: 'Social Studies',
+  سندھی: 'Sindhi',
+  اسلامیات: 'Islamiat',
+  اسلامی: 'Islamiat',
+};
+
+const SUBJECT_KEYS = Object.keys(SUBJECT_CANONICAL).sort((a, b) => b.length - a.length);
+
+const NUMBER_WORDS = {
+  one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8, nine: 9, ten: 10,
+  eleven: 11, twelve: 12,
+  // Urdu / Roman Urdu number words for class
+  پہلی: 1, دوسری: 2, تیسری: 3, چوتھی: 4, پنجم: 5, پانچویں: 5, چھٹی: 6, ساتویں: 7,
+  آٹھویں: 8, نہم: 9, نویں: 9, دہم: 10, دسویں: 10,
+};
+
+const LANGUAGE_HINTS = {
+  english: 'en',
+  inglish: 'en',
+  انگریزی: 'en',
+  urdu: 'ur',
+  اردو: 'ur',
+  sindhi: 'sd',
+  sindhee: 'sd',
+  سندھی: 'sd',
+  swahili: 'sw',
+  kiswahili: 'sw',
+  سواحلی: 'sw',
+};
+
+function _toGrade(raw) {
+  if (raw == null) return null;
+  if (typeof raw === 'number') return raw >= 1 && raw <= 12 ? raw : null;
+  const s = String(raw).trim().toLowerCase();
+  const n = parseInt(s, 10);
+  if (!Number.isNaN(n) && n >= 1 && n <= 12) return n;
+  if (NUMBER_WORDS[s] != null) return NUMBER_WORDS[s];
+  return null;
+}
+
+function _findSubject(text) {
+  const lower = text.toLowerCase();
+  for (const key of SUBJECT_KEYS) {
+    // Check Urdu separately (case-insensitive matters less for Arabic script)
+    if (/[؀-ۿ]/.test(key)) {
+      if (text.includes(key)) return SUBJECT_CANONICAL[key];
+    } else {
+      // Word-boundary match — avoid "math" matching inside "maths" twice etc.
+      const re = new RegExp(`\\b${key.replace(/\s+/g, '\\s+')}\\b`, 'i');
+      if (re.test(lower)) return SUBJECT_CANONICAL[key];
+    }
+  }
+  return null;
+}
+
+function _findGrade(text) {
+  // Pattern A: "Class: 5", "Class 5", "Class Five", "grade 5", "grade2", "Grade Five"
+  const numericMatch = text.match(/\b(?:class|grade|درجہ|جماعت)\s*[:\-]?\s*(\d{1,2})\b/i);
+  if (numericMatch) {
+    const g = _toGrade(numericMatch[1]);
+    if (g != null) return g;
+  }
+  // Pattern B: word numbers — "Class Five", "Grade Two"
+  const wordMatch = text.match(/\b(?:class|grade)\s*[:\-]?\s*(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b/i);
+  if (wordMatch) {
+    const g = _toGrade(wordMatch[1]);
+    if (g != null) return g;
+  }
+  // Pattern C: Urdu "جماعت: پنجم" — direct word match
+  for (const word of Object.keys(NUMBER_WORDS)) {
+    if (/[؀-ۿ]/.test(word) && text.includes(word)) {
+      // Only accept if there's a class/grade prefix nearby, OR if the word
+      // appears in a structured "جماعت: X" / "درجہ: X" pattern
+      if (new RegExp(`(?:جماعت|درجہ)\\s*[:\\-]?\\s*${word}`).test(text)) {
+        return NUMBER_WORDS[word];
+      }
+    }
+  }
+  return null;
+}
+
+// Generic placeholders the regex would otherwise capture as a "topic" — these
+// mean "use the photo", not a literal topic name. Example: a caption like
+// "Generate grade 7 lesson plan on this topic" would match `lesson plan on` and
+// capture "this topic", clobbering an LLM-extracted real topic.
+const GENERIC_TOPIC_PLACEHOLDERS = /^(this|that|the|it|attached|above|below|here|here's|here is|this\s+(?:topic|lesson|chapter|page|photo|image|book|sabaq|سبق)|the\s+(?:topic|lesson|chapter|page|photo|image|book|sabaq|سبق)|attached\s+(?:topic|lesson|chapter|page|photo|image)|اس|یہ|سبق|عنوان|باب)$/i;
+
+function _isGenericPlaceholder(t) {
+  if (!t) return true;
+  return GENERIC_TOPIC_PLACEHOLDERS.test(t.trim());
+}
+
+// Strip trailing chunks that aren't part of the actual topic. Used after every
+// topic-extraction regex (A1/A2/B) so a teacher's "topic Respiration in english"
+// or "lesson plan on this in swahili" don't leak language tails into the topic.
+const _LANG_NAME_ALT = Object.keys(LANGUAGE_HINTS).join('|');
+const _LANG_TAIL_RE = new RegExp(`\\bin\\s+(?:${_LANG_NAME_ALT})(?:\\s+medium)?\\s*$`, 'i');
+function _cleanTopic(raw) {
+  if (!raw) return raw;
+  return raw
+    .replace(/\b(?:exercise|ex\.?)\s*[\d.]+.*$/i, '')
+    .replace(/\bka\s+lesson\s+plan\b.*$/i, '')
+    .replace(/\blesson\s+plan\b.*$/i, '')
+    .replace(_LANG_TAIL_RE, '')
+    .replace(/[.,;\s]+$/, '')
+    .trim();
+}
+
+function _findTopic(text) {
+  // Pattern A1: English explicit key — "Topic: <X>" / "Chapter: <X>"
+  const enKeyMatch = text.match(/\b(?:topic|chapter)\s*[:\-]?\s*([^\n,/]+)/i);
+  if (enKeyMatch) {
+    const t = _cleanTopic(enKeyMatch[1]);
+    if (t.length >= 2 && t.length <= 120 && !_isGenericPlaceholder(t)) return t;
+  }
+  // Pattern A2: Urdu explicit key — \b doesn't work for Arabic script in
+  // JavaScript regex, so anchor on start-of-string or whitespace instead.
+  const urKeyMatch = text.match(/(?:^|\s)(?:سبق(?:\s*کا\s*عنوان)?|عنوان|باب)\s*[:\-]?\s*([^\n,/]+)/);
+  if (urKeyMatch) {
+    const t = _cleanTopic(urKeyMatch[1]);
+    if (t.length >= 2 && t.length <= 120 && !_isGenericPlaceholder(t)) return t;
+  }
+  // Pattern B: ", topic X exercise Y" / "lesson plan for X" / "X ka lesson plan"
+  const ofMatch = text.match(/\b(?:topic|on|about|of|lesson plan for|lesson plan on)\s+([^\n,.]{3,80})/i);
+  if (ofMatch) {
+    const cleaned = _cleanTopic(ofMatch[1]);
+    if (cleaned.length >= 3 && cleaned.length <= 120 && !_isGenericPlaceholder(cleaned)) return cleaned;
+  }
+  // Pattern C: Roman Urdu "<X> ka lesson plan" — pull "X" preceding "ka lesson plan"
+  const romanMatch = text.match(/(?:chapter|sabaq)\s+([^\n,.]{3,80}?)\s+(?:ka|ke|ki)\s+lesson/i);
+  if (romanMatch) {
+    const t = romanMatch[1].trim();
+    if (!_isGenericPlaceholder(t)) return t;
+  }
+  return null;
+}
+
+function _findLanguage(text) {
+  // Pattern A: "in <lang>" — "lesson plan in Urdu"
+  const inMatch = text.match(/\b(?:in|me(?:in)?|main|میں)\s+(english|inglish|urdu|sindhi|sindhee|swahili|kiswahili|اردو|انگریزی|سندھی|سواحلی)\b/i);
+  if (inMatch) return LANGUAGE_HINTS[inMatch[1].toLowerCase()] || null;
+  // Pattern A2: Roman Urdu "<lang> me/mein" — "sindhi me lesson plan"
+  const langFirstMatch = text.match(/\b(english|inglish|urdu|sindhi|sindhee|swahili|kiswahili)\s+(?:me|mein|main)\b/i);
+  if (langFirstMatch) return LANGUAGE_HINTS[langFirstMatch[1].toLowerCase()] || null;
+  // Pattern B: "Medium: <lang>" / "Language: <lang>"
+  const mediumMatch = text.match(/\b(?:medium|language|زبان)\s*[:\-]?\s*(english|inglish|urdu|sindhi|sindhee|swahili|kiswahili|اردو|انگریزی|سندھی|سواحلی)\b/i);
+  if (mediumMatch) return LANGUAGE_HINTS[mediumMatch[1].toLowerCase()] || null;
+  return null;
+}
+
+/**
+ * Extract grade / subject / topic / language from a caption.
+ * Returns shape: { grade, subject, topic, language } where any field may be null.
+ *
+ * Pure function. Returns null shape (no exceptions) for empty/null input.
+ *
+ * @param {string|null|undefined} caption
+ * @returns {{grade: number|null, subject: string|null, topic: string|null, language: string|null}}
+ */
+function extractFromCaption(caption) {
+  if (!caption || typeof caption !== 'string' || caption.trim().length === 0) {
+    return { grade: null, subject: null, topic: null, language: null };
+  }
+  const text = caption.trim();
+
+  // LP-intent gate: captions can include non-LP intents like "translate this
+  // text into Urdu" — those would otherwise match _findSubject('English') and
+  // pollute the form. Only proceed with the pre-fill when the caption looks
+  // LP-shaped: explicit "lesson plan" / "sabaq" / "سبق" / "lp" intent, OR
+  // structured "Class: N" / "Subject: X" / "جماعت: X" key-value markers, OR a
+  // numeric Class/Grade/جماعت prefix nearby.
+  const hasLPIntent =
+    /\b(lesson\s*plan|sabaq|sabq|lp)\b/i.test(text) ||
+    /(سبق|درس)/.test(text) ||
+    /\b(?:class|grade|درجہ|جماعت)\s*[:\-]?\s*\d/i.test(text) ||
+    /(?:Class|Subject|Topic|Medium|Language|جماعت|مضمون|عنوان)\s*:/.test(text);
+  if (!hasLPIntent) {
+    return { grade: null, subject: null, topic: null, language: null };
+  }
+
+  return {
+    grade: _findGrade(text),
+    subject: _findSubject(text),
+    topic: _findTopic(text),
+    language: _findLanguage(text),
+  };
+}
+
+/**
+ * Merge an LLM extraction result with a caption-derived prefill.
+ * Caption values WIN where present — teacher's explicit ask outranks
+ * our inference from the page. LLM fills gaps the caption left empty.
+ *
+ * @param {{grade,subject,topic,ocr_text}} llmResult
+ * @param {{grade,subject,topic,language}} captionResult
+ * @returns {{grade,subject,topic,ocr_text,language}}
+ */
+function mergeWithCaption(llmResult, captionResult) {
+  const llm = llmResult || {};
+  const cap = captionResult || {};
+  return {
+    grade: cap.grade != null ? cap.grade : (llm.grade != null ? llm.grade : null),
+    subject: cap.subject || llm.subject || null,
+    topic: cap.topic || llm.topic || null,
+    language: cap.language || null, // language only ever from caption pre-fill
+    ocr_text: llm.ocr_text || '',
+  };
+}
+
+module.exports = { extractFromCaption, mergeWithCaption };

--- a/bot/shared/services/pic-to-lp/classifier.service.js
+++ b/bot/shared/services/pic-to-lp/classifier.service.js
@@ -1,0 +1,99 @@
+/**
+ * Pic-to-LP Classifier Service
+ *
+ * Single-shot vision call that decides whether an incoming WhatsApp image
+ * is a textbook page worth offering "Generate Lesson Plan" buttons for, or
+ * something else (classroom photo, student work, exam, screenshot, sticker).
+ *
+ * Returns one of:
+ *   BOOK_PAGE     — printed textbook / workbook page
+ *   CLASSROOM     — wide shot of a classroom scene
+ *   STUDENT_WORK  — handwritten work, notebook, worksheet filled by student
+ *   EXAM          — printed exam paper / question paper
+ *   OTHER         — sticker, screenshot, selfie, anything else
+ *
+ * Plus a confidence score (0..1). Callers should treat anything < 0.6 as OTHER
+ * to avoid annoying false-positive "Generate LP" prompts.
+ */
+
+const OpenAI = require('openai');
+const { logToFile } = require('../../utils/logger');
+const { OPENAI_API_KEY } = require('../../utils/constants');
+
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+const VALID_TYPES = ['BOOK_PAGE', 'CLASSROOM', 'STUDENT_WORK', 'EXAM', 'OTHER'];
+const MODEL = process.env.PIC_LP_CLASSIFIER_MODEL || 'gpt-4o-mini';
+const TIMEOUT_MS = 15000;
+
+/**
+ * Classify an incoming image.
+ * @param {Buffer} imageBuffer
+ * @param {string} mimeType
+ * @param {string} caption  optional WhatsApp caption text
+ * @returns {Promise<{type: string, confidence: number}>}
+ */
+async function classifyImageType(imageBuffer, mimeType, caption = '') {
+  try {
+    const dataUrl = `data:${mimeType};base64,${imageBuffer.toString('base64')}`;
+
+    const systemPrompt = [
+      'You classify WhatsApp images sent to a teacher-support bot.',
+      'Return ONE of: BOOK_PAGE, CLASSROOM, STUDENT_WORK, EXAM, OTHER.',
+      '',
+      'Definitions:',
+      '- BOOK_PAGE: printed textbook or workbook page (typeset, includes exercises, headings, page number).',
+      '- CLASSROOM: wide-angle photo of a classroom, students, blackboard, classroom setup.',
+      '- STUDENT_WORK: handwritten work in a notebook, filled-in worksheet, student answers.',
+      '- EXAM: printed exam paper, formal question paper with marks/instructions.',
+      '- OTHER: screenshot, selfie, sticker, meme, document not in the above buckets.',
+      '',
+      'Reply ONLY with strict JSON: {"type": "...", "confidence": 0.0-1.0}.',
+      'No prose, no markdown.',
+    ].join('\n');
+
+    const userText = caption
+      ? `Caption from sender: "${caption.substring(0, 200)}"`
+      : '(No caption)';
+
+    const completion = await openai.chat.completions.create(
+      {
+        model: MODEL,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: userText },
+              { type: 'image_url', image_url: { url: dataUrl, detail: 'low' } },
+            ],
+          },
+        ],
+        max_tokens: 60,
+        temperature: 0,
+        response_format: { type: 'json_object' },
+      },
+      { timeout: TIMEOUT_MS }
+    );
+
+    const raw = completion.choices?.[0]?.message?.content || '{}';
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      logToFile('⚠️ Pic-LP classifier returned non-JSON, defaulting OTHER', { raw });
+      return { type: 'OTHER', confidence: 0 };
+    }
+
+    let type = String(parsed.type || '').toUpperCase();
+    if (!VALID_TYPES.includes(type)) type = 'OTHER';
+    const confidence = Math.max(0, Math.min(1, Number(parsed.confidence) || 0));
+
+    return { type, confidence };
+  } catch (error) {
+    logToFile('❌ Pic-LP classifier failed', { error: error.message });
+    return { type: 'OTHER', confidence: 0 };
+  }
+}
+
+module.exports = { classifyImageType, VALID_TYPES };

--- a/bot/shared/services/pic-to-lp/completion-handler.service.js
+++ b/bot/shared/services/pic-to-lp/completion-handler.service.js
@@ -1,0 +1,151 @@
+/**
+ * Pic-LP Completion Handler
+ *
+ * Called when page collection ends (Done button, max-pages, or 2-min timeout).
+ * Runs metadata extraction over the collected pages, then sends the WhatsApp
+ * Flow form to the teacher for grade/subject/topic/language confirmation.
+ */
+
+const WhatsAppService = require('../whatsapp.service');
+const { logToFile } = require('../../utils/logger');
+const { logEvent } = require('../../utils/structured-logger');
+const { PIC_LP_FLOW_ID } = require('../../utils/constants');
+const PicLpSession = require('./pic-lp-session.service');
+const MetadataExtractor = require('./metadata-extractor.service');
+const {
+  buildGrades,
+  buildSubjects,
+  buildLanguages,
+  buildLessonPlanFormats,
+  DEFAULT_LP_FORMAT,
+} = require('./flow-options');
+const { detectRegion } = require('../../utils/region');
+
+const FORM_FLOW_TOKEN_PREFIX = 'pic_lp_form_';
+
+/**
+ * @param {object} args
+ * @param {object} args.session  pic_lp_sessions row
+ * @param {string} args.from     WhatsApp phone
+ * @param {string} args.language UI language ('en'|'ur'|...)
+ * @param {string} args.trigger  'done_clicked' | 'max_reached' | 'timeout'
+ */
+async function extractAndPromptForm({ session, from, language, trigger }) {
+  const isUrdu = language === 'ur';
+
+  await WhatsAppService.sendMessage(
+    from,
+    isUrdu
+      ? '🔍 صفحات کا جائزہ لیا جا رہا ہے...'
+      : '🔍 Reading the pages you sent...'
+  );
+
+  // Step 1: extract metadata.
+  // Fetch the teacher's registered grade + preferred language so the extractor
+  // can fall back to them when the vision pass returns null. Without this, a
+  // clean OCR that still returns grade=null + language=null leaves the form
+  // with empty required fields and the teacher may abandon.
+  const supabase = require('../../config/supabase');
+  const { data: userRow } = await supabase
+    .from('users')
+    .select('grade, preferred_language')
+    .eq('id', session.user_id)
+    .maybeSingle();
+  const userContext = {
+    registeredGrade: userRow?.grade || null,
+    preferredLanguage: userRow?.preferred_language || language || null,
+  };
+
+  const detected = await MetadataExtractor.extract(session.pages || [], session.caption || '', userContext);
+  await PicLpSession.updateDetected(session.id, detected);
+
+  logEvent('pic_lp.metadata_extracted', {
+    sessionId: session.id,
+    pageCount: (session.pages || []).length,
+    hasGrade: detected.grade != null,
+    hasSubject: detected.subject != null,
+    hasTopic: detected.topic != null,
+    ocrTextLength: (detected.ocr_text || '').length,
+    trigger,
+  });
+
+  // Step 2: bail if Flow ID not configured (shouldn't happen after registration)
+  if (!PIC_LP_FLOW_ID) {
+    logToFile('⚠️ PIC_LP_FLOW_ID not set — falling back to text confirmation', { sessionId: session.id });
+    await sendFallbackTextConfirmation({ session, from, language, detected });
+    return;
+  }
+
+  // Step 3: send the Flow form pre-filled with whatever we extracted
+  const flowToken = `${FORM_FLOW_TOKEN_PREFIX}${session.id}`;
+  await PicLpSession.attachFlowToken(session.id, flowToken);
+
+  // Dropdown source arrays MUST be sent at runtime — Flow JSON's `__example__`
+  // blocks are only used by Meta for design-time preview, not for rendering.
+  // Without these all three dropdowns render empty and the form fails validation.
+  const region = detectRegion();
+  const navigateData = {
+    grades: buildGrades(),
+    subjects: buildSubjects(region),
+    languages: buildLanguages(),
+    // format toggle data + default selection
+    lesson_plan_formats: buildLessonPlanFormats(),
+    default_lp_format: DEFAULT_LP_FORMAT,
+    detected_grade: detected.grade != null ? String(detected.grade) : '',
+    detected_subject: detected.subject || '',
+    detected_topic: detected.topic || '',
+    // Caption-derived language wins over the user's preferred-language default.
+    // If a teacher writes "lesson plan in Sindhi" in the caption, the dropdown
+    // opens with Sindhi pre-selected.
+    ui_language: detected.language || language || 'en',
+    page_count: String((session.pages || []).length),
+    session_id: session.id,
+  };
+
+  const sent = await WhatsAppService.sendFlow(from, {
+    flowId: PIC_LP_FLOW_ID,
+    header: isUrdu ? 'لیسن پلان کی تفصیلات' : 'Lesson Plan Details',
+    body: isUrdu
+      ? 'تفصیلات کنفرم کریں اور لیسن پلان بنائیں۔'
+      : 'Confirm the details below and we will generate your lesson plan.',
+    buttonText: isUrdu ? 'تفصیلات' : 'Confirm Details',
+    screen: 'PIC_LP_FORM',
+    flowToken,
+    navigateData,
+  });
+
+  if (!sent) {
+    await sendFallbackTextConfirmation({ session, from, language, detected });
+  }
+}
+
+/**
+ * Fallback when the Flow can't be sent (no Flow ID configured, Meta error).
+ * We don't want the teacher stranded with no path forward.
+ */
+async function sendFallbackTextConfirmation({ session, from, language, detected }) {
+  const isUrdu = language === 'ur';
+  const lines = [
+    isUrdu ? '📋 آپ کی معلومات:' : '📋 Detected from your pages:',
+    detected.grade != null
+      ? (isUrdu ? `• درجہ: ${detected.grade}` : `• Grade: ${detected.grade}`)
+      : (isUrdu ? '• درجہ: ?' : '• Grade: ?'),
+    detected.subject
+      ? (isUrdu ? `• مضمون: ${detected.subject}` : `• Subject: ${detected.subject}`)
+      : (isUrdu ? '• مضمون: ?' : '• Subject: ?'),
+    detected.topic
+      ? (isUrdu ? `• موضوع: ${detected.topic}` : `• Topic: ${detected.topic}`)
+      : (isUrdu ? '• موضوع: ?' : '• Topic: ?'),
+    '',
+    isUrdu
+      ? 'فی الحال فارم دستیاب نہیں۔ ہماری ٹیم کو اطلاع دے دی گئی ہے۔'
+      : "The confirmation form isn't available right now. The team has been notified.",
+  ];
+  await WhatsAppService.sendMessage(from, lines.join('\n'));
+  logToFile('⚠️ Pic-LP fallback text confirmation sent', { sessionId: session.id });
+}
+
+module.exports = {
+  extractAndPromptForm,
+  FORM_FLOW_TOKEN_PREFIX,
+};

--- a/bot/shared/services/pic-to-lp/flow-options.js
+++ b/bot/shared/services/pic-to-lp/flow-options.js
@@ -1,0 +1,83 @@
+/**
+ * Pic-LP Flow Options
+ *
+ * Shared dropdown source arrays for the pic-LP confirmation Flow. Both the
+ * completion-handler (sends Flow with navigateData) and the Flow endpoint
+ * (returns these on INIT/BACK) need the same arrays — keep them here so they
+ * can't drift.
+ */
+
+function buildGrades() {
+  return Array.from({ length: 10 }, (_, i) => ({
+    id: String(i + 1),
+    title: `Class ${i + 1}`,
+  }));
+}
+
+// Generic, region-agnostic subject list. The platform is deployed worldwide,
+// so the default dropdown uses broadly-applicable primary-school subjects.
+// IDs use title-case English (matches the downstream LP prompt subject string).
+// Deployments that want a region-specific list can extend buildSubjects().
+const DEFAULT_SUBJECTS = [
+  { id: 'Math',                  title: 'Math' },
+  { id: 'English',               title: 'English' },
+  { id: 'Science',               title: 'Science' },
+  { id: 'Social Studies',        title: 'Social Studies' },
+  { id: 'Languages',             title: 'Languages' },
+  { id: 'Religious Education',   title: 'Religious Education' },
+  { id: 'General Knowledge',     title: 'General Knowledge' },
+  { id: 'Other',                 title: 'Other' },
+];
+
+/**
+ * @param {string} [region] - ignored; the generic default list is returned.
+ *   Kept in the signature for caller compatibility.
+ */
+function buildSubjects(region) {
+  return DEFAULT_SUBJECTS.slice();
+}
+
+function buildLanguages() {
+  return [
+    { id: 'en', title: 'English' },
+    { id: 'ur', title: 'Urdu' },
+    { id: 'sd', title: 'Sindhi' },
+    { id: 'sw', title: 'Kiswahili' },
+    // gpt-image-2 renders Arabic Naskh natively — the kieai-prompt-builder
+    // treats 'ar' like 'ur' for bilingual layout but skips the
+    // "NOT Devanagari NOT Hindi" rule (Arabic is naturally Naskh).
+    { id: 'ar', title: 'Arabic' },
+  ];
+}
+
+// Lesson-plan format options for the teacher-controlled toggle.
+// 'concise' → Kie.ai 2-page (~90s English, ~4 min others) — the default path.
+// 'detailed' → Gamma 7-page (~5 min, complete teacher guide format) — OPTIONAL
+//   legacy arm. Only offered when GAMMA_API_KEY is configured AND the standalone
+//   lesson-plan-prompts service is present, since the Detailed path routes
+//   through Gamma. Clones without Gamma see only the Concise option (no
+//   misleading choice), and the Kie.ai path serves every request.
+//
+// `description` renders as a small subtitle under each radio option in the
+// WhatsApp Flow — Meta does NOT support `helper-text` on RadioButtonsGroup,
+// so per-option descriptions are how we surface the timing/length tradeoff.
+function buildLessonPlanFormats() {
+  const formats = [
+    { id: 'concise', title: 'Concise', description: '2 pages, ~90 sec' },
+  ];
+  if (process.env.GAMMA_API_KEY) {
+    formats.push({ id: 'detailed', title: 'Detailed', description: '7 pages, ~5 min — complete teacher guide' });
+  }
+  return formats;
+}
+
+const DEFAULT_LP_FORMAT = 'concise';
+
+module.exports = {
+  buildGrades,
+  buildSubjects,
+  buildLanguages,
+  buildLessonPlanFormats,
+  DEFAULT_LP_FORMAT,
+  DEFAULT_SUBJECTS,
+};

--- a/bot/shared/services/pic-to-lp/gamma-client.service.js
+++ b/bot/shared/services/pic-to-lp/gamma-client.service.js
@@ -1,0 +1,148 @@
+/**
+ * Gamma Client
+ *
+ * Standalone wrapper around the Gamma generations API. Lifted from the
+ * duplicated _generateViaGamma in the page/chapter LP generation services so
+ * pic-to-LP doesn't add a third copy.
+ *
+ * Language support:
+ *   en  → textOptions.language='en' (default)
+ *   ur  → textOptions.language='ur' + Urdu RTL instructions
+ *   sw  → textOptions.language='sw' (Gamma supports it natively)
+ *   sd  → textOptions.language='ur' (Gamma doesn't support 'sd') + Sindhi instructions
+ *          asking the model to write in Sindhi using Naskh script. Best-effort.
+ */
+
+const axios = require('axios');
+const { logToFile } = require('../../utils/logger');
+const { GAMMA_API_KEY, GAMMA_MAX_ATTEMPTS, GAMMA_POLL_INTERVAL } = require('../../utils/constants');
+
+const SUPPORTED_LANGUAGES = ['en', 'ur', 'sw', 'sd'];
+
+const BASE_INSTRUCTIONS = 'LAYOUT: For each daily lesson plan, use a TWO-COLUMN layout — Engage/Explore/Explain on the LEFT column, Practice/Exit Ticket/Homework on the RIGHT column. Use a TIMELINE for the lesson flow overview at the top of each day. CALLOUT DIFFERENTIATION: Use different callout styles — "Teacher says:" QUOTE block, "MODEL ANSWER:" TIP/SUCCESS callout, "Watch out:" WARNING/CAUTION callout. Render BOARD CONTENT as CODE BLOCKS (monospace, bordered, grey) — number lines, place value charts, ASCII diagrams. Display vocabulary as a styled TABLE. Use ICON layouts for materials. NUMBERED LISTS for practice problems. Bold all time allocations. Use TOGGLE blocks for extension activities. Embed scaffolding/extension within Practice — no separate DIFFERENTIATION section.';
+
+function buildLanguageOverrides(language) {
+  switch (language) {
+    case 'ur':
+      return {
+        gammaLang: 'ur',
+        extraInstructions: ' Write in Urdu (RTL). Use bilingual terms for technical vocabulary (e.g., "Fraction (کسر)").',
+      };
+    case 'sw':
+      return {
+        gammaLang: 'sw',
+        extraInstructions: ' Write the lesson plan body in Kiswahili. Keep technical/educational terms in English (e.g., lesson plan, exit ticket, worksheet).',
+      };
+    case 'sd':
+      return {
+        gammaLang: 'ur', // Gamma falls back; we coerce via prompt instructions below.
+        extraInstructions: ' Write the lesson plan body in Sindhi (سنڌي), using Sindhi-Arabic Naskh script. Keep technical/educational terms in English (e.g., fraction, lesson plan). Where useful, gloss new terms in English first then Sindhi in parentheses.',
+      };
+    case 'en':
+    default:
+      return {
+        gammaLang: 'en',
+        extraInstructions: '',
+      };
+  }
+}
+
+/**
+ * Generate a Gamma document.
+ * @param {object} args
+ * @param {string} args.prompt   The full prompt (typically built via LessonPlanPromptsService.buildChapterPrompt)
+ * @param {string} args.title    Header text for top-right of every page
+ * @param {string} args.language One of SUPPORTED_LANGUAGES
+ * @returns {Promise<{success: boolean, gammaUrl?: string, pdfUrl?: string, error?: string, generationId?: string}>}
+ */
+async function generate({ prompt, title, language = 'en' }) {
+  const lang = SUPPORTED_LANGUAGES.includes(language) ? language : 'en';
+  const { gammaLang, extraInstructions } = buildLanguageOverrides(lang);
+
+  const requestBody = {
+    inputText: prompt,
+    format: 'document',
+    exportAs: 'pdf',
+    themeId: 'cornflower',
+    textMode: 'generate',
+    // Cap card count to match the main LP path. Without this, Gamma auto-picks
+    // 10-15 cards from our verbose prompt and generations land in 5-10 min
+    // instead of the 2-3 min Gamma's own docs promise.
+    numCards: 7,
+    cardSplit: 'inputTextBreaks',
+    additionalInstructions: BASE_INSTRUCTIONS + extraInstructions,
+    cardOptions: {
+      headerFooter: {
+        topLeft: { type: 'image', source: 'custom', src: 'https://hellorumi.ai/rumi-logo-transparent.png', size: 'sm' },
+        topRight: { type: 'text', value: title },
+        bottomCenter: { type: 'cardNumber' },
+        bottomRight: { type: 'text', value: 'generate your lesson plan at hellorumi.ai' },
+      },
+    },
+    textOptions: {
+      language: gammaLang,
+      audience: 'teachers in diverse, resource-limited classrooms who may not be subject matter experts',
+      tone: 'supportive, practical, step-by-step, and encouraging — like a mentor guiding a new teacher',
+      amount: 'detailed',
+    },
+    imageOptions: {
+      source: 'webAllImages',
+      style: 'educational, classroom, science diagrams, clean',
+    },
+  };
+
+  try {
+    const axiosInstance = axios.default || axios;
+    const createResponse = await axiosInstance.post(
+      'https://public-api.gamma.app/v1.0/generations',
+      requestBody,
+      { headers: { 'X-API-KEY': GAMMA_API_KEY, 'Content-Type': 'application/json' } }
+    );
+
+    const generationId = createResponse.data.generationId;
+    logToFile('Pic-LP Gamma generation started', { generationId, title, language: lang });
+
+    let attempts = 0;
+    while (attempts < GAMMA_MAX_ATTEMPTS) {
+      await new Promise((r) => setTimeout(r, GAMMA_POLL_INTERVAL));
+
+      const statusResponse = await axiosInstance.get(
+        `https://public-api.gamma.app/v1.0/generations/${generationId}`,
+        { headers: { 'X-API-KEY': GAMMA_API_KEY } }
+      );
+
+      if (statusResponse.data.status === 'completed') {
+        const pdfUrl = statusResponse.data.pdfUrl || statusResponse.data.exportUrl || statusResponse.data.fileUrl;
+        logToFile('Pic-LP Gamma generation completed', {
+          generationId,
+          title,
+          creditsDeducted: statusResponse.data.credits?.deducted,
+          creditsRemaining: statusResponse.data.credits?.remaining,
+        });
+        return {
+          success: true,
+          generationId,
+          gammaUrl: statusResponse.data.gammaUrl,
+          pdfUrl,
+        };
+      }
+
+      if (statusResponse.data.status === 'failed') {
+        return {
+          success: false,
+          generationId,
+          error: statusResponse.data.error || 'Gamma generation failed',
+        };
+      }
+
+      attempts++;
+    }
+
+    return { success: false, generationId, error: 'Timed out waiting for Gamma' };
+  } catch (error) {
+    logToFile('❌ Pic-LP Gamma client failed', { error: error.message, language: lang });
+    return { success: false, error: error.message };
+  }
+}
+
+module.exports = { generate, SUPPORTED_LANGUAGES };

--- a/bot/shared/services/pic-to-lp/image-batch-coalescer.service.js
+++ b/bot/shared/services/pic-to-lp/image-batch-coalescer.service.js
@@ -1,0 +1,142 @@
+/**
+ * Image Batch Coalescer
+ *
+ * Per-user webhook-layer buffer for pic-to-LP image arrivals. WhatsApp delivers
+ * an album/batch send as N independent webhooks within ~1 second. Without this
+ * service, each webhook would independently run through the pic-LP entry path,
+ * race to create its own pic_lp_session, and most would either fall through to
+ * generic vision-feedback or accumulate as stale sessions.
+ *
+ * This service collects per-user webhooks into a 2.5-second sliding window and
+ * fires a single `onFlush(batch)` callback. The caller (image-message.handler)
+ * picks the primary (caption-carrying) photo, runs the classifier ONCE, creates
+ * ONE pic_lp_session, and appends the rest as pages.
+ *
+ * Design notes:
+ *  - Trailing-edge debounce per user: each new image refreshes the timer.
+ *    Slow-drip senders still get one-batch-per-photo behavior.
+ *  - mediaId dedupe inside the buffer (Meta occasionally retries webhooks).
+ *  - Caption picker: any image carrying a caption wins primary status; the
+ *    earliest such caption is preserved. If no captions, first-arriving wins.
+ *  - MAX_BATCH_SIZE (5) matches MAX_PIC_LP_PAGES — overflow immediately flushes
+ *    the current batch and starts a new one.
+ *  - Per-user isolation via Map<userId, BatchState>.
+ *  - Errors from onFlush are caught + logged; subsequent batches keep working.
+ */
+
+const { logToFile } = require('../../utils/logger');
+
+const BATCH_WINDOW_MS = 2500;
+const MAX_BATCH_SIZE = 5;
+
+/** @typedef {{ mediaId: string, mimeType?: string, caption?: string, receivedAt?: number }} ImageEvent */
+/** @typedef {{ userId: string, images: ImageEvent[], primary: ImageEvent, caption: string }} Batch */
+
+/** @type {Map<string, { images: ImageEvent[], onFlush: Function, timer: NodeJS.Timeout }>} */
+const buffers = new Map();
+
+/**
+ * Enqueue an image for this user. If a buffer exists for the user, append and
+ * reset the timer; otherwise start a new buffer. If MAX_BATCH_SIZE is reached
+ * BEFORE the incoming image, flush the current buffer immediately and start a
+ * fresh one with the incoming image.
+ *
+ * @param {object} args
+ * @param {string} args.userId   - Teacher UUID
+ * @param {ImageEvent} args.image
+ * @param {(batch: Batch) => void | Promise<void>} args.onFlush - fires on window close or max-batch
+ */
+function enqueue({ userId, image, onFlush }) {
+  if (!userId || !image || !image.mediaId) {
+    throw new Error('image-batch-coalescer: userId, image, image.mediaId all required');
+  }
+
+  let state = buffers.get(userId);
+
+  // Cap-reached: flush current + start fresh batch with this image as the seed.
+  if (state && state.images.length >= MAX_BATCH_SIZE) {
+    fireFlush(userId);
+    state = undefined; // a fresh batch follows
+  }
+
+  if (!state) {
+    state = { images: [], onFlush, timer: null };
+    buffers.set(userId, state);
+  } else {
+    // Refresh the registered callback in case the caller's closure changed
+    // (e.g. test re-enqueue across calls). Practically always identical.
+    state.onFlush = onFlush;
+  }
+
+  // Dedupe by mediaId — Meta sometimes retries webhooks for the same image.
+  const alreadyHave = state.images.some((i) => i.mediaId === image.mediaId);
+  if (!alreadyHave) {
+    state.images.push({
+      mediaId: image.mediaId,
+      mimeType: image.mimeType,
+      caption: image.caption || '',
+      receivedAt: image.receivedAt || Date.now(),
+    });
+  }
+
+  // (Re)arm the trailing-edge debounce timer.
+  if (state.timer) clearTimeout(state.timer);
+  state.timer = setTimeout(() => fireFlush(userId), BATCH_WINDOW_MS);
+}
+
+/**
+ * Force-fire any pending batch for this user. No-op if no buffer.
+ * Useful for graceful shutdown, error paths, or tests.
+ */
+function flushNow(userId) {
+  if (buffers.has(userId)) {
+    fireFlush(userId);
+  }
+}
+
+function fireFlush(userId) {
+  const state = buffers.get(userId);
+  if (!state) return;
+
+  if (state.timer) clearTimeout(state.timer);
+  buffers.delete(userId);
+
+  const { images, onFlush } = state;
+  if (images.length === 0) return;
+
+  // Primary = first image with a caption (preserve arrival order); else first.
+  let primary = images.find((i) => (i.caption || '').trim().length > 0);
+  if (!primary) primary = images[0];
+  const caption = primary.caption || '';
+
+  const batch = { userId, images, primary, caption };
+
+  try {
+    onFlush(batch);
+  } catch (err) {
+    logToFile('image-batch-coalescer: onFlush callback threw', {
+      userId,
+      error: err.message,
+      batchSize: images.length,
+    });
+  }
+}
+
+/**
+ * Test-only: reset all internal state. Do NOT call from production paths —
+ * a real-world reset would orphan in-flight batches.
+ */
+function __resetForTest() {
+  for (const state of buffers.values()) {
+    if (state.timer) clearTimeout(state.timer);
+  }
+  buffers.clear();
+}
+
+module.exports = {
+  BATCH_WINDOW_MS,
+  MAX_BATCH_SIZE,
+  enqueue,
+  flushNow,
+  __resetForTest,
+};

--- a/bot/shared/services/pic-to-lp/kieai-client.service.js
+++ b/bot/shared/services/pic-to-lp/kieai-client.service.js
@@ -1,0 +1,238 @@
+/**
+ * Kie.ai Client
+ *
+ * Standalone wrapper around the Kie.ai jobs API for the pic-to-LP backend.
+ * Mirrors the gamma-client.service.js shape so the handoff service can swap
+ * callers cleanly.
+ *
+ * Routing:
+ *   language='en' → gpt-image-2-image-to-image at 1K resolution (~80s)
+ *   language ∈ {'ur','sd','pa'} → gpt-image-2-image-to-image at 2K (~4 min)
+ *
+ * The 2K Urdu path is cheaper per image than nano-banana-pro at the cost of
+ * ~60s extra latency. The teacher is told the expected wait upfront via the
+ * pic-lp-wait-message service.
+ *
+ * NOTE: Different model identifier prefix means different request shape:
+ *   gpt-image-2-image-to-image  → uses `input_urls` array
+ *   nano-banana-pro / nano-banana-2 → use `image_input` array
+ * (The nano-banana variants aren't used by default, but the detection logic
+ *  is kept for future flexibility.)
+ */
+
+const https = require('https');
+const { logToFile } = require('../../utils/logger');
+const { KIE_API_KEY_PIC_LP, KIE_MAX_ATTEMPTS, KIE_POLL_INTERVAL } = require('../../utils/constants');
+// Pic-to-LP uses its dedicated key (falls back to the shared KIE_API_KEY if
+// unset) so its rate-limit budget is isolated from other image features.
+const KIE_API_KEY = KIE_API_KEY_PIC_LP;
+
+const KIE_API_HOST = 'api.kie.ai';
+const SOCKET_TIMEOUT_MS = 60000;
+const RETRY_TRANSIENT_RE = /ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket timeout|socket hang up/;
+
+/**
+ * Pick model + resolution by language. Codified as the locked routing rule.
+ *
+ * @param {string} language - 'en' | 'ur' | 'sd' | 'pa'
+ * @returns {{model: string, resolution: string, costUsdPerPage: number, expectedSec: number, upperSec: number}}
+ */
+function pickBackend(language) {
+  // Latin-script languages → 1K (cheaper + faster; sufficient glyph fidelity
+  // for Latin). RTL non-Latin → 2K (Nastaliq + Naskh glyphs need the extra
+  // pixels per character).
+  const LATIN_SCRIPT = ['en', 'sw']; // English, Kiswahili
+  if (LATIN_SCRIPT.includes(language)) {
+    return {
+      model: 'gpt-image-2-image-to-image',
+      resolution: '1K',
+      costUsdPerPage: 0.03,
+      expectedSec: 90,
+      upperSec: 180,
+    };
+  }
+  // Urdu (Nastaliq), Sindhi (Nastaliq), Punjabi (Shahmukhi/Nastaliq), Arabic (Naskh)
+  return {
+    model: 'gpt-image-2-image-to-image',
+    resolution: '2K',
+    costUsdPerPage: 0.05,
+    expectedSec: 240,
+    upperSec: 420,
+  };
+}
+
+/**
+ * Pick the input-array field name for a given model.
+ * Detection is by prefix because Kie.ai's API field name varies.
+ */
+function inputFieldFor(model) {
+  if (model && model.startsWith('gpt-image-2')) return 'input_urls';
+  return 'image_input'; // nano-banana-pro / nano-banana-2 / google/nano-banana-edit
+}
+
+function httpsRequestOnce(opts, body) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(opts, (res) => {
+      let data = '';
+      res.on('data', (c) => (data += c));
+      res.on('end', () => {
+        try { resolve(JSON.parse(data)); }
+        catch (_) { reject(new Error(`Bad JSON from kie.ai: ${data.slice(0, 200)}`)); }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(SOCKET_TIMEOUT_MS, () => req.destroy(new Error('socket timeout')));
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+async function httpsRequest(opts, body, maxRetries = 5) {
+  let lastErr;
+  for (let i = 0; i < maxRetries; i++) {
+    try { return await httpsRequestOnce(opts, body); }
+    catch (e) {
+      lastErr = e;
+      const transient = RETRY_TRANSIENT_RE.test(e.message);
+      if (!transient && i === 0) throw e;
+      const wait = Math.min(2000 * Math.pow(2, i), 16000);
+      logToFile(`Kie.ai retry ${i + 1}/${maxRetries}: ${e.message} (sleeping ${wait}ms)`);
+      await new Promise((r) => setTimeout(r, wait));
+    }
+  }
+  throw lastErr;
+}
+
+// GPT-Image-2's output moderation is stochastic — the same prompt + same inputs
+// can fail one attempt and succeed the next (e.g. a benign educational biology
+// illustration with a student-cast hook scene can trip a false positive). One
+// stochastic flag shouldn't strand a teacher, so retry up to MAX_CP_RETRIES
+// times before declaring the generation terminal.
+const CONTENT_POLICY_RE = /content polic|may violate/i;
+const MAX_CP_RETRIES = 2;
+
+/**
+ * Generate one image via Kie.ai (createTask + poll until success).
+ *
+ * Retries on stochastic content-policy false positives up to MAX_CP_RETRIES
+ * times. All other failure modes (timeout, createTask error, malformed
+ * response) remain terminal on first occurrence.
+ *
+ * @param {Object} opts
+ * @param {string} opts.prompt        - The image prompt (under 10K chars)
+ * @param {string[]} opts.inputUrls   - Reference image URLs (logo + textbook page)
+ * @param {string} opts.language      - 'en' | 'ur' | 'sd' | 'pa' (drives routing)
+ * @param {string} opts.label         - Diagnostic label for logs
+ * @returns {Promise<{success: boolean, url?: string, generationMs?: number, error?: string, model?: string, resolution?: string, attempts?: number}>}
+ */
+async function generate({ prompt, inputUrls, language, label }) {
+  if (!KIE_API_KEY) {
+    return { success: false, error: 'KIE_API_KEY env var is missing' };
+  }
+  const tStart = Date.now();
+  let lastResult = null;
+  for (let attempt = 1; attempt <= MAX_CP_RETRIES + 1; attempt++) {
+    const attemptLabel = attempt === 1 ? label : `${label}#retry${attempt - 1}`;
+    lastResult = await _singleAttempt({ prompt, inputUrls, language, label: attemptLabel });
+    if (lastResult.success) {
+      return { ...lastResult, attempts: attempt };
+    }
+    // Only retry on content-policy false positives; all other errors terminal.
+    if (!CONTENT_POLICY_RE.test(lastResult.error || '')) {
+      return { ...lastResult, attempts: attempt };
+    }
+    if (attempt > MAX_CP_RETRIES) break;
+    const waitMs = 1000 * attempt; // 1s, 2s
+    logToFile('Kie.ai content-policy false positive — retrying', {
+      label, attempt, nextAttemptIn: waitMs, error: lastResult.error,
+    });
+    await new Promise((r) => setTimeout(r, waitMs));
+  }
+  // All retries exhausted; return the last failure with attempts count.
+  return {
+    ...lastResult,
+    attempts: MAX_CP_RETRIES + 1,
+    totalMs: Date.now() - tStart,
+  };
+}
+
+/**
+ * One createTask + poll cycle. Internal helper; callers should use generate()
+ * which wraps this in the content-policy retry loop.
+ */
+async function _singleAttempt({ prompt, inputUrls, language, label }) {
+  const backend = pickBackend(language);
+  const inputField = inputFieldFor(backend.model);
+
+  const payload = {
+    model: backend.model,
+    input: {
+      prompt,
+      [inputField]: inputUrls,
+      aspect_ratio: '3:4',
+      resolution: backend.resolution,
+    },
+  };
+  // gpt-image-2 doesn't accept output_format; nano-banana variants do.
+  if (!backend.model.startsWith('gpt-image-2')) {
+    payload.input.output_format = 'png';
+  }
+
+  const t0 = Date.now();
+  let create;
+  try {
+    create = await httpsRequest({
+      method: 'POST',
+      hostname: KIE_API_HOST,
+      path: '/api/v1/jobs/createTask',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${KIE_API_KEY}` },
+    }, payload);
+  } catch (e) {
+    logToFile('Kie.ai createTask threw', { label, error: e.message });
+    return { success: false, error: `createTask failed: ${e.message}` };
+  }
+
+  const taskId = create?.data?.taskId;
+  if (!taskId) {
+    logToFile('Kie.ai createTask returned no taskId', { label, response: JSON.stringify(create).slice(0, 300) });
+    return { success: false, error: `createTask failed: ${JSON.stringify(create).slice(0, 200)}` };
+  }
+  logToFile('Kie.ai task created', { label, taskId, model: backend.model, resolution: backend.resolution });
+
+  for (let i = 0; i < KIE_MAX_ATTEMPTS; i++) {
+    await new Promise((r) => setTimeout(r, KIE_POLL_INTERVAL));
+    let info;
+    try {
+      info = await httpsRequest({
+        method: 'GET',
+        hostname: KIE_API_HOST,
+        path: `/api/v1/jobs/recordInfo?taskId=${taskId}`,
+        headers: { Authorization: `Bearer ${KIE_API_KEY}` },
+      });
+    } catch (e) {
+      logToFile('Kie.ai poll threw, will retry next tick', { label, taskId, error: e.message });
+      continue;
+    }
+
+    const state = info?.data?.state;
+    if (state === 'success') {
+      const generationMs = Date.now() - t0;
+      let url;
+      try {
+        url = JSON.parse(info.data.resultJson).resultUrls[0];
+      } catch (_) {
+        return { success: false, error: 'Bad resultJson from Kie.ai' };
+      }
+      logToFile('Kie.ai task success', { label, taskId, generationMs });
+      return { success: true, url, generationMs, model: backend.model, resolution: backend.resolution };
+    }
+    if (state === 'fail') {
+      const failMsg = info?.data?.failMsg || 'unknown';
+      logToFile('Kie.ai task failed', { label, taskId, failMsg });
+      return { success: false, error: `kie.ai failed: ${failMsg}` };
+    }
+  }
+  return { success: false, error: `kie.ai timeout after ${KIE_MAX_ATTEMPTS} polls` };
+}
+
+module.exports = { generate, pickBackend, inputFieldFor };

--- a/bot/shared/services/pic-to-lp/kieai-handoff.service.js
+++ b/bot/shared/services/pic-to-lp/kieai-handoff.service.js
@@ -1,0 +1,125 @@
+/**
+ * Kie.ai Handoff Service
+ *
+ * The orchestrator: receives the Flow form submission, sends the upfront
+ * wait message in the teacher's language, enqueues an SQS job, returns
+ * immediately. The actual generation runs on a worker replica via
+ * workers/pic-lp-kieai.worker.js.
+ *
+ * Replaces the synchronous Gamma path (lp-handoff.service.js) when
+ * app_settings.pic_lp_backend_ab routes to 'kieai'.
+ */
+
+const SQSQueueService = require('../queue/sqs-queue.service');
+const WhatsAppService = require('../whatsapp.service');
+const PicLpSession = require('./pic-lp-session.service');
+const PicLpLatency = require('./pic-lp-latency.service');
+const PicLpWaitMessage = require('./pic-lp-wait-message.service');
+const supabase = require('../../config/supabase');
+const { logToFile } = require('../../utils/logger');
+const { logEvent } = require('../../utils/structured-logger');
+
+const SQS_JOB_TYPE = 'pic_lp_kieai_generation';
+
+/**
+ * Enqueue a pic-LP kieai generation job + send the upfront wait message.
+ * Returns immediately — does NOT wait for Kie.ai. The web replica is
+ * freed in ~100ms regardless of Kie.ai latency (4-7 min for Urdu).
+ *
+ * @param {Object} args
+ * @param {Object} args.session - pic_lp_sessions row
+ * @param {Object} args.formData - { grade, subject, topic, language }
+ * @param {string} args.from - Teacher's WhatsApp phone
+ */
+async function enqueueAndAck({ session, formData, from }) {
+  // Update session state to 'queued' (transitioning from awaiting_form_submit).
+  // Note: pic_lp_sessions.status CHECK includes 'generating' but not 'queued'.
+  // Reuse 'generating' as the state machine value — the worker updates to
+  // 'handed_off' on success / 'failed' on error.
+  await PicLpSession.updateStatus(session.id, 'generating', {
+    detected: { ...(session.detected || {}), ...formData },
+  });
+
+  // System messages (wait + feedback prompts) use the teacher's
+  // user.preferred_language, NOT the LP-content language from the form. These
+  // are different things: a teacher who prefers an English UI may still want an
+  // Urdu lesson plan.
+  let userPreferredLang = 'en';
+  try {
+    const { data: userRow } = await supabase
+      .from('users')
+      .select('preferred_language')
+      .eq('id', session.user_id)
+      .maybeSingle();
+    if (userRow?.preferred_language) userPreferredLang = userRow.preferred_language;
+  } catch (e) {
+    logToFile('Pic-LP: user lookup soft-failed (defaulting to en)', { sessionId: session.id, error: e.message });
+  }
+  // The wait-message TIMING depends on the BACKEND, and the backend is selected
+  // from the CONTENT language (formData.language → 1K vs 2K, see
+  // kieai-client.pickBackend). So we split: the message TEXT uses the system
+  // language (preferred_language), but the message TIMING uses the content
+  // language. Without this split, an English-locked teacher who generates a
+  // Sindhi LP sees "~90 seconds" in English when actual generation is ~4 min.
+  const systemLanguage = userPreferredLang;
+  const contentLanguage = formData?.language || userPreferredLang;
+  const sourceForStats = 'pic_to_lp_kieai';
+
+  let dbStats = null;
+  try {
+    dbStats = await PicLpLatency.getStats(sourceForStats);
+  } catch (e) {
+    // Soft-fail — fall through to fallback values from pickBackend()
+    logToFile('Pic-LP latency lookup soft-failed (using fallback)', {
+      error: e.message, sessionId: session.id,
+    });
+  }
+
+  const waitMessage = PicLpWaitMessage.buildWaitMessage({
+    systemLanguage,
+    contentLanguage,
+    dbStats,
+  });
+  await WhatsAppService.sendMessage(from, waitMessage);
+
+  // Enqueue the SQS job. Worker replica picks it up, runs Kie.ai, assembles
+  // the PDF, delivers it, INSERTs into lesson_plans, schedules feedback.
+  const payload = {
+    sessionId: session.id,
+    formData,
+    from,
+    enqueuedAt: Date.now(),
+  };
+
+  try {
+    await SQSQueueService.queueCoachingJob(session.id, SQS_JOB_TYPE, payload);
+  } catch (e) {
+    // SQS enqueue failure is rare but recoverable — surface to teacher,
+    // mark session failed so the stale-session worker doesn't loop on it.
+    logToFile('Pic-LP SQS enqueue failed', {
+      error: e.message, sessionId: session.id,
+    });
+    await PicLpSession.updateStatus(session.id, 'failed', {
+      last_error: `SQS enqueue: ${e.message}`,
+    });
+    const lang = contentLanguage;
+    const isUrdu = lang === 'ur' || lang === 'sd' || lang === 'pa';
+    await WhatsAppService.sendMessage(from, isUrdu
+      ? '⚠️ معذرت، لیسن پلان بنانے میں مسئلہ آیا۔ براہ کرم دوبارہ کوشش کریں۔'
+      : '⚠️ Sorry, I had trouble queueing your lesson plan. Please try again.');
+    logEvent('pic_lp.enqueue_failed', {
+      sessionId: session.id, from, error: e.message,
+    });
+    return { success: false, error: e.message };
+  }
+
+  logEvent('pic_lp.enqueued_for_kieai', {
+    sessionId: session.id, from,
+    grade: formData.grade, subject: formData.subject, language: formData.language,
+    topic: formData.topic,
+  });
+
+  return { success: true, queued: true };
+}
+
+module.exports = { enqueueAndAck, SQS_JOB_TYPE };

--- a/bot/shared/services/pic-to-lp/kieai-prompt-builder.service.js
+++ b/bot/shared/services/pic-to-lp/kieai-prompt-builder.service.js
@@ -1,0 +1,520 @@
+/**
+ * Kie.ai Prompt Builder
+ *
+ * Pure functions: build the page-1 + page-2 v7-grade lesson-plan prompts
+ * from the form data the teacher submitted via PIC_LP_FLOW.
+ *
+ * V7-pattern principles encoded here:
+ *   - Style preamble: 8-line block with palette, fonts, paper format,
+ *     reference-image roles. NO dimension annotations in prose (they bleed
+ *     into rendered text). Hardcore Nastaliq rule for non-English LPs.
+ *   - Reference images at the top: IMAGE 1 = white smile logo (native
+ *     render in header), IMAGE 2 = teacher's textbook page (visual style anchor).
+ *   - Big Idea callout on page 1 — concept distinction + common misconception
+ *     + 1-sentence demo move. The pedagogical heart.
+ *   - Hook with verbatim character speech bubbles.
+ *   - I-Do / We-Do / You-Do gradual release per structured pedagogy.
+ *   - Board work with FULL answer keys (never "leave blank for students").
+ *   - Exit ticket MCQ with correct answer green-highlighted.
+ *   - Coaching corner with a lesson-specific reflection (and an optional
+ *     WhatsApp contact line when a coaching number is configured).
+ *   - Title Case for English headings (avoids a GPT-Image-2 glitch where
+ *     all-caps headings render garbled).
+ *   - Per-card REPEAT of the Nastaliq rule for non-English (defends against
+ *     Naskh/Devanagari fallback).
+ *
+ * The PROMPT BODY for non-English is itself written in Nastaliq Urdu —
+ * English-prose-with-Urdu-phrases lets the model default Urdu to Naskh.
+ */
+
+const SUBJECT_COLOR = {
+  'Math':                      '#059669', // green
+  'Maths':                     '#059669',
+  'English':                   '#7c3aed', // purple
+  'Urdu':                      '#7c3aed',
+  'Sindhi':                    '#7c3aed',
+  'Science':                   '#dc2626', // red
+  'Social Studies':            '#ea580c', // orange
+  'Islamiat':                  '#0891b2', // teal
+  'General Knowledge':         '#0891b2',
+  'Mathematics':               '#059669', // green — math family
+  'Kiswahili':                 '#b91c1c', // red-700
+  'Civics & Moral Education':  '#d97706', // amber-600
+  'Religious Education':       '#7c3aed', // purple
+  'Vocational Skills':         '#0e7490', // cyan-700
+  'Languages':                 '#7c3aed', // purple — language family
+  'Other':                     '#059669', // fallback green
+};
+
+function colorFor(subject) {
+  return SUBJECT_COLOR[subject] || '#059669';
+}
+
+function isLatinScript(language) {
+  // 'sw' (Kiswahili) uses Latin script too — treat as English-like for layout
+  // purposes. Arabic ('ar') is RTL like Urdu but uses NASKH natively (not
+  // Nastaliq), so it gets its own branch below.
+  return language === 'en' || language === 'sw';
+}
+
+function isArabicScript(language) {
+  return language === 'ar';
+}
+
+// Explicit content-language instruction for every NON-URDU language that uses
+// the structural-English body template (sw/ar/sd/pa). Without this, the model
+// defaults to writing English content (matching the structural labels) inside
+// the language's font — e.g. English text in Naskh Sindhi glyphs. Urdu is the
+// ONLY language that gets its own hardcoded body template.
+function contentLanguageInstruction(language) {
+  switch (language) {
+    case 'sw':
+      // Render EVERYTHING in Kiswahili, including the structural section
+      // labels/headings — not just the body. The label translations are
+      // already substituted into the template via structuralLabelsFor('sw');
+      // this directive reinforces it for the model.
+      return 'CONTENT LANGUAGE: EVERYTHING on this page — all teacher-facing content (warm-up body, hook speech bubbles, Big Idea paragraphs, board work, exit ticket question + answers, coaching corner) AND every structural section label/heading (e.g. Lengo la Leo, Wazo Kuu, Maandalizi, Mwalimu Anafanya, Tunafanya Pamoja, Wewe Fanya, Kona ya Kocha) — MUST be written in NATURAL Kiswahili. The ONLY non-Kiswahili text allowed is Hindu-Arabic numerals (0-9) for math and the brand name "Rumi". Do NOT render any English headings or labels. The teacher reading this is in East Africa (Kenya / Tanzania / Uganda) and expects native Kiswahili educational vocabulary.';
+    case 'ar':
+      // Render EVERYTHING in MSA Arabic, including the structural section
+      // labels/headings (RTL Naskh) — not just the body.
+      return 'CONTENT LANGUAGE: EVERYTHING on this page — all teacher-facing content (warm-up body, hook speech bubbles, Big Idea paragraphs, board work, exit ticket question + answers, coaching corner) AND every structural section label/heading (e.g. هدف اليوم, الفكرة الكبرى, التهيئة, المعلّم يؤدّي, نعمل معًا, دورك أنت, ركن التدريب) — MUST be written in NATURAL Modern Standard Arabic (MSA / فصحى), right-to-left. The ONLY non-Arabic text allowed is Hindu-Arabic numerals (0-9) for math and the brand name "Rumi". Do NOT render any English headings or labels. The teacher reading this is in the MENA region and expects native Arabic educational vocabulary.';
+    case 'sd':
+      return 'CONTENT LANGUAGE: All teacher-facing content (warm-up body, hook speech bubbles, Big Idea paragraphs, board work, exit ticket question + answers, coaching corner) MUST be written in NATURAL Pakistani Sindhi using the Perso-Arabic Sindhi script (Naskh Sindhi / Lateef tradition, with Sindhi-specific letters ڄ ڃ ڳ ڱ ڙ ڪ). Use English ONLY for structural section labels (Today\'s Goal, Big Idea, I Do, We Do, You Do, etc.) and Hindu-Arabic numerals for math. The teacher is in Sindh (Pakistan) and expects native Sindhi educational vocabulary, NOT translated Urdu and NOT Urdu Nastaliq style.';
+    case 'pa':
+      return 'CONTENT LANGUAGE: All teacher-facing content (warm-up body, hook speech bubbles, Big Idea paragraphs, board work, exit ticket question + answers, coaching corner) MUST be written in NATURAL Pakistani Punjabi using Shahmukhi script (Perso-Arabic, same letters as Urdu Nastaliq). Use English ONLY for structural section labels and Hindu-Arabic numerals for math. The teacher is in Pakistani Punjab and expects native Punjabi educational vocabulary, NOT translated Urdu.';
+    default:
+      return null; // en handled by structural template alone; ur has its own dedicated body
+  }
+}
+
+// characterCastFor + classroomContextFor are sourced from the shared
+// lp-localization service so the pic-LP path and the Gamma text-LP path read
+// ONE cultural-context table and can never drift.
+const { characterCastFor, classroomContextFor } = require('../pedagogy/lp-localization.service');
+
+// Educational-context preamble. Signals to GPT-Image-2's output moderator that
+// this is a sanctioned K-12 classroom resource, not edgy content. Reduces (does
+// not eliminate) stochastic content-policy false positives on benign
+// educational topics. The retry loop in kieai-client.service.js is the actual
+// mitigation; this preamble is risk reduction.
+function educationalContextPreamble({ subject, grade }) {
+  return [
+    'EDUCATIONAL CONTEXT (for content moderation): This is a printable K-12 school',
+    `lesson-plan handout for a teacher of Grade ${grade} ${subject}, intended to be`,
+    'used as a classroom resource. The illustration is a clean instructional diagram',
+    'in the style of a school textbook. All depicted humans are fully clothed children',
+    'or teachers shown waist-up or in school-uniform full-body, in a learning context.',
+    'There is no graphic medical, anatomical, violent, or otherwise sensitive content;',
+    'biological topics (e.g. cells, plants, body systems) are rendered at age-appropriate',
+    'textbook level — labeled diagrams, not anatomical detail.',
+    '',
+  ].join('\n');
+}
+
+// Structural section labels per language. en/sd/pa/ur return the English label
+// set (those template branches must not change). sw → Kiswahili, ar → MSA
+// Arabic. The template substitutes these values for the previously-hardcoded
+// English strings. Hindu-Arabic numerals + "Rumi" stay non-target text everywhere.
+function structuralLabelsFor(language) {
+  // English label set. en/sd/pa/ur use this unchanged. (The Urdu body template
+  // embeds these English labels inline by design — see buildPage1Prompt — so it
+  // also reads from the English set.)
+  const EN = {
+    todaysGoal: "Today's Goal",
+    bigIdea: 'The Big Idea',
+    warmUp: 'WARM-UP',
+    hook: 'HOOK',
+    keyWords: 'Key Words',
+    iDo: 'I Do',
+    weDo: 'We Do',
+    youDo: 'You Do',
+    writeOnBoard: 'Write on the Board',
+    exitTicket: 'Exit Ticket',
+    coachingCorner: 'Coaching Corner',
+    cfu: 'CFU',
+    howItWorks: 'How It Works',
+    minutes: 'min',
+    basic: 'Basic',
+    guided: 'Guided',
+    challenge: 'Challenge',
+    // Page-2 phrase headings (kept as full phrases to preserve byte-identical
+    // English; sw/ar override with the in-language equivalent).
+    practiceTogether: 'Practice Together',
+    yourTurn: 'Your Turn',
+    beforeYouGo: 'Before You Go',
+    needHelp: 'Need Help?',
+    challengeBang: 'Challenge!',
+  };
+
+  switch (language) {
+    case 'sw':
+      return {
+        todaysGoal: 'Lengo la Leo',
+        bigIdea: 'Wazo Kuu',
+        warmUp: 'Maandalizi',
+        hook: 'Kichocheo',
+        keyWords: 'Maneno Muhimu',
+        iDo: 'Mwalimu Anafanya',
+        weDo: 'Tunafanya Pamoja',
+        youDo: 'Wewe Fanya',
+        writeOnBoard: 'Andika Ubaoni',
+        exitTicket: 'Tiketi ya Kutoka',
+        coachingCorner: 'Kona ya Kocha',
+        cfu: 'Kupima Uelewa',
+        howItWorks: 'Jinsi Inavyofanya Kazi',
+        minutes: 'Dakika',
+        basic: 'Msingi',
+        guided: 'Kwa Mwongozo',
+        challenge: 'Changamoto',
+        practiceTogether: 'Tufanye Mazoezi Pamoja',
+        yourTurn: 'Zamu Yako',
+        beforeYouGo: 'Kabla ya Kuondoka',
+        needHelp: 'Unahitaji Msaada?',
+        challengeBang: 'Changamoto!',
+      };
+    case 'ar':
+      return {
+        todaysGoal: 'هدف اليوم',
+        bigIdea: 'الفكرة الكبرى',
+        warmUp: 'التهيئة',
+        hook: 'التشويق',
+        keyWords: 'الكلمات المفتاحية',
+        iDo: 'المعلّم يؤدّي',
+        weDo: 'نعمل معًا',
+        youDo: 'دورك أنت',
+        writeOnBoard: 'اكتب على السبورة',
+        exitTicket: 'تذكرة الخروج',
+        coachingCorner: 'ركن التدريب',
+        cfu: 'التحقق من الفهم',
+        howItWorks: 'كيف يعمل',
+        minutes: 'دقيقة',
+        basic: 'أساسي',
+        guided: 'موجَّه',
+        challenge: 'تحدٍّ',
+        practiceTogether: 'نتدرّب معًا',
+        yourTurn: 'دورك',
+        beforeYouGo: 'قبل أن تغادر',
+        needHelp: 'تحتاج مساعدة؟',
+        challengeBang: 'تحدٍّ!',
+      };
+    default:
+      // en, sd, pa, ur — unchanged English labels.
+      return EN;
+  }
+}
+
+// Coaching Corner WhatsApp contact number. Open-source deployments configure a
+// single teacher-facing number via the COACHING_WHATSAPP_NUMBER env var; when
+// it is unset the Coaching Corner simply omits the contact line. The `region`
+// parameter is ignored (kept for caller compatibility).
+function coachingNumberFor(region) {
+  return process.env.COACHING_WHATSAPP_NUMBER || '';
+}
+
+function styleBlock({ subject, language, grade }) {
+  const color = colorFor(subject);
+  const isLatin = isLatinScript(language);
+  const region = classroomContextFor(language);
+
+  const baseLines = [
+    'Clean flat vector illustration, educational infographic style.',
+    `${region} Grade ${grade} classroom. White background. Minimal clutter.`,
+    'Bold simple shapes. High contrast colors.',
+    'Dark navy #1e293b header bar. Amber #fbbf24 highlights.',
+    `Subject color: ${color}.`,
+  ];
+
+  if (isLatin) {
+    baseLines.push('Clean sans-serif font (Nunito or Inter). LTR layout.');
+  } else if (isArabicScript(language)) {
+    // Arabic uses Naskh natively — that's the right script. NO "NOT Devanagari
+    // NOT Hindi" rule (those anti-rules are Urdu-specific). Font: Noto Naskh Arabic.
+    baseLines.push(
+      'Noto Naskh Arabic font for ALL Arabic text, right-to-left. Clean sans-serif (Nunito/Inter) for English labels. RTL layout for Arabic sections.'
+    );
+  } else if (language === 'sd') {
+    // Sindhi (Pakistan) uses Perso-Arabic / Naskh Sindhi script, NOT Urdu
+    // Nastaliq. Lateef + Noto Naskh Sindhi are the standard fonts in Pakistani
+    // Sindhi school textbooks. The "NOT Devanagari" rule still applies (Sindhi
+    // has Indian-Devanagari variants we want to exclude).
+    baseLines.push(
+      'Noto Naskh Sindhi or Lateef font for ALL Sindhi text, right-to-left. Sindhi-specific letters (ڄ ڃ ڳ ڱ ڙ ڪ) must render correctly. No diacritics. NOT Devanagari, NOT Hindi, NOT Urdu Nastaliq style. Clean sans-serif (Nunito/Inter) for English labels. RTL layout for Sindhi sections.'
+    );
+  } else {
+    // Urdu / Punjabi (Shahmukhi) — hardcore Nastaliq rule. Punjabi-Shahmukhi
+    // shares Urdu's Nastaliq tradition.
+    baseLines.push(
+      'Noto Nastaliq Urdu font for ALL Urdu text, right-to-left. No diacritics (no zer, zabar, pesh). Clean sans-serif (Nunito/Inter) for English labels. RTL layout for Urdu sections.'
+    );
+  }
+
+  baseLines.push('No photography. Crisp digital illustration. Print-ready A4 portrait 3:4 format.');
+  baseLines.push('');
+  baseLines.push('REFERENCE IMAGES (in order):');
+  baseLines.push('  IMAGE 1 = the EXACT Rumi brand mark — a clean white smile-only mark (curved line + two small cheek dots). Render this image pixel-for-pixel at small size (about 8% of page width, vertically centered in the dark-navy header bar, anchored 3% from the left edge). DO NOT redesign. DO NOT add a circle around it. DO NOT change its color.');
+  baseLines.push("  IMAGE 2 = the teacher's textbook page — for visual style reference only. Do NOT copy any text from this image. Use only for visual style cues.");
+
+  return baseLines.join('\n');
+}
+
+function nastaliqPerCardLine() {
+  // Repeated per card for non-English LPs. Anchors the model so it doesn't
+  // drift to Naskh on individual sections. NEVER add "NOT Naskh" — only
+  // "NOT Devanagari, NOT Hindi".
+  return 'All Urdu text in this card must use Noto Nastaliq Urdu font, right-to-left. No diacritics. NOT Devanagari, NOT Hindi.';
+}
+
+// Build the Coaching Corner contact suffix. When a coaching number is
+// configured we append the "WhatsApp Rumi · <number>" line; otherwise we omit
+// the contact line entirely (keeping the rest of the coaching corner).
+function coachingContactSuffixEn(coachingNumber) {
+  return coachingNumber ? ` WhatsApp Rumi · ${coachingNumber}` : '';
+}
+function coachingContactSuffixUr(coachingNumber) {
+  return coachingNumber ? ` WhatsApp Rumi · ${coachingNumber}` : '';
+}
+
+/**
+ * Build page 1 prompt (Hook, Today's Goal, Big Idea, I-Do, Board Work).
+ *
+ * @param {Object} args
+ * @param {number|string} args.grade
+ * @param {string} args.subject
+ * @param {string} args.topic
+ * @param {string} args.language - 'en' | 'ur' | 'sd' | 'pa'
+ * @param {string} [args.ocrText] - Optional OCR text from the textbook page (for content grounding)
+ * @returns {string}
+ */
+function buildPage1Prompt({ grade, subject, topic, language, ocrText, region, coachingNumber }) {
+  // Only Urdu (ur) uses the Urdu-hardcoded body template. Every other language
+  // uses the structural-English body (English labels) + contentLanguageInstruction
+  // telling the model what language to write CONTENT in.
+  const useUrduBodyTemplate = (language === 'ur');
+  const color = colorFor(subject);
+  const eduPreamble = educationalContextPreamble({ subject, grade });
+  const style = `${eduPreamble}${styleBlock({ subject, language, grade })}`;
+  const nastaliqLine = useUrduBodyTemplate ? `\n${nastaliqPerCardLine()}\n` : '';
+  // Explicit content-language instruction for every non-Urdu RTL/non-Latin
+  // language (sw/ar/sd/pa) — anchors content language before any English
+  // structural labels are read.
+  const contentLangLine = contentLanguageInstruction(language);
+  const contentLangBlock = contentLangLine ? `\n${contentLangLine}\n` : '';
+  const cast = characterCastFor(language);
+  // Structural labels per language. en/sd/pa/ur → English (unchanged). sw →
+  // Kiswahili, ar → MSA Arabic. Substituted into the template below in place of
+  // the previously-hardcoded English strings.
+  const L = structuralLabelsFor(language);
+
+  const titleEn = `Grade ${grade} ${subject} — ${topic}`;
+  const ocrSnippet = (ocrText || '').slice(0, 1500); // cap for prompt budget
+
+  // Universal grade calibration block — drives age-appropriate vocab, sentence
+  // length, worked-example count, CFU cadence, differentiation, etc. The LP's
+  // VISUAL sections never change; only the content density inside them adapts.
+  const { renderCalibrationBlock } = require('../pedagogy/grade-calibration.service');
+  const calibrationBlock = renderCalibrationBlock(grade);
+
+  // Structural-English LP body (en + sw + ar + sd + pa) — Title Case headings,
+  // Big Idea callout, full answer keys. Cast/region parameterized per language.
+  if (!useUrduBodyTemplate) {
+    return `${style}${contentLangBlock}
+${calibrationBlock}
+
+Hook, Today's Goal, Big Idea, I-Do (How It Works), and Board Work card. Portrait 3:4.
+
+HEADER BAR (dark navy #1e293b, full width):
+  Left edge: render IMAGE 1 (the white smile brand mark) small, vertically centered, 3% from left.
+  Center: "${titleEn}" in white bold.
+  Right: small ${color} pill containing "Grade ${grade} · 35 min" in white.
+
+WARM-UP REVIEW (light gray #f3f4f6 background, full width strip):
+  Label "${L.warmUp} · 4 min" in dark navy bold.
+  Body: a 1-2 sentence quick recall connecting yesterday's lesson to today's. Reference the textbook page where appropriate.
+  Small ${L.cfu} pill on right (teal #059669): "${L.cfu} · Thumbs up if you remember!"
+
+HOOK (white background, with bordered amber #fbbf24 frame):
+  Heading "${L.hook} · 4 min" in amber bold.
+  Two ${cast.region} Grade ${grade} students illustrated facing each other.
+  Character "${cast.boy}" (boy, left, school uniform): speech bubble with a verbatim curiosity question about ${topic}.
+  Character "${cast.girl}" (girl, right, ${cast.girlDress}): speech bubble with the verbatim correct insight.
+  Each character has a distinct speech bubble with their own text clearly visible.
+
+BIG IDEA (prominent white card with thick ${color} border, lightbulb icon, ~22% page height):
+  Heading "${L.bigIdea}" in ${color} bold.
+  Three short paragraphs in dark navy:
+    1. The concept distinction the textbook doesn't make explicit (what students often confuse).
+    2. The common student misconception (what kids will get wrong, and why).
+    3. A 1-sentence demo move (how to teach the distinction in class).
+
+TODAY'S GOAL + KEY WORDS (two boxes side by side, full width):
+  Left box (${color} background, white text): heading "${L.todaysGoal}", body: a single learning objective sentence about ${topic}.
+  Right box (amber #fbbf24, navy text): heading "${L.keyWords}", body: 4 vertical key words from ${topic}.
+
+I DO · HOW IT WORKS (white background, blue #2563eb section header):
+  Heading "${L.iDo} · ${L.howItWorks} · 6 min" in blue bold.
+  Generate EXACTLY 3 numbered step panels stacked vertically. Do not add additional panels.
+    Step 1, Step 2, Step 3 — each with verbatim teacher script (what the teacher SAYS or WRITES on the board) about ${topic}, drawing from the textbook page content.
+  Small downward arrows between panels.
+
+BOARD WORK (dark navy #1e293b chalkboard-style box at bottom, full width, white chalk-style text):
+  Header in amber: "${L.writeOnBoard}"
+  3 worked examples with FULL answer keys visible (never "leave blank for students").
+  Below the table: a 1-line note connecting the board work back to the Big Idea.
+
+CRITICAL: This page MUST be about ${topic} (Class ${grade} ${subject}). Do not render content about any other topic.
+
+IMPORTANT: Render IMAGE 1 pixel-for-pixel as the brand mark in top-left header. Bottom 4% of page must be empty (footer overlaid). Use Title Case for headings.${ocrSnippet ? `\n\nTextbook page content (for grounding, do NOT copy verbatim):\n${ocrSnippet}` : ''}`;
+  }
+
+  // Urdu / Sindhi / Punjabi LP body — written IN Nastaliq throughout, with
+  // English structural labels in Title Case. The model renders Nastaliq when it
+  // SEES Nastaliq in the prompt. The calibration block applies to the Urdu path
+  // too — grade-appropriate vocab/pacing/differentiation are universal.
+  return `${style}${contentLangBlock}
+${calibrationBlock}
+${nastaliqLine}
+HEADER BAR (dark navy #1e293b, full width):
+  Left edge: render IMAGE 1 (the white smile brand mark) small, vertically centered, 3% from left.
+  Center: title in white bold — "Grade ${grade} ${subject} — ${topic}" (English label first, dot separator, then Urdu Nastaliq content).
+  Right: small ${color} pill containing "Grade ${grade} · 35 min" in white.
+
+WARM-UP REVIEW (light gray #f3f4f6 background, full width strip):
+  Label "WARM-UP · 4 min" in dark navy bold.
+  Body in Nastaliq: "استاد بورڈ پر لکھیں — کل کے سبق کا ایک مختصر دہراؤ۔ پھر آج کا موضوع متعارف کرائیں — ${topic}۔"
+  CFU pill on right (teal #059669): "CFU · Thumbs up if you remember!"
+
+HOOK (white background, with bordered amber #fbbf24 frame):
+  Heading "HOOK · 4 min" in amber bold.
+  Two Pakistani Grade ${grade} students illustrated facing each other.
+  Character "احمد" (طالب علم، لڑکا) positioned بائیں: speech bubble in Nastaliq — ایک تجسس بھرا سوال ${topic} کے بارے میں۔
+  Character "زینب" (طالبہ، لڑکی) positioned دائیں: speech bubble in Nastaliq — صحیح جواب جو ${topic} کا بنیادی تصور بیان کرے۔
+  Each character has a distinct speech bubble in clean Nastaliq.
+
+BIG IDEA (prominent white card with thick ${color} border, lightbulb icon, ~22% page height):
+  Heading "The Big Idea · بنیادی تصور" in ${color} bold.
+  Three short Nastaliq paragraphs:
+    ۱۔ ${topic} کا بنیادی تصور — وہ فرق جو کتاب میں واضح نہیں ہے۔
+    ۲۔ بچوں کی عام غلطی — وہ کیا غلط سمجھتے ہیں اور کیوں۔
+    ۳۔ Quick demo: ایک فوری board move جو استاد آج کلاس میں استعمال کر سکتی ہے۔
+
+TODAY'S GOAL + KEY WORDS (two boxes side by side):
+  Left box (${color} background, white text): heading "Today's Goal", body in Nastaliq: ${topic} کا ایک واضح learning objective۔
+  Right box (amber #fbbf24, navy text): heading "Key Words", body: 4 vertical key terms from ${topic} (Nastaliq with English in brackets where useful).
+
+I DO · HOW IT WORKS (white background, blue #2563eb section header):
+  Heading "I Do · How It Works · 6 min" in blue bold.
+  Generate EXACTLY 3 numbered step panels stacked vertically. Do not add additional panels.
+  Each step in Nastaliq with embedded English content words (numbers, formulas, English vocabulary).
+
+BOARD WORK (dark navy #1e293b chalkboard-style box at bottom, full width, white chalk-style text):
+  Header in amber: "Write on the Board"
+  3 examples in Nastaliq with FULL answer keys (never "leave blank for students"). Use Hindu-Arabic numerals (0-9) for math.
+
+CRITICAL: This page MUST be about ${topic} (Class ${grade} ${subject}). Do not render content about any other topic.
+
+IMPORTANT: Render IMAGE 1 pixel-for-pixel as the brand mark in top-left header. Bottom 4% of page must be empty (footer overlaid). Use Hindu-Arabic numerals (0-9) for math equations. Use Title Case for English headings.${ocrSnippet ? `\n\nTextbook page content (for grounding, do NOT copy verbatim):\n${ocrSnippet}` : ''}`;
+}
+
+/**
+ * Build page 2 prompt (We-Do, You-Do, Differentiation, Exit Ticket, Coaching).
+ *
+ * Same args as buildPage1Prompt.
+ */
+function buildPage2Prompt({ grade, subject, topic, language, ocrText, region, coachingNumber }) {
+  // See buildPage1Prompt for the dispatch rationale. Only ur uses the
+  // Urdu-hardcoded template; everything else uses structural-English.
+  const useUrduBodyTemplate = (language === 'ur');
+  const color = colorFor(subject);
+  const eduPreamble = educationalContextPreamble({ subject, grade });
+  const style = `${eduPreamble}${styleBlock({ subject, language, grade })}`;
+  const nastaliqLine = useUrduBodyTemplate ? `\n${nastaliqPerCardLine()}\n` : '';
+  const contentLangLine = contentLanguageInstruction(language);
+  const contentLangBlock = contentLangLine ? `\n${contentLangLine}\n` : '';
+  // In-language structural labels (en/sd/pa/ur unchanged).
+  const L = structuralLabelsFor(language);
+  // Coaching Corner contact number. Explicit coachingNumber wins; else the
+  // env-driven value; else empty (which omits the contact line).
+  const resolvedCoachingNumber = coachingNumber || coachingNumberFor(region);
+
+  // Same calibration block as Page 1 — the model needs the grade-appropriate
+  // guidance on We-Do/You-Do/Exit-Ticket complexity too.
+  const { renderCalibrationBlock } = require('../pedagogy/grade-calibration.service');
+  const calibrationBlock = renderCalibrationBlock(grade);
+
+  if (!useUrduBodyTemplate) {
+    return `${style}${contentLangBlock}
+${calibrationBlock}
+
+We-Do, You-Do, Differentiation, Exit Ticket, Coaching Corner card. Portrait 3:4.
+
+HEADER BAR (dark navy #1e293b, full width):
+  Left edge: render IMAGE 1 (the white smile brand mark) small, vertically centered, 3% from left.
+  Center: "Grade ${grade} ${subject} — ${topic} · Page 2" in white bold.
+  Right: small amber pill containing "Grade ${grade} · 35 min".
+
+WE DO · GUIDED PRACTICE (top section, light tinted ${color} card with ${color} header bar):
+  Heading "${L.weDo} · ${L.practiceTogether} · 10 min" in white on ${color}.
+  A worked example with full step-by-step solution shown (so the teacher has the answer key on hand).
+  Below the example, a partner-activity instruction strip with verbatim student dialogue lines.
+
+YOU DO · YOUR TURN (middle section, white background, amber #fbbf24 header bar):
+  Heading "${L.youDo} · ${L.yourTurn} · 12 min" in dark navy bold.
+  Instruction in plain English: pick the activity that matches ${topic}.
+  Three problems numbered 1-3, with model answers in light gray italic next to each (so the teacher has the key).
+
+DIFFERENTIATION (two boxes side by side):
+  LEFT (amber #fef3c7 fill, "${L.needHelp}" label in amber bold): 1-sentence scaffolding move for struggling students.
+  RIGHT (purple #7c3aed fill, "${L.challengeBang}" label in white bold): 1-sentence stretch task for advanced students.
+
+EXIT TICKET (light blue #dbeafe card, full width):
+  Heading "${L.beforeYouGo} · ${L.exitTicket} · 4 min" in dark navy bold.
+  A single MCQ question about ${topic} with 4 answer chips (A, B, C, D). The correct chip highlighted in green #059669 with a white check mark.
+
+COACHING CORNER (light amber #fef3c7 strip at bottom, full width):
+  Heading "${L.coachingCorner}" in dark navy bold.
+  Body: a lesson-specific reflection — what to watch for, the most likely student mistake, and a 2-minute reteach move. Tied to ${topic} specifically.
+  Right side: small green WhatsApp icon next to text "Send me a recording of today's lesson — I'll give you personalised feedback.${coachingContactSuffixEn(resolvedCoachingNumber)}"
+
+CRITICAL: This page MUST be about ${topic}. Do not render content about any other topic.
+
+IMPORTANT: Render IMAGE 1 pixel-for-pixel as the brand mark in top-left header. Bottom 4% must be empty. Use Title Case for English headings.${ocrText ? `\n\nTextbook page content (for grounding):\n${ocrText.slice(0, 1500)}` : ''}`;
+  }
+
+  // Urdu/Sindhi/Punjabi page 2 (the calibration block applies here too)
+  return `${style}${contentLangBlock}
+${calibrationBlock}
+${nastaliqLine}
+HEADER BAR (dark navy #1e293b, full width):
+  Left edge: render IMAGE 1 (the white smile brand mark) small, vertically centered, 3% from left.
+  Center: "Grade ${grade} ${subject} — ${topic} · Page 2" in white bold.
+  Right: small amber pill containing "Grade ${grade} · 35 min".
+
+WE DO · GUIDED PRACTICE (top section, light tinted ${color} card with ${color} header bar):
+  Heading "We Do · Practice Together · 10 min" in white on ${color}.
+  A worked example in Nastaliq with full step-by-step solution. The teacher gets the answer key on hand.
+  Below the example, instruction strip in dark navy Nastaliq about how to call a student to the board.
+
+YOU DO · YOUR TURN (middle section, white background, amber #fbbf24 header bar):
+  Heading "You Do · Your Turn · 12 min" in dark navy bold.
+  Instruction in Nastaliq: "اپنی copy میں ${topic} کے بارے میں ۳ مشقیں حل کریں۔"
+  Three problems numbered ۱، ۲، ۳ in Nastaliq, with model answers in light gray italic.
+
+DIFFERENTIATION (two boxes side by side):
+  LEFT (amber #fef3c7 fill, "Need Help?" label in amber bold, body in Nastaliq): scaffolding move for struggling students.
+  RIGHT (purple #7c3aed fill, "Challenge!" label in white bold, body in Nastaliq): stretch task for advanced students.
+
+EXIT TICKET (light blue #dbeafe card, full width):
+  Heading "Before You Go · Exit Ticket · 4 min" in dark navy bold.
+  Single MCQ in Nastaliq about ${topic} with 4 answer chips. Correct chip highlighted green #059669 with white check.
+
+COACHING CORNER (light amber #fef3c7 strip at bottom, full width):
+  Heading "Coaching Corner" in dark navy bold.
+  Body in Nastaliq: lesson-specific reflection tied to ${topic} — what to watch for, common mistake, 2-min reteach move.
+  Right side: small green WhatsApp icon next to text in Nastaliq: "آج کا lesson record کر کے Rumi کو بھیجیں — personalised feedback ملے گا۔${coachingContactSuffixUr(resolvedCoachingNumber)}"
+
+CRITICAL: This page MUST be about ${topic}. Do not render content about any other topic.
+
+IMPORTANT: Render IMAGE 1 pixel-for-pixel as brand mark in top-left header. Bottom 4% must be empty. Hindu-Arabic numerals (0-9) for math. Title Case for English headings.${ocrText ? `\n\nTextbook page content (for grounding):\n${ocrText.slice(0, 1500)}` : ''}`;
+}
+
+module.exports = { buildPage1Prompt, buildPage2Prompt, colorFor, structuralLabelsFor, coachingNumberFor };

--- a/bot/shared/services/pic-to-lp/lp-handoff.service.js
+++ b/bot/shared/services/pic-to-lp/lp-handoff.service.js
@@ -1,0 +1,285 @@
+/**
+ * LP Handoff
+ *
+ * After the teacher submits the WhatsApp Flow form, this service:
+ *   1. Builds the LP prompt via LessonPlanPromptsService.buildChapterPrompt,
+ *      passing the full vision-extracted ocr_text as the textbook `content`.
+ *   2. Calls Gamma directly via gamma-client.service (NOT through the
+ *      pre-gen lesson-plan handler, which would ignore the teacher's photo and
+ *      serve a stock PDF).
+ *   3. Sends the resulting PDF to the teacher.
+ *
+ * NOTE (open-source port): the Gamma "Detailed" path depends on the bot's
+ * lesson-plan-prompts service, which is not part of this OSS bundle. That
+ * dependency is required lazily inside generateAndDeliver(), so pickBackend()
+ * and module load work without it; the Kie.ai "Concise" path (the production
+ * default) has no such dependency.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const WhatsAppService = require('../whatsapp.service');
+const PicLpSession = require('./pic-lp-session.service');
+const GammaClient = require('./gamma-client.service');
+const { logToFile } = require('../../utils/logger');
+const { logEvent } = require('../../utils/structured-logger');
+const { TEMP_DIR } = require('../../utils/constants');
+const supabase = require('../../config/supabase');
+const crypto = require('crypto');
+
+const PIC_LP_DEFAULT_DAYS = 1; // single-page → single-lesson plan by default
+
+/**
+ * Decide which backend processes this user's pic-LP request.
+ *
+ * Resolution order (first hit wins):
+ *   1. PIC_LP_FORCE_GAMMA env var (debug override) → gamma
+ *   2. Teacher-picked formData.lesson_plan_format === 'detailed' → gamma
+ *      (teacher choice wins over BOTH the staging force-kieai flag and the DB toggle —
+ *       if she explicitly asked for the rich format, she gets the rich format)
+ *   3. PIC_LP_FORCE_KIEAI env var (debug override) → kieai
+ *   4. DB toggle app_settings.pic_lp_backend_ab → kieai or gamma
+ *
+ * The DB toggle (step 4) reads a JSONB column shaped { "kieai": <0..1>, "gamma": <0..1> }.
+ * Deterministic per-user hash into [0,1); route to 'kieai' if hash < kieai_share, else 'gamma'.
+ * Same teacher always sees the same backend within a toggle setting. Used as the
+ * Concise-route arbiter AND as a global kill-switch (kieai=0 disables Kie.ai for everyone).
+ *
+ * Safe default (presence-based) when the DB row is missing / malformed / userId
+ * is null: prefer whichever backend the deployment actually has keys for.
+ * If a Kie.ai key is present → 'kieai'; else if a Gamma key is present →
+ * 'gamma'; else 'gamma'. This way an OSS deployment that configured only one
+ * image backend gets routed to the one it can actually run.
+ *
+ * @param {string|null} userId - Teacher UUID
+ * @param {object} [formData] - Flow form data; .lesson_plan_format may be 'concise' | 'detailed'
+ * @returns {Promise<'kieai' | 'gamma'>}
+ */
+function presenceBasedDefault() {
+  // Presence-based safe default: route to the backend the deployment is
+  // actually configured for, instead of a fixed literal.
+  if (process.env.KIE_API_KEY_PIC_LP || process.env.KIE_API_KEY) return 'kieai';
+  if (process.env.GAMMA_API_KEY) return 'gamma';
+  return 'gamma';
+}
+
+async function pickBackend(userId, formData) {
+  if ((process.env.PIC_LP_FORCE_GAMMA || '').toLowerCase() === 'true') return 'gamma';
+  // Teacher's explicit "Detailed" pick wins over staging force-flags and the DB
+  // toggle. She asked for the rich format; honor it.
+  if (formData && formData.lesson_plan_format === 'detailed') return 'gamma';
+
+  if (!userId) return presenceBasedDefault();
+  if ((process.env.PIC_LP_FORCE_KIEAI || '').toLowerCase() === 'true') return 'kieai';
+
+  const { data, error } = await supabase
+    .from('app_settings')
+    .select('value')
+    .eq('key', 'pic_lp_backend_ab')
+    .maybeSingle();
+  if (error || !data?.value) return presenceBasedDefault();
+  let split;
+  try {
+    split = (typeof data.value === 'string') ? JSON.parse(data.value) : data.value;
+  } catch (_) {
+    return presenceBasedDefault();
+  }
+  const kieaiShare = parseFloat(split.kieai);
+  if (!Number.isFinite(kieaiShare) || kieaiShare <= 0) return 'gamma';
+  if (kieaiShare >= 1) return 'kieai';
+  // Deterministic per-user assignment: same teacher always lands on the same
+  // backend within a given toggle setting. Hash the userId into a [0, 1)
+  // bucket; route to kieai if bucket < kieaiShare.
+  const hash = crypto.createHash('md5').update(userId).digest('hex').slice(0, 8);
+  const bucket = parseInt(hash, 16) / 0xffffffff;
+  return (bucket < kieaiShare) ? 'kieai' : 'gamma';
+}
+
+/**
+ * Trigger the Gamma generation and ship the PDF.
+ * @param {object} args
+ * @param {object} args.session   pic_lp_sessions row (already updated with detected metadata)
+ * @param {object} args.formData  { grade, subject, topic, language, days? } — Flow submission
+ * @param {string} args.from      WhatsApp phone number
+ */
+async function generateAndDeliver({ session, formData, from }) {
+  const startTime = Date.now();
+
+  // A/B router branch — when app_settings.pic_lp_backend_ab routes to 'kieai',
+  // delegate to the SQS-routed Kie.ai pipeline. The Kie.ai path sends its own
+  // multilingual wait message + queues an SQS job + returns immediately (frees
+  // the web replica in <1s). The Gamma sync path below stays as the 'gamma'
+  // branch + as a fallback if the app_settings row is missing.
+  try {
+    const backend = await pickBackend(session.user_id, formData);
+    if (backend === 'kieai') {
+      const KieaiHandoff = require('./kieai-handoff.service');
+      return await KieaiHandoff.enqueueAndAck({ session, formData, from });
+    }
+  } catch (e) {
+    logToFile('Pic-LP A/B router soft-failed (falling through to Gamma)', { error: e.message });
+    // Fall through to existing Gamma path — safe default
+  }
+
+  // Gamma "Detailed" path deps are required lazily — the prompt builder is not
+  // part of this OSS bundle (it is a large standalone text-LP service). Loading
+  // it only when this branch runs keeps the module importable for the Kie.ai
+  // path. If it is absent (typical OSS clone — Gamma is the optional legacy
+  // arm), fall back to the Kie.ai pipeline so the teacher still gets an LP
+  // rather than being stranded.
+  let LessonPlanPromptsService, ContentService;
+  try {
+    LessonPlanPromptsService = require('../lesson-plan-prompts.service');
+    ContentService = require('../content.service');
+  } catch (e) {
+    logToFile('Pic-LP: Gamma "Detailed" deps unavailable — falling back to Kie.ai', { error: e.message });
+    const KieaiHandoff = require('./kieai-handoff.service');
+    return await KieaiHandoff.enqueueAndAck({ session, formData, from });
+  }
+
+  await PicLpSession.updateStatus(session.id, 'generating', {
+    detected: { ...(session.detected || {}), ...formData },
+  });
+
+  const isUrdu = formData.language === 'ur';
+  // Gamma path is the "Detailed" format (~5 min, 7-page complete teacher
+  // guide). Detailed format is Gamma-only — same timing across all languages.
+  const detailedWaitCopy = {
+    ur: '⏳ آپ کا تفصیلی لیسن پلان تیار کیا جا رہا ہے۔ اس میں تقریباً 5 منٹ لگ سکتے ہیں۔',
+    sw: '⏳ Mpango wako wa somo wa kina unatengenezwa. Inaweza kuchukua ~dakika 5.',
+    en: '⏳ Generating your detailed lesson plan now. This usually takes ~5 minutes.',
+  };
+  await WhatsAppService.sendMessage(
+    from,
+    detailedWaitCopy[formData.language] || detailedWaitCopy.en
+  );
+
+  try {
+    const ocrText = String(session?.detected?.ocr_text || '').trim();
+    const caption = String(session?.caption || '').trim();
+    const pages = Array.isArray(session?.pages) ? session.pages : [];
+    const pageRange = pages.length === 1 ? '1' : `1-${pages.length}`;
+    const days = formData.days || PIC_LP_DEFAULT_DAYS;
+
+    // Build the textbook `content` block. We prepend a short marker so Gamma
+    // knows this came from teacher-supplied photos (not our pre-OCR'd content).
+    const contentBlock = [
+      '--- TEACHER-PROVIDED TEXTBOOK PAGES ---',
+      caption ? `Teacher's note: ${caption}` : '',
+      `Pages photographed: ${pages.length}`,
+      '',
+      ocrText || '(No OCR text — generate based on the topic + grade + subject below.)',
+      '--- END TEXTBOOK PAGES ---',
+    ].filter(Boolean).join('\n');
+
+    const promptLanguage = formData.language === 'sd' ? 'sd' : formData.language; // pass through
+    const prompt = LessonPlanPromptsService.buildChapterPrompt(
+      formData.subject,
+      formData.grade,
+      contentBlock,
+      formData.topic || `${formData.subject} — Grade ${formData.grade}`,
+      pageRange,
+      days,
+      // buildChapterPrompt switch only knows en/ur — that's fine for the prompt
+      // body. The Gamma `textOptions.language` carries the real language.
+      formData.language === 'ur' || formData.language === 'sd' ? 'ur' : 'en'
+    );
+
+    const gammaResult = await GammaClient.generate({
+      prompt,
+      title: formData.topic || 'Lesson Plan',
+      language: formData.language,
+    });
+
+    if (!gammaResult.success || !gammaResult.pdfUrl) {
+      logToFile('❌ Pic-LP Gamma generation failed', {
+        sessionId: session.id,
+        error: gammaResult.error,
+      });
+      await PicLpSession.updateStatus(session.id, 'failed', { last_error: gammaResult.error || 'Unknown' });
+      await WhatsAppService.sendMessage(
+        from,
+        isUrdu
+          ? '⚠️ معذرت، لیسن پلان بنانے میں مسئلہ آیا۔ براہ کرم دوبارہ کوشش کریں۔'
+          : '⚠️ Sorry, I had trouble generating that lesson plan. Please try again.'
+      );
+      return { success: false, error: gammaResult.error };
+    }
+
+    // Match the canonical Gamma-LP delivery pattern — download the PDF to a
+    // local temp file, then sendDocument(phone, tempPath, …). sendDocument
+    // expects a file path, NOT a Buffer; passing a Buffer makes the internal
+    // read stream throw and the catch returns false, which we must check.
+    const filename = makeFilename(formData);
+    const docCaption = isUrdu
+      ? '📄 آپ کا لیسن پلان تیار ہے۔'
+      : '📄 Your lesson plan is ready.';
+
+    let tempPdfPath = null;
+    try {
+      tempPdfPath = await ContentService.downloadPDF(gammaResult.pdfUrl, filename, TEMP_DIR);
+
+      const sendResult = await WhatsAppService.sendDocument(from, tempPdfPath, filename, docCaption);
+
+      // sendDocument returns false on Meta failures without throwing — must check.
+      if (!sendResult) {
+        throw new Error('WhatsApp returned false from sendDocument');
+      }
+
+      await PicLpSession.updateStatus(session.id, 'handed_off');
+
+      logEvent('pic_lp.handed_off_to_lp', {
+        sessionId: session.id,
+        durationMs: Date.now() - startTime,
+        grade: formData.grade,
+        subject: formData.subject,
+        topic: formData.topic,
+        language: formData.language,
+        pageCount: pages.length,
+      });
+
+      logToFile('✅ Pic-LP delivered', { sessionId: session.id, filename });
+      return { success: true, pdfUrl: gammaResult.pdfUrl };
+    } catch (sendErr) {
+      logToFile('❌ Pic-LP delivery failed', {
+        sessionId: session.id,
+        error: sendErr.message,
+        pdfUrl: gammaResult.pdfUrl,
+      });
+      await PicLpSession.updateStatus(session.id, 'failed', { last_error: `delivery: ${sendErr.message}` });
+      await WhatsAppService.sendMessage(
+        from,
+        isUrdu
+          ? `⚠️ لیسن پلان تیار ہے لیکن واٹس ایپ پر بھیجنے میں مسئلہ آیا۔ یہ لنک کھول کر دیکھیں:\n${gammaResult.pdfUrl}`
+          : `⚠️ The lesson plan is ready but I couldn't deliver it via WhatsApp. You can open it here:\n${gammaResult.pdfUrl}`
+      );
+      return { success: false, error: sendErr.message, pdfUrl: gammaResult.pdfUrl };
+    } finally {
+      if (tempPdfPath && fs.existsSync(tempPdfPath)) {
+        try { fs.unlinkSync(tempPdfPath); } catch (_) { /* best-effort cleanup */ }
+      }
+    }
+  } catch (error) {
+    logToFile('❌ Pic-LP handoff threw', { error: error.message, sessionId: session.id });
+    await PicLpSession.updateStatus(session.id, 'failed', { last_error: error.message });
+    await WhatsAppService.sendMessage(
+      from,
+      isUrdu
+        ? '⚠️ کچھ غلط ہو گیا۔ ٹیم کو اطلاع دے دی گئی ہے۔'
+        : "⚠️ Something went wrong on our side. We've logged it for the team."
+    );
+    return { success: false, error: error.message };
+  }
+}
+
+function makeFilename(formData) {
+  const slug = (s) => String(s || '').replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '').substring(0, 40);
+  const parts = [
+    `Grade${formData.grade || 'X'}`,
+    slug(formData.subject) || 'Subject',
+    slug(formData.topic) || 'Lesson',
+  ];
+  return `${parts.join('_')}_LessonPlan.pdf`;
+}
+
+module.exports = { generateAndDeliver, pickBackend };

--- a/bot/shared/services/pic-to-lp/metadata-extractor.service.js
+++ b/bot/shared/services/pic-to-lp/metadata-extractor.service.js
@@ -1,0 +1,188 @@
+/**
+ * Metadata Extractor
+ *
+ * Single vision call over all collected pages + the original caption. Returns
+ * best-effort {grade, subject, topic, ocr_text}. Any field may be null —
+ * the WhatsApp Flow form lets the teacher fill the gaps and edit the rest.
+ */
+
+const OpenAI = require('openai');
+const axios = require('axios');
+const { logToFile } = require('../../utils/logger');
+const { OPENAI_API_KEY } = require('../../utils/constants');
+// Presign R2 URLs before passing to OpenAI vision. The R2 bucket is private —
+// raw URLs return 400 from OpenAI's image download. Without the presign the
+// metadata extractor silently fails (the form just opens with blank pre-fills
+// and the teacher fills them in manually).
+const { getPresignedUrl } = require('../../storage/r2');
+
+const { extractFromCaption, mergeWithCaption } = require('./caption-prefill');
+
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+const MODEL = process.env.PIC_LP_EXTRACTOR_MODEL || 'gpt-4o-mini';
+const TIMEOUT_MS = 45000;
+
+// Broad subject superset across common primary curricula. The vision pass
+// validates `subject` against this list. The Flow dropdown picks the
+// deployment-appropriate sub-list at form-open time via
+// flow-options.buildSubjects(region).
+const VALID_SUBJECTS = [
+  'Math', 'Mathematics', 'English', 'Urdu', 'Science', 'Social Studies',
+  'Sindhi', 'Islamiat', 'General Knowledge', 'Kiswahili',
+  'Civics & Moral Education', 'Religious Education', 'Languages',
+  'Vocational Skills', 'Other',
+];
+
+/**
+ * Parse "Grade N" / "Grade N-M" / "Class N" → integer (1..12). Returns null if unparseable.
+ * Used by the user-context fallback chain when the vision pass returned grade=null.
+ * Range like "Grade 4-5" → 4 (lower bound is the safer default — won't make the LP harder
+ * than the teacher actually teaches).
+ */
+function parseRegisteredGrade(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const match = raw.match(/(?:grade|class)\s*(\d{1,2})/i);
+  if (!match) return null;
+  const n = parseInt(match[1], 10);
+  if (!Number.isFinite(n) || n < 1 || n > 12) return null;
+  return n;
+}
+
+/**
+ * @param {Array<{url: string, mime: string}>} pages
+ * @param {string} caption
+ * @param {object} [userContext] - { registeredGrade: string, preferredLanguage: string }
+ *   When the vision pass returns null for grade/language, fall back to the teacher's
+ *   registered values so the WhatsApp Flow form doesn't open with empty required fields.
+ *   Fallback precedence: caption pre-fill > LLM extraction > userContext fallback.
+ * @returns {Promise<{grade: number|null, subject: string|null, topic: string|null,
+ *                    language: string|null, ocr_text: string}>}
+ */
+async function extract(pages, caption = '', userContext = null) {
+  // Regex pre-pass over the caption — caption-derived fields flow into the
+  // final result even if the LLM extractor fails or returns nulls. Without it,
+  // an LLM timeout loses the caption hint and the form opens with empty
+  // dropdowns. The caption pre-fill now survives that case.
+  const captionPrefill = extractFromCaption(caption);
+
+  // User-context fallback for grade/language when vision misses them. If a clean
+  // OCR returns grade=null + language=null, the form would otherwise open with
+  // empty required fields and the teacher may abandon. With this fallback the
+  // form opens with the teacher's registered grade + preferred language.
+  const applyUserContextFallbacks = (result) => {
+    if (!userContext) return result;
+    const out = { ...result };
+    if (out.grade == null) {
+      const fallbackGrade = parseRegisteredGrade(userContext.registeredGrade);
+      if (fallbackGrade != null) out.grade = fallbackGrade;
+    }
+    if (out.language == null && userContext.preferredLanguage) {
+      out.language = userContext.preferredLanguage;
+    }
+    return out;
+  };
+
+  if (!pages || pages.length === 0) {
+    const merged = mergeWithCaption({ grade: null, subject: null, topic: null, ocr_text: '' }, captionPrefill);
+    return applyUserContextFallbacks(merged);
+  }
+
+  try {
+    // Presign each R2 URL (1-hour TTL is plenty — the vision call resolves in
+    // <45s typical). Without the presign, OpenAI returns 400.
+    const presignedPages = await Promise.all(
+      pages.slice(0, 5).map(async (p) => ({
+        ...p,
+        url: await getPresignedUrl(p.url, 3600),
+      }))
+    );
+    const imageContent = presignedPages.map((p) => ({
+      type: 'image_url',
+      image_url: { url: p.url, detail: 'high' },
+    }));
+
+    const systemPrompt = [
+      'You read photographed primary-school textbook pages and extract structured metadata.',
+      '',
+      'Return STRICT JSON ONLY with this exact shape:',
+      '{',
+      '  "grade": integer 1..12 or null,',
+      '  "subject": one of [' + VALID_SUBJECTS.map(s => `"${s}"`).join(', ') + '] or null,',
+      '  "topic": short topic title (under 80 chars) or null,',
+      '  "ocr_text": full readable text of all pages, joined with \\n\\n between pages',
+      '}',
+      '',
+      'Rules:',
+      '- "grade" is the class/grade the textbook is for. Look for "Class 5", "Grade 3", page headers, etc. If unclear, null.',
+      '- "subject" is the school subject. Use only one of the listed subjects. If unclear, null.',
+      '- "topic" is the chapter or lesson title. Keep it natural — use the exact wording printed on the page if possible. Translate to English if printed in another script.',
+      '- "ocr_text" preserves the original script (e.g. Urdu, Sindhi, English). Include exercise text, examples, instructions. Skip page numbers and footers.',
+      '',
+      'Use the caption as a hint but do not over-trust it.',
+      'No prose, no markdown — JSON only.',
+    ].join('\n');
+
+    const userText = [
+      caption ? `Sender caption: "${caption.substring(0, 500)}"` : '(No caption)',
+      `Number of pages: ${pages.length}`,
+    ].join('\n');
+
+    const completion = await openai.chat.completions.create(
+      {
+        model: MODEL,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: userText }, ...imageContent],
+          },
+        ],
+        max_tokens: 4000,
+        temperature: 0,
+        response_format: { type: 'json_object' },
+      },
+      { timeout: TIMEOUT_MS }
+    );
+
+    const raw = completion.choices?.[0]?.message?.content || '{}';
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      logToFile('⚠️ Pic-LP extractor returned non-JSON', { raw: raw.substring(0, 200) });
+      return applyUserContextFallbacks(mergeWithCaption({ grade: null, subject: null, topic: null, ocr_text: '' }, captionPrefill));
+    }
+
+    const grade = parsed.grade && Number.isInteger(parsed.grade) && parsed.grade >= 1 && parsed.grade <= 12
+      ? parsed.grade
+      : null;
+    const subject = VALID_SUBJECTS.includes(parsed.subject) ? parsed.subject : null;
+    const topic = typeof parsed.topic === 'string' && parsed.topic.trim().length > 0
+      ? parsed.topic.trim().substring(0, 120)
+      : null;
+    const ocr_text = typeof parsed.ocr_text === 'string' ? parsed.ocr_text : '';
+
+    // Caption-derived values WIN over the LLM where both produced a value
+    // (the teacher's explicit ask outranks our inference from the page).
+    let merged = mergeWithCaption({ grade, subject, topic, ocr_text }, captionPrefill);
+
+    // User-context fallback fires after caption+LLM. Only fills NULL slots.
+    merged = applyUserContextFallbacks(merged);
+
+    logToFile('📚 Pic-LP metadata extracted', {
+      grade: merged.grade, subject: merged.subject, topic: merged.topic,
+      language: merged.language,
+      ocrTextLength: merged.ocr_text.length,
+      pageCount: pages.length,
+      captionContributed: !!(captionPrefill.grade || captionPrefill.subject || captionPrefill.topic || captionPrefill.language),
+      userContextApplied: !!userContext,
+    });
+
+    return merged;
+  } catch (error) {
+    logToFile('❌ Pic-LP metadata extraction failed (caption pre-fill still applies)', { error: error.message });
+    return applyUserContextFallbacks(mergeWithCaption({ grade: null, subject: null, topic: null, ocr_text: '' }, captionPrefill));
+  }
+}
+
+module.exports = { extract, VALID_SUBJECTS };

--- a/bot/shared/services/pic-to-lp/page-collector.service.js
+++ b/bot/shared/services/pic-to-lp/page-collector.service.js
@@ -1,0 +1,226 @@
+/**
+ * Page Collector Service
+ *
+ * Owns the multi-photo collection UX after a teacher has accepted the LP
+ * intent. Mirrors the coaching classroom-photo pattern — same MAX/timeout
+ * semantics, same "Add another / Done" buttons.
+ */
+
+const WhatsAppService = require('../whatsapp.service');
+const { logToFile } = require('../../utils/logger');
+const { getUserLanguage } = require('../../utils/language-cache');
+const PicLpSession = require('./pic-lp-session.service');
+
+const MAX_PIC_LP_PAGES = 5;
+const PAGE_TIMEOUT_MS = 120000; // 2 minutes — matches coaching
+
+// Receipt-notification debounce. When teachers send multiple photos in quick
+// succession (a WhatsApp album batch), wait this long before sending the
+// "Page N received. Add another?" prompt — that way they see ONE message with
+// the final count, not N separate messages. Each subsequent photo resets the
+// timer. The max-reached path bypasses this (fires immediately).
+const PAGE_RECEIPT_DEBOUNCE_MS = 2500;
+
+const timers = new Map(); // sessionId → 2-min auto-Done timeoutHandle
+const receiptDebouncers = new Map(); // sessionId → receipt-notification debouncer
+
+/**
+ * Send the intent prompt after the FIRST book-page detection.
+ * Asks the teacher what to do with this page (LP / explain / something else).
+ */
+async function promptIntent({ sessionId, from, language, captionAlreadyHasIntent }) {
+  const isUrdu = language === 'ur';
+
+  if (captionAlreadyHasIntent) {
+    // Caption already says "make a lesson plan" or similar — skip the buttons,
+    // jump straight into the collect-pages step.
+    return startCollectingFromIntent({ sessionId, from, language });
+  }
+
+  const body = isUrdu
+    ? '📚 یہ کتاب کا صفحہ لگ رہا ہے۔ آپ کیا کرنا چاہیں گی؟'
+    : '📚 Looks like a textbook page — what would you like to do with it?';
+
+  await WhatsAppService.sendInteractiveButtons(from, {
+    body,
+    buttons: [
+      { id: `pic_lp_start_${sessionId}`, title: isUrdu ? 'سبق بنائیں' : 'Generate Lesson Plan' },
+      { id: `pic_explain_${sessionId}`,  title: isUrdu ? 'سمجھائیں' : 'Explain this topic' },
+      { id: `pic_other_${sessionId}`,    title: isUrdu ? 'کچھ اور' : 'Something else' },
+    ],
+  });
+}
+
+/**
+ * Teacher tapped "Generate Lesson Plan" (or caption already had LP intent).
+ * Move state to collecting_pages, then either:
+ *   - Single page (slow-drip case): send "Page 1 received. Add another or Done?"
+ *   - Multi-page (batch-coalesced case): skip the prompt and jump straight to
+ *     onComplete (open the form). The teacher already sent N pages — asking
+ *     "want to add more?" is friction.
+ */
+async function startCollectingFromIntent({ sessionId, from, language }) {
+  await PicLpSession.updateStatus(sessionId, 'collecting_pages');
+
+  const session = await PicLpSession.getById(sessionId);
+  const pageCount = (session?.pages || []).length || 1;
+
+  if (pageCount >= 2) {
+    logToFile('📚 Pic-LP intent confirmed for batch-coalesced session — auto-completing', {
+      sessionId, pageCount,
+    });
+    await onComplete({ sessionId, from, language, trigger: 'intent_with_multi_page_batch' });
+    return;
+  }
+
+  await sendPageReceivedPrompt({ sessionId, from, language, pageCount });
+  scheduleAutoDone({ sessionId, from });
+}
+
+/**
+ * Called when a subsequent image arrives during an active collecting_pages
+ * session. Appends the page synchronously, then debounces the user-facing
+ * receipt notification so a batch of N photos sent within ~2.5s coalesces to
+ * ONE "Page N received. Add another?" prompt instead of N.
+ *
+ * Max-reached path bypasses the debounce — that's a one-shot terminal message.
+ */
+async function appendPageAndPrompt({ sessionId, from, language, page }) {
+  const updated = await PicLpSession.appendPage(sessionId, page);
+  const pageCount = updated?.pages?.length || 1;
+
+  if (pageCount >= MAX_PIC_LP_PAGES) {
+    // Max-reached preempts any pending coalesce debouncer + the inactivity timer.
+    cancelReceiptDebouncer(sessionId);
+    cancelTimer(sessionId);
+    const isUrdu = language === 'ur';
+    await WhatsAppService.sendMessage(
+      from,
+      isUrdu
+        ? `📚 صفحہ ${pageCount} موصول۔ زیادہ سے زیادہ حد پوری — اب لیسن پلان بنائی جا رہی ہے۔`
+        : `📚 Page ${pageCount} received. Maximum reached — generating your lesson plan now.`
+    );
+    return { autoComplete: true, pageCount };
+  }
+
+  // Debounce the receipt notification. If more photos arrive in the window,
+  // this timer gets cancelled + rescheduled with the new pageCount, so only
+  // the LAST one fires (with the final count).
+  scheduleReceiptNotification({ sessionId, from, language, pageCount });
+  scheduleAutoDone({ sessionId, from }); // refresh the 2-min inactivity timer
+  return { autoComplete: false, pageCount };
+}
+
+/**
+ * Schedule (or replace) the debounced "Page N received. Add another?" prompt.
+ * Always reads the LATEST pageCount, so a batch of arrivals collapses to one
+ * message with the final count.
+ */
+function scheduleReceiptNotification({ sessionId, from, language, pageCount }) {
+  cancelReceiptDebouncer(sessionId);
+  const handle = setTimeout(async () => {
+    receiptDebouncers.delete(sessionId);
+    try {
+      await sendPageReceivedPrompt({ sessionId, from, language, pageCount });
+    } catch (err) {
+      logToFile('⚠️ pic-LP receipt-notification debounce send failed', {
+        error: err.message, sessionId,
+      });
+    }
+  }, PAGE_RECEIPT_DEBOUNCE_MS);
+  receiptDebouncers.set(sessionId, handle);
+}
+
+function cancelReceiptDebouncer(sessionId) {
+  const h = receiptDebouncers.get(sessionId);
+  if (h) clearTimeout(h);
+  receiptDebouncers.delete(sessionId);
+}
+
+/**
+ * Send "Page N received. Add another or Done?" buttons.
+ */
+async function sendPageReceivedPrompt({ sessionId, from, language, pageCount }) {
+  const isUrdu = language === 'ur';
+  await WhatsAppService.sendInteractiveButtons(from, {
+    body: isUrdu
+      ? `📚 صفحہ ${pageCount} موصول۔ کیا آپ ایک اور صفحہ بھیجنا چاہیں گی؟`
+      : `📚 Page ${pageCount} received. Would you like to send another page?`,
+    buttons: [
+      { id: `pic_more_${sessionId}`, title: isUrdu ? 'مزید صفحہ' : 'Add another page' },
+      { id: `pic_done_${sessionId}`, title: isUrdu ? 'مکمل' : 'Done' },
+    ],
+  });
+}
+
+/**
+ * Schedule an auto-Done after PAGE_TIMEOUT_MS of teacher inactivity.
+ * Replaces any existing timer for this session.
+ */
+function scheduleAutoDone({ sessionId, from }) {
+  cancelTimer(sessionId);
+  const handle = setTimeout(async () => {
+    try {
+      const session = await PicLpSession.getById(sessionId);
+      if (!session || session.status !== 'collecting_pages') return;
+      const language = await getLanguageForSession(session);
+      await onComplete({ sessionId, from, language, trigger: 'timeout' });
+    } catch (err) {
+      logToFile('⚠️ pic-LP auto-Done timer failed', { error: err.message, sessionId });
+    } finally {
+      timers.delete(sessionId);
+    }
+  }, PAGE_TIMEOUT_MS);
+  timers.set(sessionId, handle);
+}
+
+function cancelTimer(sessionId) {
+  const h = timers.get(sessionId);
+  if (h) clearTimeout(h);
+  timers.delete(sessionId);
+}
+
+/**
+ * Called when collection completes (Done button, max-reached, or timeout).
+ * Triggers metadata extraction → form prompt.
+ */
+async function onComplete({ sessionId, from, language, trigger }) {
+  cancelTimer(sessionId);
+  cancelReceiptDebouncer(sessionId); // kill any pending receipt prompt
+  const session = await PicLpSession.getById(sessionId);
+  if (!session) {
+    logToFile('⚠️ pic-LP onComplete: session vanished', { sessionId });
+    return;
+  }
+  if (!Array.isArray(session.pages) || session.pages.length === 0) {
+    logToFile('⚠️ pic-LP onComplete: no pages collected, cancelling', { sessionId, trigger });
+    await PicLpSession.updateStatus(sessionId, 'cancelled');
+    return;
+  }
+
+  // Hand off to extractor + form prompt — done in a separate module so this
+  // file stays UI-only. Lazy-required to avoid a circular import.
+  const { extractAndPromptForm } = require('./completion-handler.service');
+  await extractAndPromptForm({ session, from, language, trigger });
+}
+
+async function getLanguageForSession(session) {
+  // Best-effort language lookup. Falls back to 'en'.
+  if (session?.user_id) {
+    return (await getUserLanguage(session.user_id)) || 'en';
+  }
+  return 'en';
+}
+
+module.exports = {
+  MAX_PIC_LP_PAGES,
+  PAGE_TIMEOUT_MS,
+  PAGE_RECEIPT_DEBOUNCE_MS,
+  promptIntent,
+  startCollectingFromIntent,
+  appendPageAndPrompt,
+  onComplete,
+  scheduleAutoDone,
+  cancelTimer,
+  cancelReceiptDebouncer,
+};

--- a/bot/shared/services/pic-to-lp/pic-lp-latency.service.js
+++ b/bot/shared/services/pic-to-lp/pic-lp-latency.service.js
@@ -1,0 +1,62 @@
+/**
+ * Pic-LP Latency Service
+ *
+ * Wraps the lp_latency_stats RPC with a 5-minute in-memory cache. Used by the
+ * wait-message service to render dynamic latency hints.
+ *
+ * Cold-start: when sample_size < 10, callers fall back to the baked-in
+ * defaults from kieai-client.service.js pickBackend(). After ~10 generations,
+ * this service returns live numbers from the DB.
+ */
+
+const supabase = require('../../config/supabase');
+const { logToFile } = require('../../utils/logger');
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const LOOKBACK_HOURS = 168; // 7 days
+const cache = new Map(); // key: source string → { value, expiresAt }
+
+/**
+ * Fetch p50/p90 latency stats for a given lesson_plans.source.
+ * Returns null on RPC error (caller should use baked-in defaults).
+ *
+ * @param {string} source - 'pic_to_lp_kieai' | 'gamma_standard' | etc.
+ * @returns {Promise<{p50_ms: number, p90_ms: number, sample_size: number}|null>}
+ */
+async function getStats(source) {
+  if (!source) return null;
+  const cached = cache.get(source);
+  if (cached && Date.now() < cached.expiresAt) return cached.value;
+
+  try {
+    const { data, error } = await supabase.rpc('lp_latency_stats', {
+      p_source: source,
+      p_lookback_hours: LOOKBACK_HOURS,
+    });
+    if (error) {
+      logToFile('lp_latency_stats RPC error', { source, error: error.message });
+      return null;
+    }
+    // Supabase rpc returns an array even for single-row functions
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row) return null;
+
+    const value = {
+      p50_ms: row.p50_ms || 0,
+      p90_ms: row.p90_ms || 0,
+      sample_size: row.sample_size || 0,
+    };
+    cache.set(source, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+    return value;
+  } catch (e) {
+    logToFile('lp_latency_stats threw', { source, error: e.message });
+    return null;
+  }
+}
+
+/**
+ * Force-clear the cache. Used by tests + by the latency-recomputation job.
+ */
+function clearCache() { cache.clear(); }
+
+module.exports = { getStats, clearCache };

--- a/bot/shared/services/pic-to-lp/pic-lp-session.service.js
+++ b/bot/shared/services/pic-to-lp/pic-lp-session.service.js
@@ -1,0 +1,210 @@
+/**
+ * pic_lp_sessions CRUD wrapper
+ *
+ * Thin layer over Supabase for the pic_lp_sessions table. Mirrors the shape
+ * of the coaching-session service so anyone familiar with that flow can read
+ * this without context switching.
+ */
+
+const supabase = require('../../config/supabase');
+const { logToFile } = require('../../utils/logger');
+
+const TABLE = 'pic_lp_sessions';
+const ACTIVE_STATUSES = [
+  'awaiting_intent',
+  'collecting_pages',
+  'awaiting_form_submit',
+  'generating',
+];
+
+// Per-status TTL on pic_lp_sessions. Each step has a different real-world
+// duration, so the TTL window matches user intent. The stale-session sweeper
+// marks expired non-terminal rows `timed_out` (or `failed` for `generating` —
+// an engineering-side issue, distinct from teacher drop-off).
+//
+// Tight TTLs surface abandoned forms quickly: once a form sits idle past its
+// window, the teacher has usually moved on, so a long window just delays the
+// "your previous request timed out" nudge. `generating` is short because a
+// concise plan completes in ~90s and a detailed one in ~5 min — anything past
+// ~10 min is a pipeline crash, not slow generation.
+const TTL_MINUTES_BY_STATUS = {
+  awaiting_intent: 10,        // user said something LP-ish, never replied
+  collecting_pages: 30,       // active upload window; extends on each page
+  awaiting_form_submit: 15,   // Flow form opened; surfaces abandoned forms fast
+  generating: 10,             // past 10 min = crashed (Detailed = ~5 min)
+};
+
+const TERMINAL_STATUSES = ['cancelled', 'timed_out', 'failed', 'handed_off'];
+
+function ttlExpiryIsoForStatus(status) {
+  const minutes = TTL_MINUTES_BY_STATUS[status];
+  if (!minutes) return null; // terminal status → no expiry
+  return new Date(Date.now() + minutes * 60 * 1000).toISOString();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+/**
+ * Look up the most recent active session for a user, or null.
+ */
+async function getActiveSession(userId) {
+  // Filter rows whose expires_at has passed. Pre-migration rows
+  // (expires_at IS NULL) remain queryable for backwards compatibility;
+  // any new write populates expires_at, so this filter is sufficient
+  // going forward.
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('user_id', userId)
+    .in('status', ACTIVE_STATUSES)
+    .or(`expires_at.gt.${nowIso()},expires_at.is.null`)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    logToFile('⚠️ pic_lp_sessions getActiveSession failed', { error: error.message, userId });
+    return null;
+  }
+  return data || null;
+}
+
+async function getById(id) {
+  const { data, error } = await supabase
+    .from(TABLE).select('*').eq('id', id).maybeSingle();
+  if (error) {
+    logToFile('⚠️ pic_lp_sessions getById failed', { error: error.message, id });
+    return null;
+  }
+  return data;
+}
+
+async function getByFlowToken(flowToken) {
+  const { data, error } = await supabase
+    .from(TABLE).select('*').eq('flow_token', flowToken).maybeSingle();
+  if (error) {
+    logToFile('⚠️ pic_lp_sessions getByFlowToken failed', { error: error.message });
+    return null;
+  }
+  return data;
+}
+
+/**
+ * Create a fresh session. Caller passes the first page already.
+ * @param {object} args
+ * @param {string} args.userId
+ * @param {string} args.correlationId
+ * @param {string} args.caption
+ * @param {{url: string, mime: string, uploaded_at: string}} args.firstPage
+ */
+async function create({ userId, correlationId, caption, firstPage }) {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .insert({
+      user_id: userId,
+      status: 'awaiting_intent',
+      pages: firstPage ? [firstPage] : [],
+      caption: caption || null,
+      correlation_id: correlationId,
+      expires_at: ttlExpiryIsoForStatus('awaiting_intent'),
+    })
+    .select()
+    .single();
+  if (error) {
+    logToFile('❌ pic_lp_sessions create failed', { error: error.message, userId });
+    throw error;
+  }
+  return data;
+}
+
+async function appendPage(sessionId, page) {
+  const session = await getById(sessionId);
+  if (!session) return null;
+  const pages = Array.isArray(session.pages) ? session.pages : [];
+  pages.push(page);
+
+  // Each page upload extends the active-upload window — teacher is engaging.
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update({ pages, expires_at: ttlExpiryIsoForStatus('collecting_pages') })
+    .eq('id', sessionId)
+    .select()
+    .single();
+  if (error) {
+    logToFile('❌ pic_lp_sessions appendPage failed', { error: error.message, sessionId });
+    throw error;
+  }
+  return data;
+}
+
+async function updateStatus(sessionId, status, extras = {}) {
+  // Maintain the expires_at invariant. Terminal statuses clear it
+  // (the row is no longer trap-eligible). Non-terminal statuses set the
+  // window from TTL_MINUTES_BY_STATUS. Caller can override via extras.expires_at.
+  const update = { status, ...extras };
+  if (!('expires_at' in extras)) {
+    update.expires_at = TERMINAL_STATUSES.includes(status)
+      ? null
+      : ttlExpiryIsoForStatus(status);
+  }
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update(update)
+    .eq('id', sessionId)
+    .select()
+    .single();
+  if (error) {
+    logToFile('❌ pic_lp_sessions updateStatus failed', { error: error.message, sessionId, status });
+    throw error;
+  }
+  return data;
+}
+
+async function updateDetected(sessionId, detected) {
+  return updateStatus(sessionId, 'awaiting_form_submit', { detected });
+}
+
+async function attachFlowToken(sessionId, flowToken) {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update({ flow_token: flowToken })
+    .eq('id', sessionId)
+    .select()
+    .single();
+  if (error) {
+    logToFile('❌ pic_lp_sessions attachFlowToken failed', { error: error.message, sessionId });
+    throw error;
+  }
+  return data;
+}
+
+async function cancelActiveForUser(userId, reason = 'cancelled') {
+  const validReasons = ['cancelled', 'timed_out', 'failed'];
+  const status = validReasons.includes(reason) ? reason : 'cancelled';
+  const { error } = await supabase
+    .from(TABLE)
+    .update({ status })
+    .eq('user_id', userId)
+    .in('status', ACTIVE_STATUSES);
+  if (error) {
+    logToFile('⚠️ pic_lp_sessions cancelActiveForUser failed', { error: error.message, userId });
+  }
+}
+
+module.exports = {
+  ACTIVE_STATUSES,
+  TTL_MINUTES_BY_STATUS,
+  TERMINAL_STATUSES,
+  ttlExpiryIsoForStatus,
+  getActiveSession,
+  getById,
+  getByFlowToken,
+  create,
+  appendPage,
+  updateStatus,
+  updateDetected,
+  attachFlowToken,
+  cancelActiveForUser,
+};

--- a/bot/shared/services/pic-to-lp/pic-lp-wait-message.service.js
+++ b/bot/shared/services/pic-to-lp/pic-lp-wait-message.service.js
@@ -1,0 +1,98 @@
+/**
+ * Pic-LP Wait Message Service
+ *
+ * Builds the upfront wait message we send the teacher RIGHT AFTER they
+ * submit the Flow form, BEFORE the SQS job runs. Without this, teachers
+ * read a 4-min silent wait as "Rumi is broken" and abandon. With it,
+ * they read it as "Rumi is working" and move on.
+ *
+ * Multilingual — picks copy from a 6-language table. Defaults to English for
+ * unknown languages.
+ *
+ * Optionally uses live p50/p90 from pic-lp-latency.service.js once we have
+ * ≥10 samples in lesson_plans for the chosen backend. Until then, falls
+ * back to baked-in defaults from pickBackend() in kieai-client.service.js.
+ */
+
+const { pickBackend } = require('./kieai-client.service');
+
+/**
+ * Build the multilingual wait message.
+ *
+ * Two language inputs intentionally:
+ *   - systemLanguage = user.preferred_language (locked UI language)
+ *     → drives the COPY (which translation to render).
+ *   - contentLanguage = formData.language (LP output language)
+ *     → drives the TIMING (1K vs 2K backend, ~90s vs ~4 min).
+ *
+ * Without this split, an English-locked teacher who generates a Sindhi LP sees
+ * "~90 seconds" in English copy while the actual job takes ~4 minutes — a
+ * 3-minute trust gap.
+ *
+ * Back-compat: callers passing `language` alone still work (used as both).
+ *
+ * @param {Object} args
+ * @param {string} [args.systemLanguage] - 'en'|'ur'|'sd'|'pa'|'sw'|'ar' for copy
+ * @param {string} [args.contentLanguage] - same set, for timing
+ * @param {string} [args.language] - legacy; sets both if the split fields are absent
+ * @param {Object} [args.dbStats] - Optional { p50_ms, p90_ms, sample_size }
+ * @returns {string}
+ */
+function buildWaitMessage({ systemLanguage, contentLanguage, language, dbStats } = {}) {
+  const SUPPORTED = ['en', 'ur', 'sd', 'pa', 'sw', 'ar'];
+  const sysRaw = systemLanguage || language || 'en';
+  const contentRaw = contentLanguage || language || sysRaw;
+  const lang = SUPPORTED.includes(sysRaw) ? sysRaw : 'en';
+  const contentLang = SUPPORTED.includes(contentRaw) ? contentRaw : lang;
+  // Timing is driven by the backend that will actually run, which is selected
+  // from the CONTENT language. The text/copy is in `lang`.
+  const backend = pickBackend(contentLang);
+
+  // Use live stats only when we have a meaningful sample size — otherwise
+  // the fallback values from pickBackend() are calibrated and stable.
+  const useDb = dbStats && (dbStats.sample_size || 0) >= 10
+    && dbStats.p50_ms > 0 && dbStats.p90_ms > 0;
+  const expectedSec = useDb ? Math.round(dbStats.p50_ms / 1000) : backend.expectedSec;
+  const upperSec    = useDb ? Math.round(dbStats.p90_ms / 1000) : backend.upperSec;
+  const expectedMin = Math.max(1, Math.round(expectedSec / 60));
+  const upperMin    = Math.max(2, Math.round(upperSec / 60));
+
+  if (lang === 'en') {
+    // English: seconds for the sub-2-min fast path; minutes once we cross 2
+    // minutes (else "240 seconds" reads weirdly when actual is 4 min).
+    if (expectedSec >= 120) {
+      return `⏳ Generating your lesson plan — usually about ${expectedMin}-${expectedMin + 1} minutes (up to ${upperMin} minutes if our servers are busy).\n\nFeel free to keep using Rumi while you wait — your PDF will arrive here when it's ready.`;
+    }
+    const upper = upperSec >= 120 ? `${Math.round(upperSec / 60)}-${Math.round(upperSec / 60) + 1} minutes` : `${upperSec} seconds`;
+    return `⏳ Generating your lesson plan — usually about ${expectedSec} seconds (up to ${upper} if our servers are busy).\n\nFeel free to keep using Rumi while you wait — your PDF will arrive here when it's ready.`;
+  }
+
+  if (lang === 'ur') {
+    return `⏳ آپ کا منصوبہ تیار کیا جا رہا ہے — عام طور پر ${expectedMin} سے ${expectedMin + 1} منٹ۔ (سرور مصروف ہوں تو ${upperMin} منٹ تک)۔\n\nانتظار کے دوران Rumi استعمال کرتے رہیں — تیار ہوتے ہی PDF یہاں آ جائے گی۔`;
+  }
+
+  if (lang === 'sd') {
+    return `⏳ توهان جو منصوبو تيار ٿي رهيو آهي — عام طور تي ${expectedMin} کان ${expectedMin + 1} منٽ ۾۔ (سرور مصروف هجن ته ${upperMin} منٽن تائين)۔\n\nانتظار جي دوران Rumi استعمال ڪندا رهو — تيار ٿيندي ئي PDF هتي اچي ويندي۔`;
+  }
+
+  if (lang === 'sw') {
+    // Kiswahili — for East African teachers. Bilingual with English numbers.
+    // Express in minutes when expectedSec >= 120 (Urdu-routed slow path);
+    // seconds otherwise (English-routed fast path).
+    if (expectedSec >= 120) {
+      return `⏳ Mpango wako wa somo unatengenezwa — kawaida dakika ${expectedMin} hadi ${expectedMin + 1} (hadi dakika ${upperMin} ikiwa servers zetu ni busy).\n\nUnaweza kuendelea kutumia Rumi wakati unasubiri — PDF yako itafika hapa ikiwa tayari.`;
+    }
+    return `⏳ Mpango wako wa somo unatengenezwa — kawaida sekunde ${expectedSec} (hadi dakika ${upperMin} ikiwa servers zetu ni busy).\n\nUnaweza kuendelea kutumia Rumi wakati unasubiri — PDF yako itafika hapa ikiwa tayari.`;
+  }
+
+  if (lang === 'ar') {
+    // Arabic (Naskh script). RTL, Eastern Arabic numerals NOT used (we keep
+    // Hindu-Arabic 0-9 for math notation consistency across languages).
+    return `⏳ يتم إعداد خطة الدرس الخاصة بك — عادةً ${expectedMin} إلى ${expectedMin + 1} دقائق. (حتى ${upperMin} دقيقة إذا كانت الخوادم مشغولة).\n\nيمكنك الاستمرار في استخدام Rumi أثناء الانتظار — سيصل ملف PDF هنا فور أن يكون جاهزًا.`;
+  }
+
+  // 'pa' — Punjabi (Shahmukhi)
+  return `⏳ تہاڈا منصوبہ تیار کیتا جا رہیا اے — عام طور تے ${expectedMin} توں ${expectedMin + 1} منٹ۔ (سرور مصروف ہون تے ${upperMin} منٹاں تک)۔\n\nانتظار وچ Rumi ورتدے رہو — تیار ہوندے ہی PDF ایتھے آ جاوے گی۔`;
+}
+
+module.exports = { buildWaitMessage };

--- a/bot/shared/utils/constants.js
+++ b/bot/shared/utils/constants.js
@@ -22,6 +22,19 @@ const PORT = process.env.PORT || 3000;
 const ATTENDANCE_SETUP_FLOW_ID = process.env.ATTENDANCE_SETUP_FLOW_ID || '';
 const ATTENDANCE_MARKING_FLOW_ID = process.env.ATTENDANCE_MARKING_FLOW_ID || '';
 
+// Pic-to-LP (photo → illustrated lesson plan)
+const KIE_API_KEY = process.env.KIE_API_KEY;
+// Pic-to-LP uses a dedicated Kie.ai key for rate-limit isolation; falls back
+// to the shared KIE_API_KEY when a feature-specific key isn't set.
+const KIE_API_KEY_PIC_LP = process.env.KIE_API_KEY_PIC_LP || process.env.KIE_API_KEY;
+// R2 object key for the Rumi brand mark used as the header logo in generated LPs.
+const RUMI_LOGO_R2_KEY = process.env.RUMI_LOGO_R2_KEY || 'brand/rumi-white-smile-v1.png';
+// WhatsApp Flow ID for the pic-to-LP confirmation form (empty → text fallback).
+const PIC_LP_FLOW_ID = process.env.PIC_LP_FLOW_ID || '';
+// Teacher-facing WhatsApp number shown in the lesson-plan Coaching Corner
+// (empty → the contact line is omitted from the rendered LP).
+const COACHING_WHATSAPP_NUMBER = process.env.COACHING_WHATSAPP_NUMBER || '';
+
 // Directory Paths
 const TEMP_DIR = path.join(__dirname, '../../temp');
 const LOGS_DIR = path.join(__dirname, '../../logs');
@@ -39,6 +52,8 @@ const SONIOX_V3_TIMEOUT = 180; // 3 minutes
 const SONIOX_V2_TIMEOUT = 120; // 2 minutes
 const GAMMA_MAX_ATTEMPTS = 60; // Maximum polling attempts for Gamma
 const GAMMA_POLL_INTERVAL = 5000; // 5 seconds between polls
+const KIE_MAX_ATTEMPTS = 60;    // Maximum polling attempts for Kie.ai (8s × 60 = 8 min ceiling)
+const KIE_POLL_INTERVAL = 8000; // 8 seconds between polls (matches Kie.ai recommendation)
 const MESSAGE_MAX_AGE = 23 * 60 * 60; // 23 hours in seconds
 
 // MMS-ASR Service Configuration (for regional Pakistani languages)
@@ -106,6 +121,13 @@ module.exports = {
   ATTENDANCE_SETUP_FLOW_ID,
   ATTENDANCE_MARKING_FLOW_ID,
 
+  // Pic-to-LP
+  KIE_API_KEY,
+  KIE_API_KEY_PIC_LP,
+  RUMI_LOGO_R2_KEY,
+  PIC_LP_FLOW_ID,
+  COACHING_WHATSAPP_NUMBER,
+
   // Directory Paths
   TEMP_DIR,
   LOGS_DIR,
@@ -123,6 +145,8 @@ module.exports = {
   SONIOX_V2_TIMEOUT,
   GAMMA_MAX_ATTEMPTS,
   GAMMA_POLL_INTERVAL,
+  KIE_MAX_ATTEMPTS,
+  KIE_POLL_INTERVAL,
   MESSAGE_MAX_AGE,
 
   // MMS-ASR Service

--- a/bot/whatsapp-bot.js
+++ b/bot/whatsapp-bot.js
@@ -690,6 +690,65 @@ app.post('/webhook', async (req, res) => {
         } else {
           logToFile('⚠️ No user found for exam checker button', { buttonId, from });
         }
+      }
+      // Pic-to-LP buttons
+      //   pic_lp_start_/pic_explain_/pic_other_ → intent on a fresh book page
+      //   pic_more_/pic_done_ → page-collection control
+      else if (
+        buttonId.startsWith('pic_lp_start_') ||
+        buttonId.startsWith('pic_explain_')  ||
+        buttonId.startsWith('pic_other_')    ||
+        buttonId.startsWith('pic_more_')     ||
+        buttonId.startsWith('pic_done_')
+      ) {
+        if (!user) {
+          logToFile('⚠️ Pic-LP button from unregistered sender', { buttonId, from });
+        } else {
+          const { getUserLanguage } = require('./shared/utils/language-cache');
+          const { logEvent } = require('./shared/utils/structured-logger');
+          const PageCollector = require('./shared/services/pic-to-lp/page-collector.service');
+          const PicLpSession = require('./shared/services/pic-to-lp/pic-lp-session.service');
+          const lang = (await getUserLanguage(user.id)) || user.preferred_language || 'en';
+          // Session ID is the suffix after the last '_'
+          const sessionId = buttonId.slice(buttonId.lastIndexOf('_') + 1);
+
+          logToFile('📚 Pic-LP button tapped', { buttonId, sessionId, from, userId: user.id });
+
+          if (buttonId.startsWith('pic_lp_start_')) {
+            logEvent('pic_lp.intent_chosen', { sessionId, intent: 'lp' });
+            await PageCollector.startCollectingFromIntent({ sessionId, from, language: lang });
+          } else if (buttonId.startsWith('pic_explain_')) {
+            logEvent('pic_lp.intent_chosen', { sessionId, intent: 'explain' });
+            await PicLpSession.updateStatus(sessionId, 'cancelled');
+            const isUrdu = lang === 'ur';
+            await WhatsAppService.sendMessage(
+              from,
+              isUrdu
+                ? '👍 ٹھیک ہے۔ موضوع کی وضاحت کے لیے مجھے ایک اور تصویر بھیج دیں — میں اسے سمجھا دوں گی۔'
+                : "👍 Got it. Send me the page again and I'll explain the topic in detail."
+            );
+          } else if (buttonId.startsWith('pic_other_')) {
+            logEvent('pic_lp.intent_chosen', { sessionId, intent: 'other' });
+            await PicLpSession.updateStatus(sessionId, 'cancelled');
+            const isUrdu = lang === 'ur';
+            await WhatsAppService.sendMessage(
+              from,
+              isUrdu
+                ? '👍 ٹھیک ہے۔ مجھے بتائیں کہ آپ کو کیا چاہیے۔'
+                : "👍 No problem. Just tell me what you'd like help with."
+            );
+          } else if (buttonId.startsWith('pic_more_')) {
+            const isUrdu = lang === 'ur';
+            await WhatsAppService.sendMessage(
+              from,
+              isUrdu
+                ? '📚 ٹھیک ہے، اگلا صفحہ بھیج دیں۔ (زیادہ سے زیادہ 5 صفحات)'
+                : '📚 Great, please send the next page. (Maximum 5 pages)'
+            );
+          } else if (buttonId.startsWith('pic_done_')) {
+            await PageCollector.onComplete({ sessionId, from, language: lang, trigger: 'done_clicked' });
+          }
+        }
       } else {
         logToFile('⚠️ Unknown button ID', { buttonId });
       }

--- a/bot/workers/pic-lp-kieai.worker.js
+++ b/bot/workers/pic-lp-kieai.worker.js
@@ -1,0 +1,361 @@
+/**
+ * Pic-LP Kie.ai Worker
+ *
+ * Consumes pic_lp_kieai_generation SQS jobs. For each job:
+ *   1. Loads the pic_lp_sessions row
+ *   2. Builds the page-1 + page-2 prompts via kieai-prompt-builder
+ *   3. Renders both pages in parallel via kieai-client.service.js
+ *   4. Downloads PNGs, assembles a 2-page PDF (pdf-lib + sharp), stamps
+ *      the hellorumi.ai footer
+ *   5. Delivers via WhatsAppService.sendDocument (canonical path)
+ *   6. INSERTs a lesson_plans row with source='pic_to_lp_kieai',
+ *      cost_usd, delivery_time_ms, pic_lp_session_id, textbook_metadata
+ *   7. Schedules the lp-feedback prompt with context.askReasonOnYes=true
+ *      and context.language so the teacher gets the multilingual ask
+ *
+ * On failure: updates session status to 'failed' + sends a localized
+ * error message to the teacher. SQS DLQ handles retry for transient errors.
+ *
+ * NOTE (open-source port): the post-delivery feedback prompt depends on the
+ * bot's lp-feedback service, which is not part of this OSS bundle. That
+ * dependency is required lazily, so the worker module loads and the core
+ * generation/delivery path runs without it; if the service is absent, the
+ * feedback scheduling step is skipped (logged, non-fatal).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const sharp = require('sharp');
+const { PDFDocument, StandardFonts, rgb } = require('pdf-lib');
+
+const supabase = require('../shared/config/supabase');
+const WhatsAppService = require('../shared/services/whatsapp.service');
+const PicLpSession = require('../shared/services/pic-to-lp/pic-lp-session.service');
+const KieaiClient = require('../shared/services/pic-to-lp/kieai-client.service');
+const KieaiPromptBuilder = require('../shared/services/pic-to-lp/kieai-prompt-builder.service');
+const { getPresignedUrl, buildR2PublicUrl } = require('../shared/storage/r2');
+const { detectRegion } = require('../shared/utils/region');
+const { coachingNumberFor } = require('../shared/services/pic-to-lp/kieai-prompt-builder.service');
+const { logToFile } = require('../shared/utils/logger');
+const { logEvent } = require('../shared/utils/structured-logger');
+const { TEMP_DIR, RUMI_LOGO_R2_KEY } = require('../shared/utils/constants');
+
+const PRESIGN_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+function downloadToBuffer(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, (res) => {
+      if (res.statusCode !== 200) return reject(new Error(`HTTP ${res.statusCode}`));
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => resolve(Buffer.concat(chunks)));
+      res.on('error', reject);
+    }).on('error', reject);
+  });
+}
+
+/**
+ * Assemble the 2-page PDF: page1 + page2 + a discreet
+ * "Generate via www.hellorumi.ai" footer at the bottom of each page.
+ *
+ * @param {Object} args
+ * @param {string} args.page1Url
+ * @param {string} args.page2Url
+ * @param {string} args.outPath - Local temp PDF path
+ */
+async function assemblePDF({ page1Url, page2Url, outPath }) {
+  const [p1Buf, p2Buf] = await Promise.all([
+    downloadToBuffer(page1Url),
+    downloadToBuffer(page2Url),
+  ]);
+  const [p1Jpeg, p2Jpeg] = await Promise.all([
+    sharp(p1Buf).jpeg({ quality: 92 }).toBuffer(),
+    sharp(p2Buf).jpeg({ quality: 92 }).toBuffer(),
+  ]);
+  const meta = await sharp(p1Buf).metadata();
+  const W = meta.width;
+  const H = meta.height;
+
+  const pdf = await PDFDocument.create();
+  const helv = await pdf.embedFont(StandardFonts.Helvetica);
+
+  const drawFooter = (page) => {
+    const text = 'Generate via www.hellorumi.ai';
+    const sz = Math.max(10, Math.round(W * 0.011));
+    const fw = helv.widthOfTextAtSize(text, sz);
+    page.drawText(text, {
+      x: (page.getWidth() - fw) / 2,
+      y: Math.round(W * 0.012),
+      size: sz, font: helv,
+      color: rgb(0.42, 0.45, 0.50), // slate-500-ish, discreet
+    });
+  };
+
+  const p1Embed = await pdf.embedJpg(p1Jpeg);
+  const page1 = pdf.addPage([W, H]);
+  page1.drawImage(p1Embed, { x: 0, y: 0, width: W, height: H });
+  drawFooter(page1);
+
+  const p2Embed = await pdf.embedJpg(p2Jpeg);
+  const page2 = pdf.addPage([W, H]);
+  page2.drawImage(p2Embed, { x: 0, y: 0, width: W, height: H });
+  drawFooter(page2);
+
+  fs.writeFileSync(outPath, await pdf.save());
+}
+
+function makeFilename({ grade, subject, topic }) {
+  const slug = (s) => String(s || '').replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '').substring(0, 40);
+  return `Grade${grade || 'X'}_${slug(subject) || 'Subject'}_${slug(topic) || 'Lesson'}_LessonPlan.pdf`;
+}
+
+function localizedDeliveryCaption(language) {
+  const isUrduLike = language === 'ur' || language === 'sd' || language === 'pa';
+  return isUrduLike ? '📄 آپ کا لیسن پلان تیار ہے۔' : '📄 Your lesson plan is ready.';
+}
+
+function localizedErrorMessage(language) {
+  const isUrduLike = language === 'ur' || language === 'sd' || language === 'pa';
+  return isUrduLike
+    ? '⚠️ معذرت، لیسن پلان بنانے میں مسئلہ آیا۔ براہ کرم دوبارہ کوشش کریں۔'
+    : '⚠️ Sorry, I had trouble generating that lesson plan. Please try again.';
+}
+
+/**
+ * Main entry — called by workers/sqs-worker.js when a pic_lp_kieai_generation
+ * job arrives. Idempotent on the lesson_plans INSERT (checks for an existing
+ * row with the same pic_lp_session_id before inserting, to handle SQS
+ * at-least-once delivery).
+ *
+ * @param {Object} args - Payload from kieai-handoff.service.js enqueueAndAck
+ * @param {string} args.sessionId
+ * @param {Object} args.formData - { grade, subject, topic, language }
+ * @param {string} args.from
+ */
+async function process({ sessionId, formData, from }) {
+  const t0 = Date.now();
+  let tempPdfPath = null;
+
+  // Load fresh session state in case anything changed since enqueue
+  const session = await PicLpSession.getById(sessionId);
+  if (!session) {
+    logToFile('Pic-LP worker: session not found', { sessionId });
+    return { success: false, error: 'session_not_found' };
+  }
+
+  // Status guard — skip if the session is already in a TERMINAL state
+  // (handed_off / failed / cancelled / timed_out). This prevents SQS
+  // at-least-once re-delivery from re-processing a job whose previous attempt
+  // eventually succeeded (or was abandoned), avoiding stale "surprise" LP
+  // deliveries hours later.
+  const TERMINAL_STATES = ['handed_off', 'failed', 'cancelled', 'timed_out'];
+  if (TERMINAL_STATES.includes(session.status)) {
+    logEvent('pic_lp.kieai_worker.skipped_terminal_state', {
+      sessionId, currentStatus: session.status,
+    });
+    return { success: true, skipped: true, reason: `terminal_state_${session.status}` };
+  }
+
+  // Stale-message guard — even if not terminal, skip if the session is too old.
+  // A generous 20-min ceiling matches the worker timeout budget + gives some
+  // slack for SQS visibility-timeout overruns. Older messages = the teacher has
+  // moved on; delivering would just confuse them.
+  const STALE_THRESHOLD_MS = 20 * 60 * 1000;
+  const sessionAgeMs = Date.now() - new Date(session.created_at).getTime();
+  if (sessionAgeMs > STALE_THRESHOLD_MS) {
+    logEvent('pic_lp.kieai_worker.skipped_stale', {
+      sessionId, ageMinutes: Math.round(sessionAgeMs / 60000),
+    });
+    await PicLpSession.updateStatus(sessionId, 'timed_out', { last_error: `Stale by ${Math.round(sessionAgeMs / 60000)} min` });
+    return { success: true, skipped: true, reason: 'stale' };
+  }
+
+  // Idempotency: if a lesson_plans row already exists for this session, the
+  // job was already processed (SQS at-least-once delivery). No-op.
+  const { data: existingLp } = await supabase
+    .from('lesson_plans')
+    .select('id')
+    .eq('pic_lp_session_id', sessionId)
+    .limit(1)
+    .maybeSingle();
+  if (existingLp) {
+    logEvent('pic_lp.kieai_worker.duplicate_skipped', { sessionId, lessonPlanId: existingLp.id });
+    return { success: true, skipped: true, reason: 'already_processed' };
+  }
+
+  const language = formData.language || 'en';
+
+  try {
+    // Coaching Corner number. detectRegion() is used for caller compatibility;
+    // the number itself comes from the COACHING_WHATSAPP_NUMBER env var (or is
+    // omitted when unset).
+    const region = detectRegion();
+    const coachingNumber = coachingNumberFor(region);
+
+    // Build prompts from form data + OCR text we captured at metadata-extract time
+    const promptArgs = {
+      grade: formData.grade,
+      subject: formData.subject,
+      topic: formData.topic,
+      language,
+      ocrText: session?.detected?.ocr_text || '',
+      region,
+      coachingNumber,
+    };
+    const page1Prompt = KieaiPromptBuilder.buildPage1Prompt(promptArgs);
+    const page2Prompt = KieaiPromptBuilder.buildPage2Prompt(promptArgs);
+
+    // Presign the logo (image_input[0]) + the first teacher photo (image_input[1])
+    const logoR2Url = buildR2PublicUrl(RUMI_LOGO_R2_KEY);
+    const logoUrl = await getPresignedUrl(logoR2Url, PRESIGN_TTL_SECONDS);
+
+    const pages = Array.isArray(session?.pages) ? session.pages : [];
+    const firstPage = pages[0]?.url;
+    if (!firstPage) {
+      throw new Error('No teacher photo on the session');
+    }
+    const teacherPhotoUrl = await getPresignedUrl(firstPage, PRESIGN_TTL_SECONDS);
+    const inputUrls = [logoUrl, teacherPhotoUrl];
+
+    // Render page 1 + page 2 in parallel
+    const [p1, p2] = await Promise.all([
+      KieaiClient.generate({ prompt: page1Prompt, inputUrls, language, label: `${sessionId}-p1` }),
+      KieaiClient.generate({ prompt: page2Prompt, inputUrls, language, label: `${sessionId}-p2` }),
+    ]);
+    if (!p1.success) throw new Error(`page 1 failed: ${p1.error}`);
+    if (!p2.success) throw new Error(`page 2 failed: ${p2.error}`);
+
+    // Assemble PDF
+    const filename = makeFilename(formData);
+    // TEMP_DIR may not exist on the worker container by default (it's a
+    // separate instance from the web replica). mkdirSync recursive is
+    // idempotent — safe to call every time.
+    if (!fs.existsSync(TEMP_DIR)) {
+      fs.mkdirSync(TEMP_DIR, { recursive: true });
+    }
+    tempPdfPath = path.join(TEMP_DIR, `pic_lp_kieai_${sessionId}_${Date.now()}.pdf`);
+    await assemblePDF({ page1Url: p1.url, page2Url: p2.url, outPath: tempPdfPath });
+
+    // Deliver via WhatsApp (file path, NOT buffer)
+    const sendResult = await WhatsAppService.sendDocument(
+      from, tempPdfPath, filename, localizedDeliveryCaption(language)
+    );
+    if (!sendResult) throw new Error('WhatsApp returned false from sendDocument');
+
+    const deliveryMs = Date.now() - t0;
+
+    // Cost: each page same cost. p1 + p2 same model so just double.
+    const costUsd = (p1.model && p1.resolution)
+      ? (KieaiClient.pickBackend(language).costUsdPerPage * 2)
+      : 0;
+
+    // INSERT into lesson_plans (unified output table — same shape as v7 LPs).
+    const textbookMetadata = {
+      grade: formData.grade,
+      subject: formData.subject,
+      topic: formData.topic,
+      language,
+      backend_model: p1.model,
+      resolution: p1.resolution,
+      page_count: 2,
+      trigger_mode: 'after_pdf_only',
+      teacher_page_count: pages.length,
+    };
+    const { data: lpRow, error: insertError } = await supabase
+      .from('lesson_plans')
+      .insert({
+        user_id: session.user_id,
+        topic: formData.topic || `Grade ${formData.grade} ${formData.subject}`,
+        grade: String(formData.grade || ''),
+        subject: formData.subject,
+        type: 'pic_to_lp_kieai',
+        lp_variant: 'pic_to_lp_kieai',
+        source: 'pic_to_lp_kieai',
+        delivery_time_ms: deliveryMs,
+        cost_usd: costUsd,
+        pic_lp_session_id: sessionId,
+        textbook_metadata: textbookMetadata,
+      })
+      .select('id')
+      .single();
+
+    if (insertError) {
+      logToFile('Pic-LP kieai worker: lesson_plans INSERT failed', {
+        sessionId, error: insertError.message,
+      });
+      // Don't throw — the PDF was already delivered. Continue to update
+      // session status so the user-facing flow doesn't look broken.
+    }
+
+    await PicLpSession.updateStatus(sessionId, 'handed_off');
+
+    logEvent('pic_lp.handed_off_to_lp', {
+      sessionId, from,
+      durationMs: deliveryMs,
+      backend: p1.model,
+      resolution: p1.resolution,
+      costUsd,
+      grade: formData.grade,
+      subject: formData.subject,
+      topic: formData.topic,
+      language,
+      lessonPlanId: lpRow?.id || null,
+    });
+
+    // Schedule the post-delivery feedback prompt. Feedback prompts use the
+    // teacher's preferred_language (system-message language), not
+    // formData.language (the LP CONTENT language). Look up here.
+    let userPreferredLang = 'en';
+    try {
+      const { data: userRow } = await supabase
+        .from('users')
+        .select('preferred_language')
+        .eq('id', session.user_id)
+        .maybeSingle();
+      if (userRow?.preferred_language) userPreferredLang = userRow.preferred_language;
+    } catch (_) { /* default to en */ }
+
+    if (lpRow?.id) {
+      // Lazy-require the feedback service — it isn't part of this OSS bundle.
+      // If absent, skip scheduling (logged, non-fatal).
+      try {
+        const LpFeedbackService = require('../shared/services/lp-feedback.service');
+        LpFeedbackService.scheduleFeedbackPrompt({
+          lessonPlanId: lpRow.id,
+          userId: session.user_id,
+          phone: from,
+          context: {
+            grade: formData.grade,
+            subject: formData.subject,
+            topic: formData.topic,
+            lpVariant: 'pic_to_lp_kieai',
+            triggerMode: 'after_pdf_only',
+            language: userPreferredLang, // system-message language (NOT formData.language)
+            askReasonOnYes: true,
+          },
+        });
+      } catch (feedbackErr) {
+        logToFile('Pic-LP kieai worker: feedback scheduling skipped', {
+          sessionId, error: feedbackErr.message,
+        });
+      }
+    }
+
+    return { success: true, lessonPlanId: lpRow?.id || null };
+  } catch (e) {
+    logToFile('Pic-LP kieai worker threw', { sessionId, error: e.message });
+    logEvent('pic_lp.kieai_worker_failed', { sessionId, from, error: e.message });
+    await PicLpSession.updateStatus(sessionId, 'failed', { last_error: e.message });
+    try {
+      await WhatsAppService.sendMessage(from, localizedErrorMessage(language));
+    } catch (_) { /* best-effort */ }
+    throw e; // SQS DLQ handles retry
+  } finally {
+    if (tempPdfPath && fs.existsSync(tempPdfPath)) {
+      try { fs.unlinkSync(tempPdfPath); } catch (_) { /* best-effort */ }
+    }
+  }
+}
+
+module.exports = { process, assemblePDF };

--- a/bot/workers/sqs-worker.js
+++ b/bot/workers/sqs-worker.js
@@ -322,6 +322,15 @@ class SQSCoachingWorker {
         await ExamGradingWorker.process(payload);
         break;
 
+      case 'pic_lp_kieai_generation': {
+        // Pic-to-LP via Kie.ai. English ~80s typical; Urdu/Sindhi/Punjabi
+        // ~4 min typical, up to 7 min at peak. 12-min extension covers both.
+        await SQSQueueService.extendJobTimeout(receiptHandle, 720); // 12 min
+        const PicLpKieaiWorker = require('./pic-lp-kieai.worker');
+        await PicLpKieaiWorker.process(payload);
+        break;
+      }
+
       default:
         throw new Error(`Unknown job type: ${jobType}`);
     }

--- a/docs/flows/pic-lp-confirm-flow.json
+++ b/docs/flows/pic-lp-confirm-flow.json
@@ -1,0 +1,212 @@
+{
+  "_comment": "WhatsApp Flow for Pic-to-LP — Teacher confirms grade/subject/topic/language extracted from a photographed textbook page.",
+  "_instructions": [
+    "1. Create this Flow in your WhatsApp Business Account (WABA).",
+    "2. Point its endpoint at POST /api/flows/pic-lp.",
+    "3. Single-screen form (PIC_LP_FORM) → SUCCESS.",
+    "4. Pre-filled at runtime via flow_action_payload.data — see completion-handler.service.js."
+  ],
+  "version": "6.3",
+  "data_api_version": "3.0",
+  "routing_model": {
+    "PIC_LP_FORM": ["SUCCESS"],
+    "SUCCESS": []
+  },
+  "screens": [
+    {
+      "id": "PIC_LP_FORM",
+      "title": "Lesson Plan Details",
+      "data": {
+        "grades": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "title": { "type": "string" }
+            }
+          },
+          "__example__": [
+            { "id": "1", "title": "Class 1" },
+            { "id": "2", "title": "Class 2" },
+            { "id": "3", "title": "Class 3" },
+            { "id": "4", "title": "Class 4" },
+            { "id": "5", "title": "Class 5" },
+            { "id": "6", "title": "Class 6" },
+            { "id": "7", "title": "Class 7" },
+            { "id": "8", "title": "Class 8" },
+            { "id": "9", "title": "Class 9" },
+            { "id": "10", "title": "Class 10" }
+          ]
+        },
+        "subjects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "title": { "type": "string" }
+            }
+          },
+          "__example__": [
+            { "id": "Math", "title": "Math" },
+            { "id": "English", "title": "English" },
+            { "id": "Science", "title": "Science" },
+            { "id": "Social Studies", "title": "Social Studies" },
+            { "id": "Languages", "title": "Languages" },
+            { "id": "Religious Education", "title": "Religious Education" },
+            { "id": "General Knowledge", "title": "General Knowledge" },
+            { "id": "Other", "title": "Other" }
+          ]
+        },
+        "languages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "title": { "type": "string" }
+            }
+          },
+          "__example__": [
+            { "id": "en", "title": "English" },
+            { "id": "ur", "title": "Urdu" },
+            { "id": "sd", "title": "Sindhi" },
+            { "id": "sw", "title": "Kiswahili" }
+          ]
+        },
+        "lesson_plan_formats": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id":          { "type": "string" },
+              "title":       { "type": "string" },
+              "description": { "type": "string" }
+            }
+          },
+          "__example__": [
+            { "id": "concise",  "title": "Concise",  "description": "2 pages, ~90 sec" },
+            { "id": "detailed", "title": "Detailed", "description": "7 pages, ~5 min — complete teacher guide" }
+          ]
+        },
+        "detected_grade":   { "type": "string", "__example__": "5" },
+        "detected_subject": { "type": "string", "__example__": "Math" },
+        "detected_topic":   { "type": "string", "__example__": "Addition & Subtraction" },
+        "ui_language":      { "type": "string", "__example__": "en" },
+        "default_lp_format":{ "type": "string", "__example__": "concise" },
+        "page_count":       { "type": "string", "__example__": "1" },
+        "session_id":       { "type": "string", "__example__": "00000000-0000-0000-0000-000000000000" }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "pic_lp_form",
+            "init-values": {
+              "grade": "${data.detected_grade}",
+              "subject": "${data.detected_subject}",
+              "topic": "${data.detected_topic}",
+              "language": "${data.ui_language}",
+              "lesson_plan_format": "${data.default_lp_format}"
+            },
+            "children": [
+              {
+                "type": "TextHeading",
+                "text": "Confirm Lesson Plan Details"
+              },
+              {
+                "type": "TextBody",
+                "text": "We've read the page(s) you sent. Please confirm or edit the details below — we'll generate your lesson plan once you tap Generate."
+              },
+              {
+                "type": "Dropdown",
+                "name": "grade",
+                "label": "Grade / Class",
+                "required": true,
+                "data-source": "${data.grades}"
+              },
+              {
+                "type": "Dropdown",
+                "name": "subject",
+                "label": "Subject",
+                "required": true,
+                "data-source": "${data.subjects}"
+              },
+              {
+                "type": "TextInput",
+                "name": "topic",
+                "label": "Topic / Chapter",
+                "required": true,
+                "input-type": "text",
+                "helper-text": "Edit if needed"
+              },
+              {
+                "type": "Dropdown",
+                "name": "language",
+                "label": "Lesson Plan Language",
+                "required": true,
+                "data-source": "${data.languages}"
+              },
+              {
+                "type": "RadioButtonsGroup",
+                "name": "lesson_plan_format",
+                "label": "Lesson Plan Format",
+                "required": true,
+                "data-source": "${data.lesson_plan_formats}"
+              },
+              {
+                "type": "Footer",
+                "label": "Generate Lesson Plan",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "grade": "${form.grade}",
+                    "subject": "${form.subject}",
+                    "topic": "${form.topic}",
+                    "language": "${form.language}",
+                    "lesson_plan_format": "${form.lesson_plan_format}",
+                    "session_id": "${data.session_id}"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SUCCESS",
+      "title": "Generating",
+      "terminal": true,
+      "data": {
+        "message": {
+          "type": "string",
+          "__example__": "Generating your lesson plan — it'll arrive in this chat in 1-2 minutes."
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "TextHeading",
+            "text": "Got it!"
+          },
+          {
+            "type": "TextBody",
+            "text": "${data.message}"
+          },
+          {
+            "type": "Footer",
+            "label": "Done",
+            "on-click-action": {
+              "name": "complete",
+              "payload": {}
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/infrastructure/supabase/00_complete-schema.sql
+++ b/infrastructure/supabase/00_complete-schema.sql
@@ -3382,3 +3382,73 @@ CREATE TABLE IF NOT EXISTS region_features (
     created_at TIMESTAMPTZ DEFAULT now(),
     updated_at TIMESTAMPTZ DEFAULT now()
 );
+
+-- Key/value application settings — feature flags + A/B toggles read by the bot
+-- (e.g. pic_lp_backend_ab routes the pic-to-LP backend between Kie.ai and
+-- Gamma). `value` is JSONB so a toggle can store either a scalar or a split map.
+CREATE TABLE IF NOT EXISTS app_settings (
+    key         TEXT PRIMARY KEY,
+    value       JSONB,
+    description TEXT,
+    created_at  TIMESTAMPTZ DEFAULT now(),
+    updated_at  TIMESTAMPTZ DEFAULT now()
+);
+
+DROP TRIGGER IF EXISTS update_app_settings_updated_at ON app_settings;
+CREATE TRIGGER update_app_settings_updated_at
+    BEFORE UPDATE ON app_settings
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Pic-to-LP: tracks the multi-turn conversation when a teacher photographs
+-- textbook page(s) and asks Rumi to generate a lesson plan from them. Mirrors
+-- the coaching_sessions shape (status state machine, JSONB pages array,
+-- correlation_id threading). expires_at carries the per-status TTL invariant
+-- (set in pic-lp-session.service.js) so the stale-session sweeper can expire
+-- abandoned non-terminal rows.
+CREATE TABLE IF NOT EXISTS pic_lp_sessions (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status          TEXT NOT NULL CHECK (status IN (
+                        'awaiting_intent',
+                        'collecting_pages',
+                        'awaiting_form_submit',
+                        'generating',
+                        'handed_off',
+                        'cancelled',
+                        'timed_out',
+                        'failed'
+                    )),
+    pages           JSONB NOT NULL DEFAULT '[]'::jsonb,
+    caption         TEXT,
+    detected        JSONB,
+    flow_token      TEXT,
+    lp_request_id   UUID,
+    correlation_id  TEXT,
+    last_error      TEXT,
+    expires_at      TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Hot lookup: "does this user have an active pic-LP session?" — partial index
+-- keeps it cheap (one active row per user max while they're mid-flow).
+CREATE INDEX IF NOT EXISTS idx_pic_lp_sessions_user_active
+    ON pic_lp_sessions (user_id, created_at DESC)
+    WHERE status IN ('awaiting_intent','collecting_pages','awaiting_form_submit','generating');
+
+CREATE INDEX IF NOT EXISTS idx_pic_lp_sessions_flow_token
+    ON pic_lp_sessions (flow_token)
+    WHERE flow_token IS NOT NULL;
+
+-- Cheap "is this session past its TTL?" lookup for the stale-session worker.
+-- Partial because terminal rows never need to be visited.
+CREATE INDEX IF NOT EXISTS idx_pic_lp_sessions_expires_at_active
+    ON pic_lp_sessions (expires_at)
+    WHERE status IN ('awaiting_intent','collecting_pages','awaiting_form_submit','generating');
+
+DROP TRIGGER IF EXISTS update_pic_lp_sessions_updated_at ON pic_lp_sessions;
+CREATE TRIGGER update_pic_lp_sessions_updated_at
+    BEFORE UPDATE ON pic_lp_sessions
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();

--- a/tests/pic-to-lp/classifier.test.js
+++ b/tests/pic-to-lp/classifier.test.js
@@ -1,0 +1,66 @@
+/**
+ * Pic-LP classifier — defensive defaults: returns OTHER on non-JSON output and
+ * on a thrown error. (OpenAI mocked; never hits the network.)
+ */
+
+let Classifier;
+let createImpl;
+
+function load() {
+  jest.resetModules();
+  createImpl = jest.fn();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/utils/constants', () => ({ OPENAI_API_KEY: 'test-openai-key' }));
+  jest.doMock('openai', () => {
+    return jest.fn().mockImplementation(() => ({
+      chat: { completions: { create: createImpl } },
+    }));
+  });
+  Classifier = require('../../bot/shared/services/pic-to-lp/classifier.service');
+}
+
+afterEach(() => jest.resetModules());
+
+const buf = Buffer.from('fake-image-bytes');
+
+describe('classifyImageType', () => {
+  it('returns a valid {type, confidence} on a well-formed JSON response', async () => {
+    load();
+    createImpl.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify({ type: 'BOOK_PAGE', confidence: 0.9 }) } }],
+    });
+    const r = await Classifier.classifyImageType(buf, 'image/jpeg', 'class 5 math');
+    expect(r.type).toBe('BOOK_PAGE');
+    expect(r.confidence).toBeCloseTo(0.9);
+  });
+
+  it('returns OTHER with confidence 0 on non-JSON output', async () => {
+    load();
+    createImpl.mockResolvedValue({
+      choices: [{ message: { content: 'this is not json' } }],
+    });
+    const r = await Classifier.classifyImageType(buf, 'image/jpeg');
+    expect(r).toEqual({ type: 'OTHER', confidence: 0 });
+  });
+
+  it('coerces an unrecognized type to OTHER', async () => {
+    load();
+    createImpl.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify({ type: 'NONSENSE', confidence: 0.5 }) } }],
+    });
+    const r = await Classifier.classifyImageType(buf, 'image/jpeg');
+    expect(r.type).toBe('OTHER');
+  });
+
+  it('returns OTHER with confidence 0 when the API call throws', async () => {
+    load();
+    createImpl.mockRejectedValue(new Error('network down'));
+    const r = await Classifier.classifyImageType(buf, 'image/jpeg');
+    expect(r).toEqual({ type: 'OTHER', confidence: 0 });
+  });
+
+  it('exposes the VALID_TYPES set', () => {
+    load();
+    expect(Classifier.VALID_TYPES).toEqual(['BOOK_PAGE', 'CLASSROOM', 'STUDENT_WORK', 'EXAM', 'OTHER']);
+  });
+});

--- a/tests/pic-to-lp/flow-options.test.js
+++ b/tests/pic-to-lp/flow-options.test.js
@@ -1,0 +1,77 @@
+/**
+ * Pic-LP flow-options — region-agnostic dropdown sources.
+ * The OSS build uses a single generic subject list (no PK/TZ-specific lists).
+ */
+
+const FlowOptions = require('../../bot/shared/services/pic-to-lp/flow-options');
+
+describe('flow-options', () => {
+  it('buildSubjects returns a generic list with no PK/TZ-specific subjects', () => {
+    const subjects = FlowOptions.buildSubjects('default');
+    const ids = subjects.map((s) => s.id);
+    expect(ids).toContain('Math');
+    expect(ids).toContain('English');
+    expect(ids).toContain('Science');
+    expect(ids).toContain('Other');
+    // PK/TZ-specific subjects must NOT appear in the generic OSS list.
+    expect(ids).not.toContain('Urdu');
+    expect(ids).not.toContain('Sindhi');
+    expect(ids).not.toContain('Islamiat');
+    expect(ids).not.toContain('Kiswahili');
+    expect(ids).not.toContain('Civics & Moral Education');
+    // id === title for every entry.
+    subjects.forEach((s) => expect(s.id).toBe(s.title));
+  });
+
+  it('buildSubjects ignores the region argument (same list regardless)', () => {
+    const a = FlowOptions.buildSubjects('PK');
+    const b = FlowOptions.buildSubjects('TZ');
+    const c = FlowOptions.buildSubjects();
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+  });
+
+  it('does NOT export PK_SUBJECTS / TZ_SUBJECTS, exports DEFAULT_SUBJECTS', () => {
+    expect(FlowOptions.PK_SUBJECTS).toBeUndefined();
+    expect(FlowOptions.TZ_SUBJECTS).toBeUndefined();
+    expect(Array.isArray(FlowOptions.DEFAULT_SUBJECTS)).toBe(true);
+  });
+
+  it('buildGrades returns 10 Class options (Class 1..10)', () => {
+    const grades = FlowOptions.buildGrades();
+    expect(grades).toHaveLength(10);
+    expect(grades[0]).toEqual({ id: '1', title: 'Class 1' });
+    expect(grades[9]).toEqual({ id: '10', title: 'Class 10' });
+  });
+
+  it('buildLanguages includes en/ur', () => {
+    const ids = FlowOptions.buildLanguages().map((l) => l.id);
+    expect(ids).toContain('en');
+    expect(ids).toContain('ur');
+  });
+
+  it('buildLessonPlanFormats offers only Concise when Gamma is NOT configured', () => {
+    const saved = process.env.GAMMA_API_KEY;
+    delete process.env.GAMMA_API_KEY;
+    try {
+      const ids = FlowOptions.buildLessonPlanFormats().map((f) => f.id);
+      expect(ids).toEqual(['concise']);
+      expect(FlowOptions.DEFAULT_LP_FORMAT).toBe('concise');
+    } finally {
+      if (saved === undefined) delete process.env.GAMMA_API_KEY;
+      else process.env.GAMMA_API_KEY = saved;
+    }
+  });
+
+  it('buildLessonPlanFormats adds Detailed (Gamma) only when GAMMA_API_KEY is set', () => {
+    const saved = process.env.GAMMA_API_KEY;
+    process.env.GAMMA_API_KEY = 'gamma-test';
+    try {
+      const ids = FlowOptions.buildLessonPlanFormats().map((f) => f.id);
+      expect(ids).toEqual(['concise', 'detailed']);
+    } finally {
+      if (saved === undefined) delete process.env.GAMMA_API_KEY;
+      else process.env.GAMMA_API_KEY = saved;
+    }
+  });
+});

--- a/tests/pic-to-lp/image-handler-routing.test.js
+++ b/tests/pic-to-lp/image-handler-routing.test.js
@@ -1,0 +1,146 @@
+/**
+ * Pic-to-LP routing inside image-message.handler.js.
+ *
+ * Covers tryPicLpRoute (active-session append, fresh-image enqueue, in-flight
+ * skip) and handleCoalescedBatch (BOOK_PAGE → session + intent prompt;
+ * NOT_BOOK_PAGE → generic vision fallback). All external deps are mocked.
+ */
+
+let mocks;
+
+function load() {
+  jest.resetModules();
+  mocks = {
+    whatsapp: {
+      startContinuousTypingIndicator: jest.fn(() => ({ stop: jest.fn() })),
+      sendMessage: jest.fn().mockResolvedValue({}),
+      sendInteractiveButtons: jest.fn().mockResolvedValue({}),
+      downloadMedia: jest.fn().mockResolvedValue(Buffer.from('img')),
+    },
+    vision: { analyzeWithRetry: jest.fn().mockResolvedValue({ success: true, analysis: 'ok' }) },
+    redis: { setNX: jest.fn().mockResolvedValue(true), get: jest.fn(), set: jest.fn().mockResolvedValue('OK') },
+    r2: { uploadImageWithRetry: jest.fn().mockResolvedValue('https://r2/x.jpg') },
+    session: {
+      getActiveSession: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockResolvedValue({ id: 'sess-1' }),
+      appendPage: jest.fn().mockResolvedValue({}),
+      cancelActiveForUser: jest.fn().mockResolvedValue(),
+      updateStatus: jest.fn().mockResolvedValue({}),
+    },
+    collector: {
+      appendPageAndPrompt: jest.fn().mockResolvedValue({ autoComplete: false, pageCount: 2 }),
+      onComplete: jest.fn().mockResolvedValue(),
+      promptIntent: jest.fn().mockResolvedValue(),
+      startCollectingFromIntent: jest.fn().mockResolvedValue(),
+    },
+    coalescer: { enqueue: jest.fn() },
+    classifier: { classifyImageType: jest.fn().mockResolvedValue({ type: 'BOOK_PAGE', confidence: 0.9 }) },
+  };
+
+  jest.doMock('../../bot/shared/services/whatsapp.service', () => mocks.whatsapp);
+  jest.doMock('../../bot/shared/services/vision.service', () => mocks.vision);
+  jest.doMock('../../bot/shared/services/cache/railway-redis.service', () => mocks.redis);
+  // Chainable supabase stub: every builder method returns the same object,
+  // and it is thenable so `await ...insert().select().single()` resolves to
+  // { data, error }. Enough for the image_analysis_requests insert/update path.
+  const supaChain = {
+    insert: () => supaChain,
+    update: () => supaChain,
+    select: () => supaChain,
+    eq: () => supaChain,
+    single: () => Promise.resolve({ data: { id: 'req-1' }, error: null }),
+    then: (resolve) => resolve({ data: null, error: null }),
+  };
+  jest.doMock('../../bot/shared/config/supabase', () => ({ from: jest.fn(() => supaChain) }));
+  jest.doMock('../../bot/shared/storage/r2', () => mocks.r2);
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/utils/structured-logger', () => ({
+    logEvent: jest.fn(),
+    runWithCorrelation: (id, fn) => fn(),
+    generateCorrelationId: () => 'corr-1',
+  }));
+  jest.doMock('../../bot/shared/utils/language-cache', () => ({ getUserLanguage: jest.fn().mockResolvedValue('en') }));
+  jest.doMock('../../bot/shared/database/bot-helpers', () => ({
+    storeConversation: jest.fn().mockResolvedValue(),
+    getOrCreateSession: jest.fn().mockResolvedValue('conv-1'),
+  }));
+  jest.doMock('../../bot/shared/services/pic-to-lp/pic-lp-session.service', () => mocks.session);
+  jest.doMock('../../bot/shared/services/pic-to-lp/page-collector.service', () => mocks.collector);
+  jest.doMock('../../bot/shared/services/pic-to-lp/image-batch-coalescer.service', () => mocks.coalescer);
+  jest.doMock('../../bot/shared/services/pic-to-lp/classifier.service', () => mocks.classifier);
+
+  return require('../../bot/shared/handlers/image-message.handler');
+}
+
+const user = { id: 'user-1', preferred_language: 'en' };
+const typing = { stop: jest.fn() };
+
+afterEach(() => jest.resetModules());
+
+describe('tryPicLpRoute', () => {
+  it('appends a page when a collecting_pages session is active', async () => {
+    const h = load();
+    mocks.session.getActiveSession.mockResolvedValue({ id: 'sess-1', status: 'collecting_pages' });
+    const handled = await h.__test_only_tryPicLpRoute({
+      user, from: '123', imageId: 'img-1', mimeType: 'image/jpeg', caption: '', typingController: typing,
+    });
+    expect(handled).toBe(true);
+    expect(mocks.collector.appendPageAndPrompt).toHaveBeenCalledTimes(1);
+    expect(mocks.coalescer.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('enqueues to the batch coalescer for a fresh image (no active session)', async () => {
+    const h = load();
+    mocks.session.getActiveSession.mockResolvedValue(null);
+    const handled = await h.__test_only_tryPicLpRoute({
+      user, from: '123', imageId: 'img-1', mimeType: 'image/jpeg', caption: '', typingController: typing,
+    });
+    expect(handled).toBe(true);
+    expect(mocks.coalescer.enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips (returns false) when a recent generating session is in flight', async () => {
+    const h = load();
+    mocks.session.getActiveSession.mockResolvedValue({
+      id: 'sess-1', status: 'generating', created_at: new Date().toISOString(),
+    });
+    const handled = await h.__test_only_tryPicLpRoute({
+      user, from: '123', imageId: 'img-1', mimeType: 'image/jpeg', caption: '', typingController: typing,
+    });
+    expect(handled).toBe(false);
+    expect(mocks.coalescer.enqueue).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleCoalescedBatch', () => {
+  const batch = {
+    images: [{ mediaId: 'img-1', mimeType: 'image/jpeg', typingController: typing }],
+    primary: { mediaId: 'img-1', mimeType: 'image/jpeg', typingController: typing },
+    caption: '',
+  };
+
+  it('BOOK_PAGE → creates a session and prompts for intent', async () => {
+    const h = load();
+    mocks.classifier.classifyImageType.mockResolvedValue({ type: 'BOOK_PAGE', confidence: 0.9 });
+    await h.handleCoalescedBatch({ user, from: '123', batch });
+    expect(mocks.session.create).toHaveBeenCalledTimes(1);
+    expect(mocks.collector.promptIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it('NOT_BOOK_PAGE → falls through to generic vision analysis (no LP session)', async () => {
+    const h = load();
+    mocks.classifier.classifyImageType.mockResolvedValue({ type: 'CLASSROOM', confidence: 0.95 });
+    await h.handleCoalescedBatch({ user, from: '123', batch });
+    expect(mocks.session.create).not.toHaveBeenCalled();
+    // generic vision path runs: idempotency lock + vision analysis
+    expect(mocks.vision.analyzeWithRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('low-confidence BOOK_PAGE (<0.5) is treated as NOT_BOOK_PAGE', async () => {
+    const h = load();
+    mocks.classifier.classifyImageType.mockResolvedValue({ type: 'BOOK_PAGE', confidence: 0.4 });
+    await h.handleCoalescedBatch({ user, from: '123', batch });
+    expect(mocks.session.create).not.toHaveBeenCalled();
+    expect(mocks.vision.analyzeWithRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/pic-to-lp/kieai-client.test.js
+++ b/tests/pic-to-lp/kieai-client.test.js
@@ -1,0 +1,48 @@
+/**
+ * Kie.ai client routing — pickBackend (by language) + inputFieldFor (by model).
+ * Pure functions; no network. (We mock the logger + constants so requiring the
+ * module never reaches the network.)
+ */
+
+let KieaiClient;
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/utils/constants', () => ({
+    KIE_API_KEY_PIC_LP: 'test-kie-key',
+    KIE_MAX_ATTEMPTS: 60,
+    KIE_POLL_INTERVAL: 8000,
+  }));
+  KieaiClient = require('../../bot/shared/services/pic-to-lp/kieai-client.service');
+});
+afterEach(() => jest.resetModules());
+
+describe('kieai-client.pickBackend', () => {
+  it("routes Latin-script languages ('en','sw') to gpt-image-2 at 1K", () => {
+    for (const lang of ['en', 'sw']) {
+      const b = KieaiClient.pickBackend(lang);
+      expect(b.model).toBe('gpt-image-2-image-to-image');
+      expect(b.resolution).toBe('1K');
+    }
+  });
+
+  it("routes RTL non-Latin languages ('ur','sd','pa','ar') to 2K", () => {
+    for (const lang of ['ur', 'sd', 'pa', 'ar']) {
+      const b = KieaiClient.pickBackend(lang);
+      expect(b.model).toBe('gpt-image-2-image-to-image');
+      expect(b.resolution).toBe('2K');
+    }
+  });
+});
+
+describe('kieai-client.inputFieldFor', () => {
+  it('uses input_urls for gpt-image-2 models', () => {
+    expect(KieaiClient.inputFieldFor('gpt-image-2-image-to-image')).toBe('input_urls');
+  });
+
+  it('uses image_input for other (nano-banana) models', () => {
+    expect(KieaiClient.inputFieldFor('nano-banana-pro')).toBe('image_input');
+    expect(KieaiClient.inputFieldFor('google/nano-banana-edit')).toBe('image_input');
+  });
+});

--- a/tests/pic-to-lp/kieai-prompt-builder.test.js
+++ b/tests/pic-to-lp/kieai-prompt-builder.test.js
@@ -1,0 +1,84 @@
+/**
+ * Kie.ai prompt builder — page-1/page-2 prompt assembly + the OSS coaching-number
+ * sanitization (env-driven, omitted when unset; no PK/TZ phone literals ever).
+ */
+
+let Builder;
+function load() {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  Builder = require('../../bot/shared/services/pic-to-lp/kieai-prompt-builder.service');
+}
+
+const base = { grade: 5, subject: 'Math', topic: 'Fractions', ocrText: '' };
+
+const BANNED = ['+255', '677 095', '0329', '5012345', '92 329'];
+
+afterEach(() => {
+  delete process.env.COACHING_WHATSAPP_NUMBER;
+  jest.resetModules();
+});
+
+describe('buildPage1Prompt', () => {
+  it("English page 1 contains the topic + 'Big Idea'", () => {
+    load();
+    const out = Builder.buildPage1Prompt({ ...base, language: 'en' });
+    expect(out).toContain('Fractions');
+    expect(out).toContain('Big Idea');
+  });
+
+  it('Urdu page 1 contains the Nastaliq directive', () => {
+    load();
+    const out = Builder.buildPage1Prompt({ ...base, language: 'ur' });
+    expect(out).toContain('Noto Nastaliq Urdu');
+  });
+
+  it('never emits a banned PK/TZ phone literal', () => {
+    load();
+    const out = Builder.buildPage1Prompt({ ...base, language: 'en' });
+    BANNED.forEach((b) => expect(out).not.toContain(b));
+  });
+});
+
+describe('buildPage2Prompt coaching corner — env-driven contact line', () => {
+  it('omits the "WhatsApp Rumi ·" contact line when COACHING_WHATSAPP_NUMBER is unset', () => {
+    delete process.env.COACHING_WHATSAPP_NUMBER;
+    load();
+    const en = Builder.buildPage2Prompt({ ...base, language: 'en' });
+    const ur = Builder.buildPage2Prompt({ ...base, language: 'ur' });
+    expect(en).toContain('Coaching Corner');           // corner itself kept
+    expect(en).not.toContain('WhatsApp Rumi ·');        // contact line omitted
+    expect(ur).not.toContain('WhatsApp Rumi ·');
+  });
+
+  it('includes the contact line with the configured number when set', () => {
+    process.env.COACHING_WHATSAPP_NUMBER = '+1 555 0100';
+    load();
+    const en = Builder.buildPage2Prompt({ ...base, language: 'en' });
+    const ur = Builder.buildPage2Prompt({ ...base, language: 'ur' });
+    expect(en).toContain('WhatsApp Rumi · +1 555 0100');
+    expect(ur).toContain('WhatsApp Rumi · +1 555 0100');
+  });
+
+  it('never emits a banned PK/TZ phone literal (set or unset)', () => {
+    process.env.COACHING_WHATSAPP_NUMBER = '+1 555 0100';
+    load();
+    const out = Builder.buildPage2Prompt({ ...base, language: 'en' });
+    BANNED.forEach((b) => expect(out).not.toContain(b));
+  });
+});
+
+describe('coachingNumberFor', () => {
+  it('returns the env value and ignores the region arg', () => {
+    process.env.COACHING_WHATSAPP_NUMBER = '+1 555 0100';
+    load();
+    expect(Builder.coachingNumberFor('PK')).toBe('+1 555 0100');
+    expect(Builder.coachingNumberFor('TZ')).toBe('+1 555 0100');
+  });
+
+  it("returns '' when unset", () => {
+    delete process.env.COACHING_WHATSAPP_NUMBER;
+    load();
+    expect(Builder.coachingNumberFor('PK')).toBe('');
+  });
+});

--- a/tests/pic-to-lp/lp-handoff.test.js
+++ b/tests/pic-to-lp/lp-handoff.test.js
@@ -1,0 +1,68 @@
+/**
+ * Pic-LP lp-handoff.pickBackend — presence-based safe default.
+ * When the app_settings.pic_lp_backend_ab row is missing, the OSS port routes
+ * to whichever image backend the deployment actually has keys for:
+ *   KIE key present  → 'kieai'
+ *   only GAMMA key   → 'gamma'
+ */
+
+let LpHandoff;
+
+function load() {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/utils/structured-logger', () => ({ logEvent: jest.fn() }));
+  jest.doMock('../../bot/shared/utils/constants', () => ({ TEMP_DIR: '/tmp' }));
+  jest.doMock('../../bot/shared/services/whatsapp.service', () => ({ sendMessage: jest.fn(), sendDocument: jest.fn() }));
+  jest.doMock('../../bot/shared/services/pic-to-lp/gamma-client.service', () => ({ generate: jest.fn(), SUPPORTED_LANGUAGES: ['en'] }));
+  // Missing app_settings row → maybeSingle resolves { data: null }.
+  jest.doMock('../../bot/shared/config/supabase', () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }) }) }),
+    }),
+  }));
+  LpHandoff = require('../../bot/shared/services/pic-to-lp/lp-handoff.service');
+}
+
+const ENV_KEYS = ['KIE_API_KEY', 'KIE_API_KEY_PIC_LP', 'GAMMA_API_KEY', 'PIC_LP_FORCE_GAMMA', 'PIC_LP_FORCE_KIEAI'];
+function clearEnv() { ENV_KEYS.forEach((k) => { delete process.env[k]; }); }
+
+beforeEach(clearEnv);
+afterEach(() => { clearEnv(); jest.resetModules(); });
+
+describe('lp-handoff.pickBackend (missing app_settings row)', () => {
+  it("defaults to 'kieai' when a KIE key is set", async () => {
+    process.env.KIE_API_KEY = 'kie-test';
+    load();
+    expect(await LpHandoff.pickBackend('user-1', {})).toBe('kieai');
+  });
+
+  it("defaults to 'kieai' when only the PIC_LP-specific KIE key is set", async () => {
+    process.env.KIE_API_KEY_PIC_LP = 'kie-piclp-test';
+    load();
+    expect(await LpHandoff.pickBackend('user-1', {})).toBe('kieai');
+  });
+
+  it("defaults to 'gamma' when only a GAMMA key is set", async () => {
+    process.env.GAMMA_API_KEY = 'gamma-test';
+    load();
+    expect(await LpHandoff.pickBackend('user-1', {})).toBe('gamma');
+  });
+
+  it("defaults to 'gamma' when no image-backend keys are set", async () => {
+    load();
+    expect(await LpHandoff.pickBackend('user-1', {})).toBe('gamma');
+  });
+
+  it("uses the presence-based default for a null userId too", async () => {
+    process.env.KIE_API_KEY = 'kie-test';
+    load();
+    expect(await LpHandoff.pickBackend(null, {})).toBe('kieai');
+  });
+
+  it("honors an explicit 'detailed' format pick → gamma (overrides presence)", async () => {
+    process.env.KIE_API_KEY = 'kie-test';
+    load();
+    expect(await LpHandoff.pickBackend('user-1', { lesson_plan_format: 'detailed' })).toBe('gamma');
+  });
+});

--- a/tests/pic-to-lp/pic-lp-latency.test.js
+++ b/tests/pic-to-lp/pic-lp-latency.test.js
@@ -1,0 +1,51 @@
+/**
+ * Pic-LP latency service — RPC wrapper + cache; returns null on error, shapes
+ * the row on success.
+ */
+
+let PicLpLatency;
+let rpcImpl;
+
+function load() {
+  jest.resetModules();
+  rpcImpl = jest.fn();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/config/supabase', () => ({ rpc: rpcImpl }));
+  PicLpLatency = require('../../bot/shared/services/pic-to-lp/pic-lp-latency.service');
+}
+
+beforeEach(load);
+afterEach(() => jest.resetModules());
+
+describe('getStats', () => {
+  it('returns null for a falsy source (no RPC call)', async () => {
+    expect(await PicLpLatency.getStats('')).toBeNull();
+    expect(rpcImpl).not.toHaveBeenCalled();
+  });
+
+  it('shapes p50/p90/sample_size from the RPC row', async () => {
+    rpcImpl.mockResolvedValue({ data: [{ p50_ms: 90000, p90_ms: 180000, sample_size: 12 }], error: null });
+    const r = await PicLpLatency.getStats('pic_to_lp_kieai');
+    expect(r).toEqual({ p50_ms: 90000, p90_ms: 180000, sample_size: 12 });
+  });
+
+  it('returns null on an RPC error', async () => {
+    rpcImpl.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    expect(await PicLpLatency.getStats('gamma_standard')).toBeNull();
+  });
+
+  it('returns null when the RPC throws', async () => {
+    rpcImpl.mockRejectedValue(new Error('connection refused'));
+    expect(await PicLpLatency.getStats('pic_to_lp_kieai')).toBeNull();
+  });
+
+  it('caches a successful result (second call does not re-hit the RPC)', async () => {
+    rpcImpl.mockResolvedValue({ data: [{ p50_ms: 1, p90_ms: 2, sample_size: 3 }], error: null });
+    await PicLpLatency.getStats('src');
+    await PicLpLatency.getStats('src');
+    expect(rpcImpl).toHaveBeenCalledTimes(1);
+    PicLpLatency.clearCache();
+    await PicLpLatency.getStats('src');
+    expect(rpcImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/pic-to-lp/pic-lp-session.test.js
+++ b/tests/pic-to-lp/pic-lp-session.test.js
@@ -1,0 +1,52 @@
+/**
+ * pic-lp-session service — TTL helper + status-set shapes.
+ */
+
+let PicLpSession;
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
+  PicLpSession = require('../../bot/shared/services/pic-to-lp/pic-lp-session.service');
+});
+afterEach(() => jest.resetModules());
+
+describe('ttlExpiryIsoForStatus', () => {
+  it('returns null for terminal statuses', () => {
+    for (const s of PicLpSession.TERMINAL_STATUSES) {
+      expect(PicLpSession.ttlExpiryIsoForStatus(s)).toBeNull();
+    }
+  });
+
+  it('returns a future ISO timestamp for active statuses', () => {
+    for (const s of PicLpSession.ACTIVE_STATUSES) {
+      const iso = PicLpSession.ttlExpiryIsoForStatus(s);
+      expect(typeof iso).toBe('string');
+      expect(new Date(iso).getTime()).toBeGreaterThan(Date.now());
+    }
+  });
+
+  it('returns null for an unknown status', () => {
+    expect(PicLpSession.ttlExpiryIsoForStatus('not_a_status')).toBeNull();
+  });
+});
+
+describe('status sets', () => {
+  it('ACTIVE_STATUSES are the four non-terminal states', () => {
+    expect(PicLpSession.ACTIVE_STATUSES).toEqual([
+      'awaiting_intent', 'collecting_pages', 'awaiting_form_submit', 'generating',
+    ]);
+  });
+
+  it('TERMINAL_STATUSES include cancelled/timed_out/failed/handed_off', () => {
+    expect(PicLpSession.TERMINAL_STATUSES).toEqual(
+      expect.arrayContaining(['cancelled', 'timed_out', 'failed', 'handed_off'])
+    );
+  });
+
+  it('active and terminal sets are disjoint', () => {
+    const overlap = PicLpSession.ACTIVE_STATUSES.filter((s) => PicLpSession.TERMINAL_STATUSES.includes(s));
+    expect(overlap).toHaveLength(0);
+  });
+});

--- a/tests/pic-to-lp/pic-lp-wait-message.test.js
+++ b/tests/pic-to-lp/pic-lp-wait-message.test.js
@@ -1,0 +1,59 @@
+/**
+ * Pic-LP wait-message — multilingual copy + the system/content language split
+ * that drives copy (text) vs timing (backend selection) independently.
+ */
+
+let WaitMessage;
+
+function load() {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  // Mock the backend picker so timing is deterministic: 'en'/'sw' fast (90s),
+  // everything else slow (240s) — matches the real pickBackend contract.
+  jest.doMock('../../bot/shared/services/pic-to-lp/kieai-client.service', () => ({
+    pickBackend: (lang) => (['en', 'sw'].includes(lang)
+      ? { expectedSec: 90, upperSec: 180 }
+      : { expectedSec: 240, upperSec: 420 }),
+  }));
+  WaitMessage = require('../../bot/shared/services/pic-to-lp/pic-lp-wait-message.service');
+}
+
+beforeEach(load);
+afterEach(() => jest.resetModules());
+
+describe('buildWaitMessage', () => {
+  it('English fast path mentions seconds', () => {
+    const msg = WaitMessage.buildWaitMessage({ systemLanguage: 'en', contentLanguage: 'en' });
+    expect(msg).toMatch(/seconds/);
+  });
+
+  it('English copy with slow (Urdu-routed) content language switches to minutes', () => {
+    const msg = WaitMessage.buildWaitMessage({ systemLanguage: 'en', contentLanguage: 'ur' });
+    expect(msg).toMatch(/minutes/);
+  });
+
+  it('Urdu copy is rendered for an Urdu system language', () => {
+    const msg = WaitMessage.buildWaitMessage({ systemLanguage: 'ur', contentLanguage: 'ur' });
+    expect(msg).toContain('Rumi');
+    expect(/[؀-ۿ]/.test(msg)).toBe(true);
+  });
+
+  it('falls back to English for an unknown system language', () => {
+    const msg = WaitMessage.buildWaitMessage({ systemLanguage: 'zz', contentLanguage: 'en' });
+    expect(msg).toMatch(/Generating your lesson plan/);
+  });
+
+  it('legacy single-language arg still works (used for both copy + timing)', () => {
+    const msg = WaitMessage.buildWaitMessage({ language: 'sw' });
+    expect(msg).toContain('Rumi');
+  });
+
+  it('uses live DB stats when sample_size >= 10', () => {
+    const msg = WaitMessage.buildWaitMessage({
+      systemLanguage: 'en', contentLanguage: 'en',
+      dbStats: { p50_ms: 150000, p90_ms: 200000, sample_size: 25 },
+    });
+    // 150s p50 → crosses the 120s threshold → minutes phrasing.
+    expect(msg).toMatch(/minutes/);
+  });
+});


### PR DESCRIPTION
## What

Ports the **pic-to-LP** feature: a teacher photographs a textbook page and Rumi generates a 2-page illustrated lesson-plan PDF via Kie.ai image generation (gpt-image-2). This was the remaining missing LP variant after PR #5 (curriculum pre-gen path).

### Pipeline
photo → classifier (BOOK_PAGE?) → batch coalescer → page collector → confirm Flow (grade/subject/topic/language) → `/api/flows/pic-lp` data-exchange → A/B handoff → SQS `pic_lp_kieai_generation` → worker (Kie.ai 2 pages → pdf-lib assembly → deliver).

### Files
- **Services** (`bot/shared/services/pic-to-lp/`): classifier, pic-lp-session, metadata-extractor, page-collector, image-batch-coalescer, caption-prefill, flow-options, kieai-client, kieai-prompt-builder, kieai-handoff, lp-handoff, gamma-client, completion-handler, pic-lp-wait-message, pic-lp-latency. Pedagogy deps: lp-localization, grade-calibration.
- **Integration**: `image-message.handler.js` (generic vision extracted into `runImageAnalysis` so the coalescer reuses it for non-textbook images), `whatsapp-bot.js` button wiring, `flow-endpoint.routes.js` `/pic-lp` route, `sqs-worker.js` job dispatch, `pic-lp-kieai.worker.js`, Flow JSON.
- **Schema/config**: `pic_lp_sessions` + `app_settings` tables; `KIE_API_KEY[_PIC_LP]`, `KIE_MAX_ATTEMPTS`, `KIE_POLL_INTERVAL`, `PIC_LP_FLOW_ID`, `COACHING_WHATSAPP_NUMBER` in constants + `.env.template`.

## OSS adaptations (region-agnostic · presence-based · leak-free)
- Coaching-Corner WhatsApp number is **env-driven** (`COACHING_WHATSAPP_NUMBER`); the line is omitted when unset. All hardcoded production numbers removed.
- Generic single subject list (no country branching).
- A/B backend default is presence-based (Kie.ai if its key is set, else Gamma).
- "Detailed" (Gamma) format is only offered when `GAMMA_API_KEY` is set; the Gamma branch falls back to Kie.ai if its standalone prompt service is absent.
- Quiz-interaction gate omitted until the quiz subsystem is ported.

## Tests
9 new suites; **full suite 56 suites / 821 tests green**. Independent leak grep clean (CI gitleaks runs on push).

## Follow-ups (later phases)
- Gamma "Detailed" arm needs `lesson-plan-prompts.service.js` ported to function (Kie.ai path is self-contained and is the production default).
- Worker post-delivery feedback prompt needs `lp-feedback.service.js` (lazy, non-fatal if absent).
- Restore the quiz-session gate when the quiz subsystem lands.

Closes bd-1706 (partial — pic-to-LP slice of the LP-paths bead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)