### PR TITLE
Phase 4C (PR-B) — wire quiz subsystem end-to-end

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -386,6 +386,11 @@ SQS_QUEUE_URL=
 SQS_DLQ_URL=
 SQS_PORTAL_QUEUE_URL=
 SQS_VIDEO_QUEUE_URL=
+# Dedicated quiz queue (Standard SQS — supports per-message DelaySeconds for
+# quiz reminders/expiry/report cascades). Optional: if unset, quiz delayed jobs
+# (quiz_report/quiz_expire/quiz_nudge/quiz_reminder) won't be enqueued, but the
+# interactive quiz loop (deliver + answer) still works.
+SQS_QUIZ_QUEUE_URL=
 SQS_WORKER_CONCURRENCY=3
 SQS_WORKER_HEALTH_PORT=3004
 SQS_POLL_INTERVAL=20

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -87,6 +87,52 @@ async function handleTextMessage(message, from, messageBody, user = null) {
 
   try {
     // ============================================================
+    // QUIZ STATE INTERCEPT — runs BEFORE user creation so parents (who may
+    // not have a Rumi account) can answer quizzes. Post-quiz AI chat is checked
+    // FIRST (it is the most-recent state; running getActiveState first could
+    // recover a stale 'invited' session and send the wrong nudge), then an
+    // active quiz session.
+    // ============================================================
+    if (messageBody) {
+      try {
+        const QuizSessionService = require('../services/quiz/quiz-session.service');
+
+        const postQuizState = await QuizSessionService.getPostQuizState(from);
+        if (postQuizState) {
+          const lowerQ = (messageBody || '').trim().toLowerCase();
+          if (lowerQ === 'stop' || lowerQ === 'done') {
+            await QuizSessionService.endPostQuizChat(from);
+          } else {
+            await QuizSessionService.handlePostQuizChat(from, messageBody, postQuizState);
+          }
+          typingController.stop();
+          return;
+        }
+
+        const quizState = await QuizSessionService.getActiveState(from);
+        if (quizState) {
+          const trimmedQ = messageBody.trim();
+          const lowerQ = trimmedQ.toLowerCase();
+          if (/^(start quiz|start_quiz|کوئز شروع کریں)$/i.test(trimmedQ)) {
+            await QuizSessionService.startQuizFromInvite(from);
+          } else if (lowerQ === 'stop' || trimmedQ === 'روکیں') {
+            await QuizSessionService.endSession(from, quizState, 'incomplete');
+          } else if (/^[abc]$/i.test(trimmedQ) && quizState.currentQuestionId) {
+            await QuizSessionService.handleAnswer(from, trimmedQ, quizState);
+          } else {
+            await WhatsAppService.sendMessage(from,
+              '❓ Tap one of the answer buttons above, or type A, B, or C.\n\nType STOP to exit the quiz.'
+            );
+          }
+          typingController.stop();
+          return;
+        }
+      } catch (qErr) {
+        logToFile('⚠️ Quiz state intercept error (non-fatal)', { error: qErr.message });
+      }
+    }
+
+    // ============================================================
     // DATABASE INTEGRATION: Use provided user or get/create
     // ============================================================
   if (!user) {
@@ -374,6 +420,76 @@ async function handleTextMessage(message, from, messageBody, user = null) {
     }
 
     return; // Stop further processing
+  }
+
+  // ============================================================
+  // QUIZ FOLLOW-UP: teacher tapped a follow-up button earlier ("Revise +
+  // next topic" / "Extension" / "Bridge") and we asked for the next topic.
+  // This reply is that topic — route it to the follow-up service.
+  // ============================================================
+  if (user?.id && messageBody) {
+    try {
+      const QuizFollowUpService = require('../services/quiz/quiz-follow-up.service');
+      const awaiting = await QuizFollowUpService.getAwaitingState(user.id);
+      if (awaiting) {
+        typingController.stop();
+        await QuizFollowUpService.handleNextTopicReply(user.id, from, await getUserLanguage(from) || 'en', messageBody);
+        return;
+      }
+    } catch (e) {
+      logToFile('⚠️ Quiz follow-up topic check error (non-fatal)', { error: e.message });
+    }
+  }
+
+  // ============================================================
+  // QUIZ TOPIC RESPONSE: user is replying with a quiz topic after /quiz
+  // ============================================================
+  if (user?.id) {
+    try {
+      const awaitingQuizTopic = await redis.get(`quiz:awaiting_topic:${user.id}`);
+      if (awaitingQuizTopic) {
+        const state = JSON.parse(awaitingQuizTopic);
+        await redis.del(`quiz:awaiting_topic:${user.id}`);
+        typingController.stop();
+        const QuizOrchestrator = require('../services/quiz/quiz-orchestrator.service');
+        await QuizOrchestrator.handleTopicReply(user, from, messageBody.trim(), state);
+        return;
+      }
+    } catch (error) {
+      logToFile('⚠️ Error checking quiz topic state', { userId: user?.id, error: error.message });
+    }
+  }
+
+  // ============================================================
+  // QUIZ COMMAND: /quiz [topic] — generate + send a quiz to the class.
+  // Direct path (QuizOrchestrator). A Quiz Manager Flow can be layered later
+  // via QUIZ_FLOW_ID, but the direct path needs no Meta-flow registration.
+  // ============================================================
+  if (trimmedMessage === '/quiz' || trimmedMessage.startsWith('/quiz ')) {
+    logToFile('📝 /quiz command detected', { userId: user?.id, phoneNumber: from });
+    if (!user) {
+      typingController.stop();
+      await WhatsAppService.sendMessage(
+        from,
+        'Sorry, I could not find your account. Please send me a message first to register.\n\nمعذرت، میں آپ کا اکاؤنٹ نہیں مل سکا۔'
+      );
+      return;
+    }
+    try {
+      const QuizOrchestrator = require('../services/quiz/quiz-orchestrator.service');
+      const responseLanguage = await getUserLanguage(from) || 'en';
+      const topic = trimmedMessage.replace(/^\/quiz[\s,:;\-]*/i, '').trim() || null;
+      await QuizOrchestrator.initiateQuizRequest(user, from, sessionId, responseLanguage, topic);
+      logToFile('✅ Quiz orchestration started', { userId: user.id, topic });
+    } catch (error) {
+      logToFile('❌ Error initiating quiz', { userId: user?.id, error: error.message });
+      typingController.stop();
+      await WhatsAppService.sendMessage(
+        from,
+        'Sorry, something went wrong starting the quiz. Please try again.\n\nمعذرت، کوئز شروع کرنے میں کچھ غلط ہو گیا۔'
+      );
+    }
+    return;
   }
 
   // ============================================================

--- a/bot/shared/services/queue/sqs-queue.service.js
+++ b/bot/shared/services/queue/sqs-queue.service.js
@@ -20,7 +20,7 @@
 const AWS = require('aws-sdk');
 const { logToFile } = require('../../utils/logger');
 const RedisService = require('../cache/railway-redis.service');
-const { getCurrentCorrelationId } = require('../../utils/structured-logger');
+const { getCurrentCorrelationId, logEvent } = require('../../utils/structured-logger');
 
 class SQSQueueService {
   constructor() {
@@ -34,6 +34,7 @@ class SQSQueueService {
     this.sqs = new AWS.SQS({ apiVersion: '2012-11-05' });
     this.queueUrl = process.env.SQS_QUEUE_URL;
     this.videoQueueUrl = process.env.SQS_VIDEO_QUEUE_URL;  // Dedicated video queue
+    this.quizQueueUrl = process.env.SQS_QUIZ_QUEUE_URL;    // Dedicated quiz queue (Standard — supports per-message DelaySeconds)
     this.dlqUrl = process.env.SQS_DLQ_URL;
 
     // Redis key prefix for job idempotency
@@ -45,6 +46,9 @@ class SQSQueueService {
     }
     if (this.videoQueueUrl) {
       logToFile('✅ Dedicated video queue configured', { videoQueueUrl: this.videoQueueUrl });
+    }
+    if (this.quizQueueUrl) {
+      logToFile('✅ Dedicated quiz queue configured', { quizQueueUrl: this.quizQueueUrl });
     }
   }
 
@@ -724,6 +728,147 @@ class SQSQueueService {
       });
       throw error;
     }
+  }
+
+  /**
+   * Enqueue a generic job (v2 envelope). The worker switch in sqs-worker.js
+   * routes by `body.jobType`.
+   *
+   * Routing:
+   * - quiz_* jobTypes → SQS_QUIZ_QUEUE_URL (Standard queue)
+   * - Everything else → SQS_QUEUE_URL (the main queue)
+   *
+   * Why a separate quiz queue: the main coaching queue is FIFO (at-most-once +
+   * dedup) but rejects per-message DelaySeconds. Quiz jobs need DelaySeconds
+   * (grace period + cascade re-queue), so they live in a dedicated Standard
+   * queue. Standard is at-least-once, but the quiz handler's report-sent Redis
+   * flag guards against duplicate report generation.
+   *
+   * @param {string} groupId   Logical entity id (quizId, sessionId, lpId)
+   * @param {string} jobType   Routes to the worker handler ('quiz_report', 'quiz_expire', …)
+   * @param {object} payload   Worker-specific payload (becomes body.payload)
+   * @param {object} opts      { delaySeconds?: 0..900, deduplicationId?: string (FIFO only) }
+   * @returns {Promise<string>} SQS MessageId
+   */
+  async queueJob(groupId, jobType, payload = {}, opts = {}) {
+    const isQuizJob = jobType && jobType.startsWith('quiz_');
+    const queueUrl = isQuizJob ? (this.quizQueueUrl || this.queueUrl) : this.queueUrl;
+    const isFifo = queueUrl && queueUrl.endsWith('.fifo');
+
+    if (!queueUrl) {
+      throw new Error('SQS Queue not configured (neither SQS_QUIZ_QUEUE_URL nor SQS_QUEUE_URL set)');
+    }
+
+    const correlationId = getCurrentCorrelationId();
+    const deduplicationId = opts.deduplicationId || `${groupId}-${jobType}-${Date.now()}`;
+
+    const messageBody = {
+      groupId,
+      jobType,
+      payload,
+      correlationId,
+      queuedAt: new Date().toISOString(),
+      version: '2.0',  // generic envelope; coaching/video are still v1.0
+    };
+
+    const params = {
+      QueueUrl: queueUrl,
+      MessageBody: JSON.stringify(messageBody),
+      MessageAttributes: {
+        jobType: { DataType: 'String', StringValue: jobType },
+        groupId: { DataType: 'String', StringValue: groupId },
+      },
+    };
+
+    if (isFifo) {
+      // FIFO requires both MessageGroupId and MessageDeduplicationId; rejects DelaySeconds.
+      params.MessageGroupId = groupId;
+      params.MessageDeduplicationId = deduplicationId;
+    } else {
+      // Standard queue: supports per-message DelaySeconds; no FIFO params.
+      if (opts.delaySeconds && opts.delaySeconds > 0) {
+        params.DelaySeconds = Math.min(900, opts.delaySeconds);  // SQS hard cap
+      }
+    }
+
+    const result = await this.sqs.sendMessage(params).promise();
+
+    logToFile('📤 Job queued (v2 generic envelope)', {
+      groupId, jobType,
+      messageId: result.MessageId,
+      queueType: isFifo ? 'fifo' : 'standard',
+      delaySeconds: params.DelaySeconds || 0,
+      deduplicationId: isFifo ? deduplicationId : undefined,
+    });
+    logEvent('sqs.job.queued', { correlationId, jobType, requestId: groupId, messageId: result.MessageId });
+
+    if (isQuizJob) {
+      logEvent('quiz.' + jobType.replace('quiz_', '') + '.queued', {
+        quizId: groupId,
+        messageId: result.MessageId,
+        delaySeconds: params.DelaySeconds || 0,
+      });
+    }
+
+    return result.MessageId;
+  }
+
+  /**
+   * Receive jobs from the dedicated quiz Standard queue. Mirrors receiveJobs /
+   * receiveVideoJobs but for the quiz queue (no FIFO MessageGroupId).
+   * @param {number} maxMessages  1..10
+   * @returns {Promise<Array>}    Job messages
+   */
+  async receiveQuizJobs(maxMessages = 1) {
+    if (!this.quizQueueUrl) return [];
+    try {
+      const result = await this.sqs.receiveMessage({
+        QueueUrl: this.quizQueueUrl,
+        MaxNumberOfMessages: Math.min(maxMessages, 10),
+        WaitTimeSeconds: 20,
+        VisibilityTimeout: 600,  // 10 min — quiz_report worst case (PDF + R2 upload)
+        MessageAttributeNames: ['All']
+      }).promise();
+
+      if (!result.Messages || result.Messages.length === 0) return [];
+
+      return result.Messages.map(msg => {
+        try {
+          return {
+            messageId: msg.MessageId,
+            receiptHandle: msg.ReceiptHandle,
+            body: JSON.parse(msg.Body),
+            attributes: msg.MessageAttributes || {},
+            receivedAt: new Date().toISOString()
+          };
+        } catch (parseErr) {
+          logToFile('❌ Failed to parse quiz SQS message', { messageId: msg.MessageId, error: parseErr.message });
+          return null;
+        }
+      }).filter(Boolean);
+    } catch (err) {
+      logToFile('❌ Failed to receive quiz jobs from SQS', { error: err.message });
+      throw err;
+    }
+  }
+
+  /** Acknowledge (delete) a completed quiz job. */
+  async completeQuizJob(receiptHandle) {
+    if (!this.quizQueueUrl) throw new Error('Quiz queue not configured');
+    await this.sqs.deleteMessage({
+      QueueUrl: this.quizQueueUrl,
+      ReceiptHandle: receiptHandle
+    }).promise();
+  }
+
+  /** Extend the visibility timeout for a long-running quiz job. */
+  async extendQuizJobTimeout(receiptHandle, additionalSeconds) {
+    if (!this.quizQueueUrl) throw new Error('Quiz queue not configured');
+    await this.sqs.changeMessageVisibility({
+      QueueUrl: this.quizQueueUrl,
+      ReceiptHandle: receiptHandle,
+      VisibilityTimeout: Math.min(additionalSeconds, 43200)
+    }).promise();
   }
 }
 

--- a/bot/whatsapp-bot.js
+++ b/bot/whatsapp-bot.js
@@ -749,6 +749,54 @@ app.post('/webhook', async (req, res) => {
             await PageCollector.onComplete({ sessionId, from, language: lang, trigger: 'done_clicked' });
           }
         }
+      }
+      // Quiz invite buttons (free-message path) — a parent taps "Start Quiz"
+      // or "Not now". No Rumi account required (parent isn't necessarily a user).
+      else if (buttonId === 'quiz_invite_start') {
+        const QuizSessionService = require('./shared/services/quiz/quiz-session.service');
+        logToFile('▶️ quiz_invite_start tapped', { from });
+        await QuizSessionService.startQuizFromInvite(from);
+      }
+      else if (buttonId === 'quiz_invite_skip') {
+        const QuizSessionService = require('./shared/services/quiz/quiz-session.service');
+        logToFile('⏭️ quiz_invite_skip tapped', { from });
+        const state = await QuizSessionService.getActiveState(from);
+        if (state) await QuizSessionService.endSession(from, state, 'incomplete');
+      }
+      // Quiz answer buttons: quiz_<questionId>_<A|B|C>
+      else if (/^quiz_[a-zA-Z0-9\-]+_[ABC]$/i.test(buttonId)) {
+        const QuizSessionService = require('./shared/services/quiz/quiz-session.service');
+        logToFile('🅰️ Quiz answer button tapped', { buttonId, from });
+        const state = await QuizSessionService.getActiveState(from);
+        if (state) {
+          await QuizSessionService.handleAnswer(from, buttonId, state);
+        } else {
+          logToFile('⚠️ Quiz answer tapped but no active state', { buttonId, from });
+        }
+      }
+      // Follow-up LP buttons (post-report): stash intent + ask for next topic;
+      // text-message.handler intercepts the reply and queues the LP.
+      else if (
+        buttonId.startsWith('quiz_revise_next_') ||
+        buttonId.startsWith('quiz_revise_only_') ||
+        buttonId.startsWith('quiz_extend_') ||
+        buttonId.startsWith('quiz_bridge_')
+      ) {
+        const QuizFollowUpService = require('./shared/services/quiz/quiz-follow-up.service');
+        await QuizFollowUpService.handleFollowUpButton(buttonId, user, from);
+      }
+      else if (buttonId === 'quiz_skip_followup') {
+        logToFile('⏭️ quiz_skip_followup tapped', { from, userId: user?.id });
+        // Silent skip — teacher acknowledged the report, no follow-up LP this round.
+      }
+      // Two-button confirmation on a quiz intent (send to class vs show in chat).
+      else if (buttonId === 'quiz_send_to_class' || buttonId === 'quiz_show_in_chat') {
+        try {
+          const QuizIntentRouter = require('./shared/services/quiz/quiz-intent-router.service');
+          await QuizIntentRouter.handleConfirmationButton(buttonId, user, from);
+        } catch (err) {
+          logToFile('❌ quiz intent button routing failed', { buttonId, error: err.message });
+        }
       } else {
         logToFile('⚠️ Unknown button ID', { buttonId });
       }

--- a/bot/workers/quiz-job-handler.js
+++ b/bot/workers/quiz-job-handler.js
@@ -1,0 +1,313 @@
+'use strict';
+/**
+ * SQS-side handlers for quiz job types.
+ *
+ * The bot enqueues quiz_report / quiz_expire / quiz_nudge / quiz_reminder
+ * messages via SQSQueueService.queueJob(). The SQS worker (workers/sqs-worker.js)
+ * routes by `body.jobType` to handleQuizJob() below.
+ *
+ * Each handler does three things in order:
+ *   1. Cancel-flag check: read Redis key `sqs:cancel:<jobType>:<groupId>`.
+ *      If set, short-circuit (return without doing work). The worker
+ *      acknowledges the message on success-return, so the cancelled job
+ *      is removed from the queue.
+ *   2. Cascade re-queue (quiz_report + quiz_expire only): SQS DelaySeconds
+ *      caps at 900s. For longer waits (12h fallback timer, 24h session
+ *      expiry) the handler re-queues with another 15-min delay until the
+ *      condition is met.
+ *   3. Do the actual work: generateReport / DB flip / WhatsApp send.
+ *
+ * Handlers are exported individually so they can be unit-tested without
+ * spinning up the full SQS worker. handleQuizJob() is the dispatcher
+ * called from sqs-worker.js's switch statement.
+ */
+
+const { logToFile } = require('../shared/utils/logger');
+const { logEvent } = require('../shared/utils/structured-logger');
+const supabase = require('../shared/config/supabase');
+const RedisService = require('../shared/services/cache/railway-redis.service');
+const SQSQueueService = require('../shared/services/queue/sqs-queue.service');
+
+const TERMINAL_SESSION_STATES = ['completed', 'incomplete', 'expired', 'cancelled'];
+const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
+const SQS_MAX_DELAY_SECONDS = 900;  // 15 min — SQS hard cap
+
+// ─── Cancel-flag check (shared) ─────────────────────────────────────────────
+
+/**
+ * Check whether a Redis cancellation flag is set for this job.
+ * The flag is written by SQSQueueService.cancelByGroupId() with 1h TTL.
+ */
+async function isCancelled(jobType, groupId) {
+  try {
+    const flag = await RedisService.get(`sqs:cancel:${jobType}:${groupId}`);
+    return !!flag;
+  } catch (err) {
+    // Probe failures default to "not cancelled" — better to risk firing a
+    // cancelled report than block deliveries on a Redis blip.
+    logToFile('⚠️ isCancelled probe failed (defaulting to not-cancelled)', { jobType, groupId, error: err.message });
+    return false;
+  }
+}
+
+// ─── quiz_report ────────────────────────────────────────────────────────────
+
+async function handleQuizReport(body) {
+  const quizId = body.groupId;
+  const payload = body.payload || {};
+
+  logEvent('quiz.report.dequeued', { quizId });
+
+  if (await isCancelled('quiz_report', quizId)) {
+    logToFile('🛑 quiz_report cancelled — skipping', { quizId });
+    logEvent('quiz.report.skipped', { quizId, reason: 'cancelled' });
+    return { skipped: true, reason: 'cancelled' };
+  }
+
+  // Idempotency. Prevents double-firing when both the initial 12h-cascade
+  // message (enqueued at delivery, delaySeconds=900) and the finalized message
+  // (enqueued when all sessions are terminal, delaySeconds=60) target the same
+  // quiz. Whichever wins the race fires the report and sets this flag; the
+  // loser short-circuits cleanly. 24h TTL > the 12h cascade ceiling so a stale
+  // cascade can't slip through after the report's already gone out.
+  const SENT_FLAG_KEY = `quiz_report_sent:${quizId}`;
+  if (await RedisService.get(SENT_FLAG_KEY)) {
+    logToFile('🔁 quiz_report already fired for this quiz — skipping (cascade dedup)', { quizId });
+    logEvent('quiz.report.skipped', { quizId, reason: 'already_fired' });
+    return { skipped: true, reason: 'already_fired' };
+  }
+
+  // Lookup quiz row (also pull teacher_id so we can resolve teacherPhone from
+  // the DB when the payload arrived empty — happens with the 60s grace message
+  // which doesn't pass teacherPhone since the call site doesn't have it).
+  const { data: quiz } = await supabase
+    .from('quizzes')
+    .select('id, teacher_id, created_at, status')
+    .eq('id', quizId)
+    .single();
+
+  if (!quiz) {
+    logToFile('ℹ️ quiz_report: quiz row not found — skipping', { quizId });
+    logEvent('quiz.report.skipped', { quizId, reason: 'quiz_not_found' });
+    return { skipped: true, reason: 'quiz_not_found' };
+  }
+
+  // Defensive: if the quiz was cancelled AFTER the message was queued AND the
+  // Redis cancel flag is missing (TTL expired or cancelByGroupId failed), the
+  // quiz.status='cancelled' read still protects us.
+  if (quiz.status === 'cancelled') {
+    logToFile('ℹ️ quiz_report: quiz already cancelled — skipping', { quizId });
+    logEvent('quiz.report.skipped', { quizId, reason: 'quiz_already_cancelled' });
+    return { skipped: true, reason: 'quiz_already_cancelled' };
+  }
+
+  // Lookup peer sessions
+  const { data: peers } = await supabase
+    .from('quiz_sessions')
+    .select('status')
+    .eq('quiz_id', quizId);
+
+  const allFinal = peers && peers.length > 0 && peers.every(s => TERMINAL_SESSION_STATES.includes(s.status));
+  const ageMs = Date.now() - new Date(quiz.created_at).getTime();
+  const past12h = ageMs > TWELVE_HOURS_MS;
+
+  if (!allFinal && !past12h) {
+    // Cascade re-queue: not finalised yet, not yet 12h old → check again in 15 min
+    await SQSQueueService.queueJob(quizId, 'quiz_report', payload, {
+      delaySeconds: SQS_MAX_DELAY_SECONDS,
+      deduplicationId: `${quizId}-quiz_report-recheck-${Date.now()}`
+    });
+    logToFile('⏩ quiz_report not yet ready — re-queued for 15 min', { quizId, ageMs, peerCount: peers?.length || 0 });
+    logEvent('quiz.report.cascade_requeued', { quizId, ageMs, peerCount: peers?.length || 0, allFinal });
+    return { skipped: true, reason: 'requeued', ageMs };
+  }
+
+  // Resolve teacherPhone before firing the report. Two sources in priority
+  // order: payload.teacherPhone → quiz.teacher_id → users.phone_number.
+  // If both miss, we MUST NOT set quiz_report_sent below — otherwise the
+  // sibling 15-min cascade message (which DOES carry teacherPhone) will hit
+  // the flag and skip with reason='already_fired'.
+  let teacherPhone = payload.teacherPhone;
+  if (!teacherPhone && quiz.teacher_id) {
+    const { data: teacher } = await supabase
+      .from('users')
+      .select('phone_number')
+      .eq('id', quiz.teacher_id)
+      .single();
+    if (teacher && teacher.phone_number) {
+      const raw = String(teacher.phone_number);
+      teacherPhone = raw.startsWith('+') ? raw : `+${raw}`;
+    }
+  }
+
+  if (!teacherPhone) {
+    logToFile('⚠️ quiz_report: no teacher phone could be resolved — skipping (retry stays alive, idempotency flag NOT set)', { quizId, teacherIdPresent: !!quiz.teacher_id });
+    logEvent('quiz.report.skipped', { quizId, reason: 'no_teacher_phone' });
+    return { skipped: true, reason: 'no_teacher_phone' };
+  }
+
+  // Generate the report (12h timeout safety OR all sessions terminal)
+  logEvent('quiz.report.generation_started', { quizId, allFinal, past12h, peerCount: peers?.length || 0 });
+  const QuizReportService = require('../shared/services/quiz/quiz-report.service');
+  await QuizReportService.generateReport(quizId, { ...payload, teacherPhone });
+  logEvent('quiz.report.fired', { quizId });
+
+  // Mark fired so cascade dedup short-circuits any future dequeue for this
+  // quiz. 24h TTL — well past the 12h cascade ceiling.
+  try {
+    await RedisService.set(SENT_FLAG_KEY, '1', 86400);
+  } catch (err) {
+    logToFile('⚠️ Could not set quiz_report_sent flag (non-fatal — cascade may double-fire)', { quizId, error: err.message });
+  }
+
+  return { ok: true };
+}
+
+// ─── quiz_expire ────────────────────────────────────────────────────────────
+
+async function handleQuizExpire(body) {
+  const sessionId = body.groupId;
+  const payload = body.payload || {};
+
+  if (await isCancelled('quiz_expire', sessionId)) {
+    return { skipped: true, reason: 'cancelled' };
+  }
+
+  const { data: session } = await supabase
+    .from('quiz_sessions')
+    .select('id, status, expires_at, parent_phone')
+    .eq('id', sessionId)
+    .maybeSingle();
+
+  if (!session) {
+    return { skipped: true, reason: 'session_not_found' };
+  }
+  if (TERMINAL_SESSION_STATES.includes(session.status)) {
+    return { skipped: true, reason: 'already_terminal' };
+  }
+
+  const expiresMs = new Date(session.expires_at).getTime();
+  const remainingMs = expiresMs - Date.now();
+
+  if (remainingMs > 0) {
+    // Not yet expired — cascade re-queue
+    const delaySeconds = Math.min(SQS_MAX_DELAY_SECONDS, Math.ceil(remainingMs / 1000));
+    await SQSQueueService.queueJob(sessionId, 'quiz_expire', payload, {
+      delaySeconds,
+      deduplicationId: `${sessionId}-quiz_expire-recheck-${Date.now()}`
+    });
+    return { skipped: true, reason: 'requeued', remainingMs };
+  }
+
+  // Past expiry — flip 'invited'/'in_progress' → 'expired' for THIS session
+  // (and only this session — broader sweeps belong elsewhere).
+  await supabase
+    .from('quiz_sessions')
+    .update({ status: 'expired' })
+    .eq('id', sessionId)
+    .in('status', ['invited', 'in_progress']);
+
+  // Clear Redis ACTIVE_KEY only if it still points to this session
+  // (don't trample a fresh quiz the parent has just been invited to).
+  if (session.parent_phone) {
+    const stripPlus = (p) => (p || '').replace(/^\+/, '');
+    const key = `quiz:student:${stripPlus(session.parent_phone)}:active`;
+    try {
+      const existing = await RedisService.get(key);
+      if (existing) {
+        try {
+          const parsed = JSON.parse(existing);
+          if (parsed && parsed.sessionId === sessionId) {
+            await RedisService.del(key);
+            logToFile('🧹 quiz_expire: cleared stale Redis ACTIVE_KEY', {
+              sessionId, phone: session.parent_phone.slice(-4)
+            });
+          }
+        } catch (parseErr) {
+          // Malformed Redis value — leave it alone, delivery-side cleanup catches it
+        }
+      }
+    } catch (rErr) {
+      logToFile('⚠️ quiz_expire: Redis cleanup error (non-fatal)', { sessionId, error: rErr.message });
+    }
+  }
+
+  return { ok: true };
+}
+
+// ─── quiz_nudge ─────────────────────────────────────────────────────────────
+
+async function handleQuizNudge(body) {
+  const groupId = body.groupId;
+  const payload = body.payload || {};
+
+  if (await isCancelled('quiz_nudge', groupId)) {
+    return { skipped: true, reason: 'cancelled' };
+  }
+
+  if (!payload.teacherPhone || !payload.topic || !payload.lpId) {
+    logToFile('⚠️ quiz_nudge: missing required payload fields — skipping', { groupId });
+    return { skipped: true, reason: 'missing_payload_fields' };
+  }
+
+  const WhatsAppService = require('../shared/services/whatsapp.service');
+  await WhatsAppService.sendInteractiveButtons(payload.teacherPhone, {
+    body: `Hi! You generated a lesson plan on "${payload.topic}" earlier.\n\nWould you like to send a quiz to your students? 📝`,
+    buttons: [
+      { id: `quiz_yes_send_${payload.lpId}`, title: 'Yes, send quiz ✓' },
+      { id: 'quiz_maybe_later', title: 'Maybe later' }
+    ]
+  });
+
+  await supabase
+    .from('lesson_plans')
+    .update({ quiz_nudge_sent: true })
+    .eq('id', payload.lpId);
+
+  return { ok: true };
+}
+
+// ─── quiz_reminder ──────────────────────────────────────────────────────────
+
+async function handleQuizReminder(body) {
+  const groupId = body.groupId;
+  const payload = body.payload || {};
+
+  if (await isCancelled('quiz_reminder', groupId)) {
+    return { skipped: true, reason: 'cancelled' };
+  }
+
+  if (!payload.parentPhone || !payload.topic) {
+    return { skipped: true, reason: 'missing_payload_fields' };
+  }
+
+  const WhatsAppService = require('../shared/services/whatsapp.service');
+  await WhatsAppService.sendMessage(
+    payload.parentPhone,
+    `Still there? Your quiz on "${payload.topic}" is waiting! Tap an answer above to continue. 📚`
+  );
+
+  return { ok: true };
+}
+
+// ─── Dispatcher (called from sqs-worker.js) ─────────────────────────────────
+
+async function handleQuizJob(jobType, body) {
+  switch (jobType) {
+    case 'quiz_report':   return handleQuizReport(body);
+    case 'quiz_expire':   return handleQuizExpire(body);
+    case 'quiz_nudge':    return handleQuizNudge(body);
+    case 'quiz_reminder': return handleQuizReminder(body);
+    default:
+      throw new Error(`Unknown quiz job type: ${jobType}`);
+  }
+}
+
+module.exports = {
+  handleQuizJob,
+  handleQuizReport,
+  handleQuizExpire,
+  handleQuizNudge,
+  handleQuizReminder,
+  isCancelled,
+};

--- a/bot/workers/sqs-worker.js
+++ b/bot/workers/sqs-worker.js
@@ -133,30 +133,33 @@ class SQSCoachingWorker {
    */
   async processNextBatch(maxMessages) {
     try {
-      // Poll main queue and video queue in parallel for efficiency
+      // Poll main + (optional) video + (optional) quiz queues in parallel.
       const hasVideoQueue = !!process.env.SQS_VIDEO_QUEUE_URL;
+      const hasQuizQueue = !!process.env.SQS_QUIZ_QUEUE_URL;
 
-      // Allocate slots between queues
-      // If video queue is configured, reserve 1 slot for video jobs
-      const mainQueueSlots = hasVideoQueue ? Math.max(1, maxMessages - 1) : maxMessages;
-      const videoQueueSlots = hasVideoQueue ? 1 : 0;
+      // Reserve 1 slot for each dedicated queue that's configured.
+      const dedicated = (hasVideoQueue ? 1 : 0) + (hasQuizQueue ? 1 : 0);
+      const mainQueueSlots = dedicated ? Math.max(1, maxMessages - dedicated) : maxMessages;
 
       // Poll queues in parallel
       const pollPromises = [
         SQSQueueService.receiveJobs(mainQueueSlots)
       ];
+      if (hasVideoQueue) pollPromises.push(SQSQueueService.receiveVideoJobs(1));
+      if (hasQuizQueue) pollPromises.push(SQSQueueService.receiveQuizJobs(1));
 
-      if (hasVideoQueue) {
-        pollPromises.push(SQSQueueService.receiveVideoJobs(videoQueueSlots));
-      }
-
-      const [mainJobs, videoJobs = []] = await Promise.all(pollPromises);
+      const results = await Promise.all(pollPromises);
+      const mainJobs = results[0] || [];
+      let idx = 1;
+      const videoJobs = hasVideoQueue ? (results[idx++] || []) : [];
+      const quizJobs = hasQuizQueue ? (results[idx++] || []) : [];
 
       // Mark jobs with their source queue for proper completion
       mainJobs.forEach(job => { job.sourceQueue = 'main'; });
       videoJobs.forEach(job => { job.sourceQueue = 'video'; });
+      quizJobs.forEach(job => { job.sourceQueue = 'quiz'; });
 
-      const allJobs = [...mainJobs, ...videoJobs];
+      const allJobs = [...mainJobs, ...videoJobs, ...quizJobs];
 
       if (allJobs.length === 0) {
         // No jobs available (normal - SQS long polling will wait)
@@ -209,11 +212,13 @@ class SQSCoachingWorker {
     // Create job promise wrapped with correlation context
     // All logs within the job will automatically include correlationId
     const jobPromise = runWithCorrelation(correlationId, async () => {
-      return this.executeJob(sessionId, jobType, payload, receiptHandle, sourceQueue)
+      return this.executeJob(sessionId, jobType, payload, receiptHandle, sourceQueue, body)
         .then(async () => {
           // Job succeeded - delete from queue using correct completion method
           if (sourceQueue === 'video') {
             await SQSQueueService.completeVideoJob(receiptHandle);
+          } else if (sourceQueue === 'quiz') {
+            await SQSQueueService.completeQuizJob(receiptHandle);
           } else {
             await SQSQueueService.completeJob(receiptHandle);
           }
@@ -261,7 +266,7 @@ class SQSCoachingWorker {
    * @param {string} receiptHandle - SQS receipt handle
    * @param {string} sourceQueue - Source queue ('main' or 'video')
    */
-  async executeJob(sessionId, jobType, payload, receiptHandle, sourceQueue = 'main') {
+  async executeJob(sessionId, jobType, payload, receiptHandle, sourceQueue = 'main', body = null) {
     logToFile(`🔄 Executing ${jobType} job`, {
       workerId: this.workerId,
       sessionId,
@@ -331,9 +336,54 @@ class SQSCoachingWorker {
         break;
       }
 
+      // Quiz jobs (v2 envelope with body.groupId). Producers enqueue via
+      // SQSQueueService.queueJob(); each handler in quiz-job-handler does a
+      // cancel-flag check, an optional cascade re-queue (quiz_report/quiz_expire),
+      // then the work. Returns { ok } or { skipped } — either way we ack.
+      case 'quiz_report': {
+        // PDF render + R2 upload + WhatsApp send (up to ~10 min worst case).
+        if (sourceQueue === 'quiz') {
+          await SQSQueueService.extendQuizJobTimeout(receiptHandle, 600);
+        } else {
+          await SQSQueueService.extendJobTimeout(receiptHandle, 600);
+        }
+        const QuizJobHandler = require('./quiz-job-handler');
+        await QuizJobHandler.handleQuizReport(this._buildQuizBody(body));
+        break;
+      }
+      case 'quiz_expire': {
+        const QuizJobHandler = require('./quiz-job-handler');
+        await QuizJobHandler.handleQuizExpire(this._buildQuizBody(body));
+        break;
+      }
+      case 'quiz_nudge': {
+        const QuizJobHandler = require('./quiz-job-handler');
+        await QuizJobHandler.handleQuizNudge(this._buildQuizBody(body));
+        break;
+      }
+      case 'quiz_reminder': {
+        const QuizJobHandler = require('./quiz-job-handler');
+        await QuizJobHandler.handleQuizReminder(this._buildQuizBody(body));
+        break;
+      }
+
       default:
         throw new Error(`Unknown job type: ${jobType}`);
     }
+  }
+
+  /**
+   * Build the body shape quiz-job-handler expects from either envelope.
+   * v2.0 messages have body.groupId; v1.0 (legacy coaching/video) have
+   * sessionId / videoRequestId. Aliasing here lets quiz job-types ride the
+   * same worker without touching existing producers.
+   */
+  _buildQuizBody(body) {
+    const b = body || {};
+    return {
+      groupId: b.groupId || b.sessionId || b.videoRequestId,
+      payload: b.payload || {}
+    };
   }
 
   /**

--- a/tests/quiz/quiz-job-handler.test.js
+++ b/tests/quiz/quiz-job-handler.test.js
@@ -1,0 +1,133 @@
+/**
+ * quiz-job-handler — SQS-side quiz job handlers (cancel-flag, idempotency,
+ * cascade re-queue, fire). All deps mocked; no network/DB.
+ */
+
+let redis, supabaseTables, sqsQueue, quizReport, whatsapp, handler;
+
+function makeSupabase() {
+  // Per-table terminal results, settable per test.
+  return {
+    from(table) {
+      const t = table;
+      const builder = {
+        _t: t,
+        select() { return builder; },
+        eq() { return builder; },
+        in() { return builder; },
+        update() { return builder; },
+        single() { return Promise.resolve(supabaseTables[t]?.single ?? { data: null }); },
+        maybeSingle() { return Promise.resolve(supabaseTables[t]?.maybeSingle ?? { data: null }); },
+        then(resolve) { return resolve(supabaseTables[t]?.list ?? { data: [] }); },
+      };
+      return builder;
+    },
+  };
+}
+
+function load() {
+  jest.resetModules();
+  redis = { get: jest.fn().mockResolvedValue(null), set: jest.fn().mockResolvedValue('OK'), del: jest.fn().mockResolvedValue(1) };
+  supabaseTables = {};
+  sqsQueue = { queueJob: jest.fn().mockResolvedValue('msg-id') };
+  quizReport = { generateReport: jest.fn().mockResolvedValue() };
+  whatsapp = { sendMessage: jest.fn().mockResolvedValue({}), sendInteractiveButtons: jest.fn().mockResolvedValue({}) };
+
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/utils/structured-logger', () => ({ logEvent: jest.fn() }));
+  jest.doMock('../../bot/shared/config/supabase', () => makeSupabase(), { virtual: true });
+  jest.doMock('../../bot/shared/services/cache/railway-redis.service', () => redis);
+  jest.doMock('../../bot/shared/services/queue/sqs-queue.service', () => sqsQueue);
+  jest.doMock('../../bot/shared/services/quiz/quiz-report.service', () => quizReport, { virtual: true });
+  jest.doMock('../../bot/shared/services/whatsapp.service', () => whatsapp, { virtual: true });
+  handler = require('../../bot/workers/quiz-job-handler');
+  return handler;
+}
+
+afterEach(() => jest.resetModules());
+
+describe('handleQuizReport', () => {
+  it('skips when the cancel flag is set', async () => {
+    const h = load();
+    redis.get.mockImplementation((k) => Promise.resolve(k.startsWith('sqs:cancel:') ? '1' : null));
+    const r = await h.handleQuizReport({ groupId: 'q1', payload: {} });
+    expect(r).toEqual({ skipped: true, reason: 'cancelled' });
+    expect(quizReport.generateReport).not.toHaveBeenCalled();
+  });
+
+  it('skips when already fired (cascade dedup)', async () => {
+    const h = load();
+    redis.get.mockImplementation((k) => Promise.resolve(k === 'quiz_report_sent:q1' ? '1' : null));
+    const r = await h.handleQuizReport({ groupId: 'q1', payload: {} });
+    expect(r.reason).toBe('already_fired');
+  });
+
+  it('cascade re-queues when sessions not all final and < 12h old', async () => {
+    const h = load();
+    supabaseTables.quizzes = { single: { data: { id: 'q1', teacher_id: 't1', created_at: new Date().toISOString(), status: 'sent' } } };
+    supabaseTables.quiz_sessions = { list: { data: [{ status: 'in_progress' }] } };
+    const r = await h.handleQuizReport({ groupId: 'q1', payload: {} });
+    expect(r.reason).toBe('requeued');
+    expect(sqsQueue.queueJob).toHaveBeenCalledWith('q1', 'quiz_report', expect.anything(), expect.objectContaining({ delaySeconds: 900 }));
+    expect(quizReport.generateReport).not.toHaveBeenCalled();
+  });
+
+  it('fires the report when all sessions terminal and a teacher phone resolves', async () => {
+    const h = load();
+    supabaseTables.quizzes = { single: { data: { id: 'q1', teacher_id: 't1', created_at: new Date().toISOString(), status: 'sent' } } };
+    supabaseTables.quiz_sessions = { list: { data: [{ status: 'completed' }] } };
+    supabaseTables.users = { single: { data: { phone_number: '12025550100' } } };
+    const r = await h.handleQuizReport({ groupId: 'q1', payload: {} });
+    expect(r).toEqual({ ok: true });
+    expect(quizReport.generateReport).toHaveBeenCalledTimes(1);
+    expect(redis.set).toHaveBeenCalledWith('quiz_report_sent:q1', '1', 86400);
+  });
+
+  it('does NOT set the sent flag when no teacher phone resolves', async () => {
+    const h = load();
+    supabaseTables.quizzes = { single: { data: { id: 'q1', teacher_id: null, created_at: new Date().toISOString(), status: 'sent' } } };
+    supabaseTables.quiz_sessions = { list: { data: [{ status: 'completed' }] } };
+    const r = await h.handleQuizReport({ groupId: 'q1', payload: {} });
+    expect(r.reason).toBe('no_teacher_phone');
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleQuizExpire', () => {
+  it('re-queues while the session is still before expiry', async () => {
+    const h = load();
+    supabaseTables.quiz_sessions = { maybeSingle: { data: { id: 's1', status: 'in_progress', expires_at: new Date(Date.now() + 5 * 60000).toISOString() } } };
+    const r = await h.handleQuizExpire({ groupId: 's1', payload: {} });
+    expect(r.reason).toBe('requeued');
+    expect(sqsQueue.queueJob).toHaveBeenCalled();
+  });
+
+  it('skips when the session is already terminal', async () => {
+    const h = load();
+    supabaseTables.quiz_sessions = { maybeSingle: { data: { id: 's1', status: 'completed' } } };
+    const r = await h.handleQuizExpire({ groupId: 's1', payload: {} });
+    expect(r.reason).toBe('already_terminal');
+  });
+});
+
+describe('handleQuizNudge / handleQuizReminder', () => {
+  it('nudge skips on missing payload fields', async () => {
+    const h = load();
+    const r = await h.handleQuizNudge({ groupId: 'lp1', payload: { topic: 'x' } });
+    expect(r.reason).toBe('missing_payload_fields');
+  });
+
+  it('reminder sends when payload complete', async () => {
+    const h = load();
+    const r = await h.handleQuizReminder({ groupId: 's1', payload: { parentPhone: '12025550100', topic: 'Fractions' } });
+    expect(r).toEqual({ ok: true });
+    expect(whatsapp.sendMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleQuizJob dispatcher', () => {
+  it('throws on unknown job type', async () => {
+    const h = load();
+    await expect(h.handleQuizJob('quiz_bogus', { groupId: 'x' })).rejects.toThrow(/Unknown quiz job type/);
+  });
+});

--- a/tests/quiz/sqs-queue-quiz.test.js
+++ b/tests/quiz/sqs-queue-quiz.test.js
@@ -1,0 +1,68 @@
+/**
+ * sqs-queue.service.queueJob — quiz jobs route to the dedicated quiz Standard
+ * queue with per-message DelaySeconds; non-quiz jobs go to the main queue.
+ * aws-sdk is virtually mocked (bot-only dep, not installed at root test time).
+ */
+
+let sendMessageMock;
+const MAIN = 'https://sqs/main';
+const QUIZ = 'https://sqs/quiz';
+
+function load() {
+  jest.resetModules();
+  sendMessageMock = jest.fn(() => ({ promise: () => Promise.resolve({ MessageId: 'm1' }) }));
+  jest.doMock('aws-sdk', () => ({
+    config: { update: jest.fn() },
+    SQS: jest.fn(() => ({ sendMessage: sendMessageMock })),
+  }), { virtual: true });
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/services/cache/railway-redis.service', () => ({}), { virtual: true });
+  jest.doMock('../../bot/shared/utils/structured-logger', () => ({ getCurrentCorrelationId: () => 'c1', logEvent: jest.fn() }));
+
+  process.env.SQS_QUEUE_URL = MAIN;
+  process.env.SQS_QUIZ_QUEUE_URL = QUIZ;
+  return require('../../bot/shared/services/queue/sqs-queue.service');
+}
+
+afterEach(() => {
+  jest.resetModules();
+  delete process.env.SQS_QUIZ_QUEUE_URL;
+});
+
+describe('queueJob routing', () => {
+  it('routes a quiz_* job to the quiz queue with DelaySeconds', async () => {
+    const q = load();
+    await q.queueJob('quiz1', 'quiz_report', { foo: 1 }, { delaySeconds: 60 });
+    const params = sendMessageMock.mock.calls[0][0];
+    expect(params.QueueUrl).toBe(QUIZ);
+    expect(params.DelaySeconds).toBe(60);
+    expect(JSON.parse(params.MessageBody)).toMatchObject({ groupId: 'quiz1', jobType: 'quiz_report', version: '2.0' });
+  });
+
+  it('caps DelaySeconds at the SQS hard limit (900)', async () => {
+    const q = load();
+    await q.queueJob('quiz1', 'quiz_expire', {}, { delaySeconds: 5000 });
+    expect(sendMessageMock.mock.calls[0][0].DelaySeconds).toBe(900);
+  });
+
+  it('routes a non-quiz job to the main queue', async () => {
+    const q = load();
+    await q.queueJob('lp1', 'some_other_job', {});
+    expect(sendMessageMock.mock.calls[0][0].QueueUrl).toBe(MAIN);
+  });
+
+  it('receiveQuizJobs returns [] when no quiz queue is configured', async () => {
+    delete process.env.SQS_QUIZ_QUEUE_URL;
+    const q = load();
+    delete process.env.SQS_QUIZ_QUEUE_URL; // ensure unset post-require too
+    // re-require with quiz url unset
+    jest.resetModules();
+    jest.doMock('aws-sdk', () => ({ config: { update: jest.fn() }, SQS: jest.fn(() => ({ sendMessage: sendMessageMock })) }), { virtual: true });
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/services/cache/railway-redis.service', () => ({}), { virtual: true });
+    jest.doMock('../../bot/shared/utils/structured-logger', () => ({ getCurrentCorrelationId: () => 'c1', logEvent: jest.fn() }));
+    process.env.SQS_QUEUE_URL = MAIN;
+    const q2 = require('../../bot/shared/services/queue/sqs-queue.service');
+    await expect(q2.receiveQuizJobs(1)).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## What
Activates the quiz services from PR-A (#8) by wiring the integration surface. Quiz is now usable end-to-end: a teacher runs `/quiz [topic]`, parents answer over WhatsApp, and reports/reminders/expiry run via a dedicated SQS queue.

- **`sqs-queue.service`** (shared — **additive only**, no existing method changed): `quizQueueUrl` + generic `queueJob()` v2 envelope (quiz_* → dedicated Standard queue with per-message `DelaySeconds`; else → main queue) + `receiveQuizJobs`/`completeQuizJob`/`extendQuizJobTimeout`, mirroring the video-queue methods.
- **`sqs-worker`**: polls the quiz queue, completes via `completeQuizJob`, and dispatches `quiz_report`/`quiz_expire`/`quiz_nudge`/`quiz_reminder` → newly-ported `quiz-job-handler` (cancel-flag check, cascade re-queue, idempotency, the work).
- **`text-message.handler`**: quiz state intercept **before user creation** (parents answer without an account) — post-quiz chat first, then active quiz; plus `/quiz [topic]` command, awaiting-topic reply, and follow-up next-topic capture.
- **`whatsapp-bot.js`**: quiz buttons (invite start/skip, answer regex, follow-up revise/extend/bridge, skip-followup, send-to-class/show-in-chat).
- **`.env.template`**: `SQS_QUIZ_QUEUE_URL` (optional — interactive quiz works without it; only delayed jobs need it).

## Safety
The shared `sqs-queue.service` change is **purely additive** (one constructor line + one import + four new methods) — existing coaching/video/main consumers are untouched. Verified additive via diff.

## Tests
`quiz-job-handler` (cancel / idempotency / cascade re-queue / fire / expire / nudge / reminder / dispatcher) + `sqs-queue.queueJob` routing (quiz→quiz-queue + DelaySeconds cap, non-quiz→main). **Full suite 68 suites / 912 tests green.** Added lines leak-clean.

## Deferred (refinements, noted in plan)
Quiz Manager Flow (`QUIZ_FLOW_ID`) + NL quiz-intent detection. The `/quiz` command + post-LP nudge are the entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)