### PR TITLE
feat(settings): user settings flow (language + observation framework) — Phase 4E

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -86,6 +86,15 @@ APP_URL=https://your-app.up.railway.app
 # per region; no code changes needed. Leave as 'default' for the generic setup.
 DEFAULT_REGION=default
 
+# Default observation framework shown in the settings flow (oecd|hots|teach|fico).
+DEFAULT_OBSERVATION_FRAMEWORK=oecd
+# Optional per-region framework overrides as a JSON object, e.g.
+# REGION_FRAMEWORK_MAP={"punjab":"hots"}. Unset regions use the default above.
+REGION_FRAMEWORK_MAP=
+# Optional override for the settings language dropdown — JSON array of
+# {"id","title"} objects. Unset uses the built-in multilingual default list.
+SETTINGS_LANGUAGES=
+
 # --- ENABLES: Voice notes in (transcription) — Soniox -----------------------
 # Set this to let teachers send voice notes the bot understands (multi-language
 # STT: Urdu, Balochi, Sindhi, Pashto, ...). Also required for reading assessment
@@ -144,6 +153,8 @@ ATTENDANCE_SETUP_FLOW_ID=
 ATTENDANCE_MARKING_FLOW_ID=
 REGISTRATION_FLOW_ID=
 EXAM_CHECKER_STUDENTS_FLOW_ID=
+# Settings flow — empty disables the /settings command.
+SETTINGS_FLOW_ID=
 
 # --- Optional: BullMQ Worker --------------------------------------------------
 # Configuration for background job processing

--- a/bot/shared/config/region-config.js
+++ b/bot/shared/config/region-config.js
@@ -1,0 +1,56 @@
+/**
+ * Region Configuration
+ *
+ * Maps regions to their default observation framework + holds the framework
+ * display labels used by the settings flow and confirmation messages.
+ *
+ * Region-agnostic by design: there are NO hardcoded region names here. The
+ * default framework is env-driven (DEFAULT_OBSERVATION_FRAMEWORK), and a
+ * deployment that wants per-region defaults supplies a JSON map via
+ * REGION_FRAMEWORK_MAP (e.g. {"punjab":"hots","coast":"teach"}). Unknown or
+ * unset regions fall back to the global default. Services must NEVER hardcode
+ * region→framework routing — they read it from here.
+ */
+
+// Observation framework display names (settings dropdown + confirmations).
+const FRAMEWORK_LABELS = {
+  oecd: 'OECD 5D Framework',
+  hots: 'HOTS Framework',
+  teach: 'Teach (World Bank)',
+  fico: 'FICO Unified Tool',
+};
+
+// Global default framework for regions without an explicit override.
+const DEFAULT_FRAMEWORK = process.env.DEFAULT_OBSERVATION_FRAMEWORK || 'oecd';
+
+// Optional per-region overrides, supplied as a JSON object string in the env.
+// Keys are lowercased region names; values are framework keys from FRAMEWORK_LABELS.
+function parseRegionFrameworkMap() {
+  try {
+    const parsed = JSON.parse(process.env.REGION_FRAMEWORK_MAP || '{}');
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+const REGION_FRAMEWORK_MAP = parseRegionFrameworkMap();
+
+/**
+ * Resolve the default observation framework for a region.
+ * @param {string} region - Region name (any case), or empty/undefined.
+ * @returns {string} A framework key present in FRAMEWORK_LABELS.
+ */
+function defaultFrameworkForRegion(region) {
+  const key = (region || '').toLowerCase();
+  const mapped = REGION_FRAMEWORK_MAP[key];
+  if (mapped && FRAMEWORK_LABELS[mapped]) return mapped;
+  return DEFAULT_FRAMEWORK;
+}
+
+module.exports = {
+  FRAMEWORK_LABELS,
+  DEFAULT_FRAMEWORK,
+  REGION_FRAMEWORK_MAP,
+  defaultFrameworkForRegion,
+};

--- a/bot/shared/config/settings-config.js
+++ b/bot/shared/config/settings-config.js
@@ -1,0 +1,50 @@
+/**
+ * Settings Flow Data Configuration
+ *
+ * Static data for the WhatsApp Flow settings form — {id, title} arrays used as
+ * Flow dropdown data-sources.
+ *
+ * Flow JSON references:
+ *   SETTINGS_MAIN: ${data.languages}, ${data.frameworks}
+ *
+ * Region-agnostic: the language list defaults to a broad multilingual set, and
+ * a deployment can narrow it to the languages it actually supports by setting
+ * SETTINGS_LANGUAGES to a JSON array of {id,title} objects. The framework list
+ * is derived from region-config FRAMEWORK_LABELS.
+ */
+
+const { FRAMEWORK_LABELS } = require('./region-config');
+
+// Default language options. Override via SETTINGS_LANGUAGES (JSON array).
+const DEFAULT_LANGUAGES = [
+  { id: 'en', title: 'English' },
+  { id: 'ur', title: 'اردو (Urdu)' },
+  { id: 'sw', title: 'Kiswahili' },
+  { id: 'ar', title: 'العربية (Arabic)' },
+  { id: 'es', title: 'Español' },
+];
+
+function parseLanguagesEnv() {
+  try {
+    const parsed = JSON.parse(process.env.SETTINGS_LANGUAGES || '[]');
+    if (Array.isArray(parsed) && parsed.length && parsed.every(o => o && o.id && o.title)) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const LANGUAGES_DROPDOWN = parseLanguagesEnv() || DEFAULT_LANGUAGES;
+
+// Observation framework options — built from region-config labels.
+const FRAMEWORKS_DROPDOWN = Object.entries(FRAMEWORK_LABELS).map(([id, title]) => ({
+  id,
+  title,
+}));
+
+module.exports = {
+  LANGUAGES_DROPDOWN,
+  FRAMEWORKS_DROPDOWN,
+};

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -1146,6 +1146,52 @@ async function handleTextMessage(message, from, messageBody, user = null) {
   }
 
   // ============================================================
+  // /settings COMMAND: Open the settings flow (language + observation framework)
+  // ============================================================
+  if (messageBody === '/settings' || messageBody.toLowerCase() === '/settings') {
+    logToFile('⚙️ Settings command detected', { userId: user?.id, phoneNumber: from });
+    typingController.stop();
+
+    // Block settings change during an active coaching session
+    if (sessionId && user?.id) {
+      const sessionType = await redisService.get(`session:${sessionId}:type`);
+      if (sessionType === 'coaching' || sessionType === 'coaching_active') {
+        const blockMessage = ({
+          ur: '⚠️ آپ ابھی کوچنگ سیشن میں ہیں۔ سیشن ختم ہونے کے بعد سیٹنگز تبدیل کر سکتے ہیں۔',
+          sw: '⚠️ Uko katika kipindi cha kufundisha sasa. Unaweza kubadilisha mipangilio baada ya kipindi kukamilika.',
+        })[responseLanguage] || 'You can change settings after the coaching session completes.';
+        await WhatsAppService.sendMessage(from, blockMessage);
+        return;
+      }
+    }
+
+    const SETTINGS_FLOW_ID = process.env.SETTINGS_FLOW_ID || '';
+    if (!SETTINGS_FLOW_ID) {
+      await WhatsAppService.sendMessage(from, ({
+        ur: 'سیٹنگز ابھی دستیاب نہیں ہیں۔ بعد میں دوبارہ کوشش کریں۔',
+        sw: 'Mipangilio bado haijapatikana. Tafadhali jaribu tena baadaye.',
+      })[responseLanguage] || 'Settings are not available yet. Please try again later.');
+      return;
+    }
+
+    const flowToken = `${user?.id}:settings:${Date.now()}`;
+    await WhatsAppService.sendFlow(from, {
+      flowId: SETTINGS_FLOW_ID,
+      header: 'Rumi Settings',
+      body: ({
+        ur: 'اپنی زبان اور آبزرویشن ٹول کی ترجیحات اپ ڈیٹ کریں۔',
+        sw: 'Sasisha mapendeleo yako ya lugha na zana ya uchunguzi.',
+      })[responseLanguage] || 'Update your language and observation tool preferences.',
+      buttonText: ({
+        ur: 'سیٹنگز کھولیں',
+        sw: 'Fungua Mipangilio',
+      })[responseLanguage] || 'Open Settings',
+      flowToken
+    });
+    return;
+  }
+
+  // ============================================================
   // ATTENDANCE SYSTEM INTEGRATION (bd-060)
   // ============================================================
   // Check if user is in an active attendance session

--- a/bot/shared/routes/flow-endpoint.routes.js
+++ b/bot/shared/routes/flow-endpoint.routes.js
@@ -35,6 +35,11 @@ const {
   handlePicLpDataExchange,
   handlePicLpBack
 } = require('./pic-lp-endpoint');
+const {
+  handleSettingsInit,
+  handleSettingsDataExchange,
+  handleSettingsBack
+} = require('./settings-endpoint');
 
 /**
  * Handle attendance marking flow data requests
@@ -565,6 +570,72 @@ async function handlePicLpRequest(data) {
   }
 
   logToFile('Unknown flow action', { action });
+  return FlowEncryptionService.createErrorResponse('Unknown action');
+}
+
+// ============================================================
+// SETTINGS FLOW ENDPOINT
+// ============================================================
+
+router.post('/settings', async (req, res) => {
+  try {
+    if (!FlowEncryptionService.isConfigured()) {
+      logToFile('Flow encryption not configured', { endpoint: 'settings' });
+      return res.status(500).json({ error: 'Flow encryption not configured' });
+    }
+
+    const encryptedResponse = await FlowEncryptionService.processEncryptedRequest(
+      req.body,
+      async (decryptedData) => {
+        return await handleSettingsRequest(decryptedData);
+      }
+    );
+
+    res.set('Content-Type', 'text/plain');
+    res.send(encryptedResponse);
+  } catch (error) {
+    logToFile('Flow endpoint error', {
+      endpoint: 'settings',
+      error: error.message,
+      stack: error.stack,
+    });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * Handle decrypted settings request
+ * @param {Object} data - Decrypted request data
+ * @returns {Object} - Response to encrypt
+ */
+async function handleSettingsRequest(data) {
+  const { action, flow_token, screen, data: screenData } = data;
+
+  logToFile('Handling settings request', {
+    action,
+    screen,
+    hasFlowToken: !!flow_token,
+    screenDataKeys: screenData ? Object.keys(screenData) : []
+  });
+
+  if (action === 'ping') {
+    return FlowEncryptionService.handlePing();
+  }
+
+  // Flow token format: "userId:settings:timestamp"
+  const userId = (flow_token || '').split(':')[0];
+
+  if (action === 'INIT' || action === 'init') {
+    return await handleSettingsInit(userId);
+  }
+  if (action === 'data_exchange') {
+    return await handleSettingsDataExchange(userId, screen, screenData, flow_token);
+  }
+  if (action === 'BACK') {
+    return await handleSettingsBack(userId, screen, flow_token);
+  }
+
+  logToFile('Unknown settings flow action', { action });
   return FlowEncryptionService.createErrorResponse('Unknown action');
 }
 

--- a/bot/shared/routes/settings-endpoint.js
+++ b/bot/shared/routes/settings-endpoint.js
@@ -1,0 +1,167 @@
+/**
+ * Settings Flow Endpoint Handler
+ *
+ * Handles the endpoint-based WhatsApp Flow for user settings.
+ * Uses data_api_version 3.0 with encrypted data exchange.
+ *
+ * Flow screens:
+ *   SETTINGS_MAIN → SUCCESS
+ *
+ * SETTINGS_MAIN: language, observation_framework
+ *   Endpoint provides: languages, frameworks (dropdown data-sources),
+ *     current_language, current_framework, info_text (pre-selected values)
+ *
+ * SUCCESS: terminal screen
+ *   Endpoint provides: confirmation_message, details_message, extension_message_response
+ *
+ * Key patterns (shared with the registration endpoint):
+ * - Response format: {screen, data} ONLY — NO version field
+ * - INIT returns dropdown data + current values for init-values
+ * - data_exchange saves preferences and returns SUCCESS
+ *
+ * Region-agnostic: the default observation framework comes from
+ * region-config (env-driven), never a hardcoded region list.
+ */
+
+const { logToFile } = require('../utils/logger');
+const { LANGUAGES_DROPDOWN, FRAMEWORKS_DROPDOWN } = require('../config/settings-config');
+const { FRAMEWORK_LABELS, defaultFrameworkForRegion } = require('../config/region-config');
+const supabase = require('../config/supabase');
+
+// Look up a language's display label from the configured dropdown.
+function languageLabel(code) {
+  const match = LANGUAGES_DROPDOWN.find(l => l.id === code);
+  return match ? match.title : (LANGUAGES_DROPDOWN[0]?.title || 'English');
+}
+
+/**
+ * Handle INIT action — return SETTINGS_MAIN with current user preferences
+ */
+async function handleSettingsInit(userId) {
+  logToFile('⚙️ Settings flow INIT', { userId });
+
+  // Fetch user's current preferences + region
+  const { data: user } = await supabase
+    .from('users')
+    .select('preferred_language, preferences, region')
+    .eq('id', userId)
+    .single();
+
+  const prefs = user?.preferences || {};
+  const region = (user?.region || '').toLowerCase();
+  const regionDefault = defaultFrameworkForRegion(region);
+
+  const currentLang = prefs.language || user?.preferred_language || 'en';
+  const currentFramework = prefs.observation_framework || regionDefault;
+
+  const regionLabel = region ? region.charAt(0).toUpperCase() + region.slice(1) : 'your region';
+  const defaultLabel = FRAMEWORK_LABELS[regionDefault] || regionDefault;
+
+  const response = {
+    screen: 'SETTINGS_MAIN',
+    data: {
+      languages: LANGUAGES_DROPDOWN,
+      frameworks: FRAMEWORKS_DROPDOWN,
+      current_language: currentLang,
+      current_framework: currentFramework,
+      info_text: `Default for ${regionLabel}: ${defaultLabel}. You can change this anytime.`
+    }
+  };
+
+  logToFile('📤 Settings INIT response', { userId, response: JSON.stringify(response) });
+  return response;
+}
+
+/**
+ * Handle data_exchange for settings screens
+ */
+async function handleSettingsDataExchange(userId, screen, screenData, flowToken) {
+  logToFile('⚙️ Settings flow data_exchange', {
+    userId,
+    screen,
+    screenDataKeys: Object.keys(screenData || {}),
+    screenData
+  });
+
+  if (screen === 'SETTINGS_MAIN') {
+    return await handleSettingsMainSubmit(userId, screenData, flowToken);
+  }
+
+  logToFile('⚠️ Unknown screen in settings flow', { screen });
+  return { data: { error: { message: 'Unknown screen' } } };
+}
+
+/**
+ * Handle SETTINGS_MAIN submission — validate and save preferences to DB
+ */
+async function handleSettingsMainSubmit(userId, screenData, flowToken) {
+  const language = screenData.language || 'en';
+  const framework = screenData.observation_framework || 'oecd';
+
+  // Validate framework is one we support
+  if (!FRAMEWORK_LABELS[framework]) {
+    logToFile('⚠️ Invalid framework in settings', { userId, framework });
+    return { data: { error: { message: 'Invalid observation framework' } } };
+  }
+
+  // Fetch existing preferences to merge (preserve lesson_plan_source, curriculum, etc.)
+  const { data: user } = await supabase
+    .from('users')
+    .select('preferences')
+    .eq('id', userId)
+    .single();
+
+  const existingPrefs = user?.preferences || {};
+  const updatedPrefs = {
+    ...existingPrefs,
+    language,
+    observation_framework: framework,
+  };
+
+  // Update preferences JSONB + preferred_language column (legacy compat)
+  await supabase
+    .from('users')
+    .update({
+      preferences: updatedPrefs,
+      preferred_language: language,
+    })
+    .eq('id', userId);
+
+  const langLabel = languageLabel(language);
+  const frameworkLabel = FRAMEWORK_LABELS[framework] || framework;
+
+  const response = {
+    screen: 'SUCCESS',
+    data: {
+      extension_message_response: {
+        params: {
+          flow_token: flowToken,
+          language,
+          observation_framework: framework,
+        }
+      },
+      confirmation_message: 'Your settings have been saved successfully.',
+      details_message: `Language: ${langLabel} | Observation: ${frameworkLabel}`
+    }
+  };
+
+  logToFile('📤 SETTINGS_MAIN → SUCCESS', {
+    userId, language, framework, response: JSON.stringify(response)
+  });
+
+  return response;
+}
+
+/**
+ * Handle BACK navigation — return to SETTINGS_MAIN with current values
+ */
+async function handleSettingsBack(userId, screen, flowToken) {
+  logToFile('⚙️ Settings flow BACK', { userId, screen });
+  return await handleSettingsInit(userId);
+}
+
+module.exports = {
+  handleSettingsInit,
+  handleSettingsDataExchange,
+  handleSettingsBack,
+};

--- a/bot/shared/utils/constants.js
+++ b/bot/shared/utils/constants.js
@@ -21,6 +21,8 @@ const PORT = process.env.PORT || 3000;
 // Attendance Flow IDs (registered with Meta)
 const ATTENDANCE_SETUP_FLOW_ID = process.env.ATTENDANCE_SETUP_FLOW_ID || '';
 const ATTENDANCE_MARKING_FLOW_ID = process.env.ATTENDANCE_MARKING_FLOW_ID || '';
+// WhatsApp Flow ID for the user settings form (empty → /settings is disabled).
+const SETTINGS_FLOW_ID = process.env.SETTINGS_FLOW_ID || '';
 
 // Pic-to-LP (photo → illustrated lesson plan)
 const KIE_API_KEY = process.env.KIE_API_KEY;
@@ -120,6 +122,7 @@ module.exports = {
   // Attendance Flow IDs
   ATTENDANCE_SETUP_FLOW_ID,
   ATTENDANCE_MARKING_FLOW_ID,
+  SETTINGS_FLOW_ID,
 
   // Pic-to-LP
   KIE_API_KEY,

--- a/docs/flows/settings-flow.json
+++ b/docs/flows/settings-flow.json
@@ -1,0 +1,151 @@
+{
+  "_comment": "WhatsApp Flow for User Settings — Endpoint-based (data_api_version 3.0)",
+  "_instructions": [
+    "1. Register this Flow with Meta and set its ID as SETTINGS_FLOW_ID.",
+    "2. Endpoint: POST /api/flows/settings",
+    "3. The endpoint controls navigation + provides dropdown data with pre-selected current values.",
+    "4. Screens: SETTINGS_MAIN -> SUCCESS"
+  ],
+
+  "version": "6.3",
+  "data_api_version": "3.0",
+  "routing_model": {
+    "SETTINGS_MAIN": ["SUCCESS"],
+    "SUCCESS": []
+  },
+  "screens": [
+    {
+      "id": "SETTINGS_MAIN",
+      "title": "Rumi Settings",
+      "data": {
+        "languages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "title": { "type": "string" }
+            }
+          },
+          "__example__": [
+            { "id": "en", "title": "English" },
+            { "id": "ur", "title": "اردو (Urdu)" },
+            { "id": "sw", "title": "Kiswahili" }
+          ]
+        },
+        "frameworks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "title": { "type": "string" }
+            }
+          },
+          "__example__": [
+            { "id": "oecd", "title": "OECD 5D Framework" },
+            { "id": "hots", "title": "HOTS Framework" }
+          ]
+        },
+        "current_language": {
+          "type": "string",
+          "__example__": "en"
+        },
+        "current_framework": {
+          "type": "string",
+          "__example__": "oecd"
+        },
+        "info_text": {
+          "type": "string",
+          "__example__": "Default for your region: OECD 5D Framework. You can change this anytime."
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "settings_form",
+            "init-values": {
+              "language": "${data.current_language}",
+              "observation_framework": "${data.current_framework}"
+            },
+            "children": [
+              {
+                "type": "TextHeading",
+                "text": "Rumi Settings"
+              },
+              {
+                "type": "TextBody",
+                "text": "Update your language and observation tool preferences."
+              },
+              {
+                "type": "Dropdown",
+                "name": "language",
+                "label": "Language",
+                "required": true,
+                "data-source": "${data.languages}"
+              },
+              {
+                "type": "Dropdown",
+                "name": "observation_framework",
+                "label": "Observation Framework",
+                "required": true,
+                "data-source": "${data.frameworks}"
+              },
+              {
+                "type": "TextBody",
+                "text": "${data.info_text}"
+              },
+              {
+                "type": "Footer",
+                "label": "Save Settings",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "language": "${form.language}",
+                    "observation_framework": "${form.observation_framework}"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SUCCESS",
+      "title": "Settings Saved",
+      "terminal": true,
+      "data": {
+        "confirmation_message": { "type": "string", "__example__": "Your settings have been saved." },
+        "details_message": { "type": "string", "__example__": "Language: English | Observation: OECD 5D Framework" }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "TextHeading",
+            "text": "Settings Saved!"
+          },
+          {
+            "type": "TextBody",
+            "text": "${data.confirmation_message}"
+          },
+          {
+            "type": "TextBody",
+            "text": "${data.details_message}"
+          },
+          {
+            "type": "Footer",
+            "label": "Done",
+            "on-click-action": {
+              "name": "complete",
+              "payload": {}
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/settings/settings-flow.test.js
+++ b/tests/settings/settings-flow.test.js
@@ -1,0 +1,214 @@
+/**
+ * Settings flow — region-config (region-agnostic default framework),
+ * settings-config (env-overridable language dropdown), and the
+ * settings-endpoint INIT / data_exchange / BACK handlers.
+ *
+ * All bot-only deps (supabase, logger) are mocked so the suite runs at the
+ * repo root before `bot/` deps are installed (CI test-ordering trap).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function makeSupabaseChain(result = { data: null, error: null }) {
+  const chain = {};
+  for (const m of ['select', 'insert', 'update', 'delete', 'eq', 'in', 'order', 'limit']) {
+    chain[m] = jest.fn(() => chain);
+  }
+  chain.single = jest.fn().mockResolvedValue(result);
+  chain.maybeSingle = jest.fn().mockResolvedValue(result);
+  chain.then = (resolve) => resolve(result);
+  return chain;
+}
+
+// ── region-config ──────────────────────────────────────────────────────────
+describe('region-config', () => {
+  const ORIG = { ...process.env };
+  afterEach(() => { process.env = { ...ORIG }; jest.resetModules(); });
+
+  it('defaults the framework to OECD when no env is set', () => {
+    jest.resetModules();
+    delete process.env.DEFAULT_OBSERVATION_FRAMEWORK;
+    delete process.env.REGION_FRAMEWORK_MAP;
+    const rc = require('../../bot/shared/config/region-config');
+    expect(rc.DEFAULT_FRAMEWORK).toBe('oecd');
+    expect(rc.defaultFrameworkForRegion('anywhere')).toBe('oecd');
+    expect(rc.defaultFrameworkForRegion('')).toBe('oecd');
+    expect(rc.defaultFrameworkForRegion(undefined)).toBe('oecd');
+  });
+
+  it('honours DEFAULT_OBSERVATION_FRAMEWORK', () => {
+    jest.resetModules();
+    process.env.DEFAULT_OBSERVATION_FRAMEWORK = 'teach';
+    const rc = require('../../bot/shared/config/region-config');
+    expect(rc.defaultFrameworkForRegion('xyz')).toBe('teach');
+  });
+
+  it('applies REGION_FRAMEWORK_MAP overrides (case-insensitive), ignoring unknown framework keys', () => {
+    jest.resetModules();
+    process.env.REGION_FRAMEWORK_MAP = JSON.stringify({ punjab: 'hots', coast: 'bogus' });
+    const rc = require('../../bot/shared/config/region-config');
+    expect(rc.defaultFrameworkForRegion('Punjab')).toBe('hots'); // mapped + valid
+    expect(rc.defaultFrameworkForRegion('coast')).toBe('oecd');   // mapped but invalid → default
+    expect(rc.defaultFrameworkForRegion('elsewhere')).toBe('oecd');
+  });
+
+  it('survives malformed REGION_FRAMEWORK_MAP JSON', () => {
+    jest.resetModules();
+    process.env.REGION_FRAMEWORK_MAP = 'not json{';
+    const rc = require('../../bot/shared/config/region-config');
+    expect(rc.defaultFrameworkForRegion('punjab')).toBe('oecd');
+  });
+
+  it('has no hardcoded region names in the source', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../bot/shared/config/region-config.js'), 'utf8'
+    );
+    expect(src).not.toMatch(/HOTS_DEFAULT_REGIONS/);
+    expect(src.toLowerCase()).not.toContain('rawalpindi');
+  });
+});
+
+// ── settings-config ──────────────────────────────────────────────────────────
+describe('settings-config', () => {
+  const ORIG = { ...process.env };
+  afterEach(() => { process.env = { ...ORIG }; jest.resetModules(); });
+
+  it('exposes a default language dropdown of {id,title} objects', () => {
+    jest.resetModules();
+    delete process.env.SETTINGS_LANGUAGES;
+    const { LANGUAGES_DROPDOWN, FRAMEWORKS_DROPDOWN } = require('../../bot/shared/config/settings-config');
+    expect(LANGUAGES_DROPDOWN.length).toBeGreaterThan(0);
+    expect(LANGUAGES_DROPDOWN[0]).toEqual({ id: 'en', title: 'English' });
+    LANGUAGES_DROPDOWN.forEach(l => { expect(l).toHaveProperty('id'); expect(l).toHaveProperty('title'); });
+    // frameworks derived from region-config labels
+    expect(FRAMEWORKS_DROPDOWN.map(f => f.id).sort()).toEqual(['fico', 'hots', 'oecd', 'teach']);
+  });
+
+  it('honours SETTINGS_LANGUAGES override', () => {
+    jest.resetModules();
+    process.env.SETTINGS_LANGUAGES = JSON.stringify([{ id: 'sw', title: 'Kiswahili' }]);
+    const { LANGUAGES_DROPDOWN } = require('../../bot/shared/config/settings-config');
+    expect(LANGUAGES_DROPDOWN).toEqual([{ id: 'sw', title: 'Kiswahili' }]);
+  });
+
+  it('falls back to the default list when SETTINGS_LANGUAGES is malformed or empty', () => {
+    jest.resetModules();
+    process.env.SETTINGS_LANGUAGES = '[]';
+    let cfg = require('../../bot/shared/config/settings-config');
+    expect(cfg.LANGUAGES_DROPDOWN[0].id).toBe('en');
+    jest.resetModules();
+    process.env.SETTINGS_LANGUAGES = 'broken';
+    cfg = require('../../bot/shared/config/settings-config');
+    expect(cfg.LANGUAGES_DROPDOWN[0].id).toBe('en');
+  });
+});
+
+// ── settings-endpoint ────────────────────────────────────────────────────────
+describe('settings-endpoint', () => {
+  let endpoint;
+  let supabaseFrom;
+  let updateSpy;
+
+  function loadEndpoint(userRow) {
+    jest.resetModules();
+    delete process.env.DEFAULT_OBSERVATION_FRAMEWORK;
+    delete process.env.REGION_FRAMEWORK_MAP;
+    delete process.env.SETTINGS_LANGUAGES;
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    updateSpy = jest.fn(() => chainFor({ data: null, error: null }));
+    function chainFor(result) {
+      const chain = makeSupabaseChain(result);
+      chain.update = updateSpy;
+      return chain;
+    }
+    supabaseFrom = jest.fn(() => chainFor({ data: userRow, error: null }));
+    jest.doMock('../../bot/shared/config/supabase', () => ({ from: supabaseFrom }));
+    endpoint = require('../../bot/shared/routes/settings-endpoint');
+  }
+
+  it('INIT returns SETTINGS_MAIN with dropdowns + current values', async () => {
+    loadEndpoint({ preferred_language: 'ur', preferences: {}, region: '' });
+    const res = await endpoint.handleSettingsInit('user-1');
+    expect(res.screen).toBe('SETTINGS_MAIN');
+    expect(Array.isArray(res.data.languages)).toBe(true);
+    expect(Array.isArray(res.data.frameworks)).toBe(true);
+    expect(res.data.current_language).toBe('ur');
+    expect(res.data.current_framework).toBe('oecd'); // region default
+    expect(res.data.info_text).toContain('OECD');
+  });
+
+  it('INIT uses a per-region framework override when configured', async () => {
+    jest.resetModules();
+    process.env.REGION_FRAMEWORK_MAP = JSON.stringify({ punjab: 'hots' });
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/config/supabase', () => ({
+      from: () => makeSupabaseChain({ data: { preferred_language: 'en', preferences: {}, region: 'punjab' }, error: null }),
+    }));
+    const ep = require('../../bot/shared/routes/settings-endpoint');
+    const res = await ep.handleSettingsInit('user-2');
+    expect(res.data.current_framework).toBe('hots');
+    delete process.env.REGION_FRAMEWORK_MAP;
+  });
+
+  it('data_exchange on SETTINGS_MAIN persists prefs and returns SUCCESS', async () => {
+    loadEndpoint({ preferences: { curriculum: 'national' } });
+    const res = await endpoint.handleSettingsDataExchange(
+      'user-3', 'SETTINGS_MAIN',
+      { language: 'sw', observation_framework: 'teach' },
+      'user-3:settings:123'
+    );
+    expect(res.screen).toBe('SUCCESS');
+    expect(res.data.details_message).toContain('Kiswahili');
+    expect(res.data.details_message).toContain('Teach');
+    expect(res.data.extension_message_response.params.flow_token).toBe('user-3:settings:123');
+    // merged prefs preserve existing keys + write preferred_language
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      preferred_language: 'sw',
+      preferences: expect.objectContaining({ curriculum: 'national', language: 'sw', observation_framework: 'teach' }),
+    }));
+  });
+
+  it('data_exchange rejects an unsupported framework', async () => {
+    loadEndpoint({ preferences: {} });
+    const res = await endpoint.handleSettingsDataExchange(
+      'user-4', 'SETTINGS_MAIN', { language: 'en', observation_framework: 'nonsense' }, 'tok'
+    );
+    expect(res.data.error).toBeDefined();
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('data_exchange on an unknown screen returns an error', async () => {
+    loadEndpoint({ preferences: {} });
+    const res = await endpoint.handleSettingsDataExchange('user-5', 'MYSTERY', {}, 'tok');
+    expect(res.data.error).toBeDefined();
+  });
+
+  it('BACK returns the SETTINGS_MAIN init payload', async () => {
+    loadEndpoint({ preferred_language: 'en', preferences: {}, region: '' });
+    const res = await endpoint.handleSettingsBack('user-6', 'SUCCESS', 'tok');
+    expect(res.screen).toBe('SETTINGS_MAIN');
+  });
+});
+
+// ── flow JSON + leak gate ─────────────────────────────────────────────────────
+describe('settings-flow.json', () => {
+  const flowPath = path.join(__dirname, '../../docs/flows/settings-flow.json');
+
+  it('is valid JSON with SETTINGS_MAIN → SUCCESS routing', () => {
+    const flow = JSON.parse(fs.readFileSync(flowPath, 'utf8'));
+    expect(flow.routing_model.SETTINGS_MAIN).toEqual(['SUCCESS']);
+    const ids = flow.screens.map(s => s.id);
+    expect(ids).toContain('SETTINGS_MAIN');
+    expect(ids).toContain('SUCCESS');
+  });
+
+  it('is leak-free (no internal phone/name/path/bead tokens)', () => {
+    const raw = fs.readFileSync(flowPath, 'utf8');
+    const endpointSrc = fs.readFileSync(path.join(__dirname, '../../bot/shared/routes/settings-endpoint.js'), 'utf8');
+    for (const banned of ['+92', '+255', '0329', '5012345', 'Taleemabad', 'Rawalpindi', 'TaleemHub', 'bd-', 'PROJ-', 'Silverleaf']) {
+      expect(raw).not.toContain(banned);
+      expect(endpointSrc).not.toContain(banned);
+    }
+  });
+});


### PR DESCRIPTION
## Phase 4E — settings flow (first of the remaining flow-features)

Ports the endpoint-based WhatsApp **settings Flow** to the open-source bot, region-agnostic and presence-gated.

### What's added
- **region-config.js** — framework labels + env-driven default (`DEFAULT_OBSERVATION_FRAMEWORK`) with optional per-region overrides (`REGION_FRAMEWORK_MAP`). No hardcoded region names.
- **settings-config.js** — language dropdown (env-overridable via `SETTINGS_LANGUAGES`) + frameworks dropdown derived from labels.
- **settings-endpoint.js** — `INIT` / `data_exchange` / `BACK` handlers; persists `language` + `observation_framework` into `users.preferences` (and `preferred_language`).
- `POST /settings` mounted in **flow-endpoint.routes.js**.
- **/settings** command trigger in text-message.handler.js — gated on `SETTINGS_FLOW_ID`, blocked during an active coaching session.
- `SETTINGS_FLOW_ID` constant + `.env.template` entries.
- **docs/flows/settings-flow.json** (`SETTINGS_MAIN → SUCCESS`).

### Presence gating
`/settings` is inert unless `SETTINGS_FLOW_ID` is set — a clone with no settings Flow registered shows a graceful "not available yet" message.

### Tests
16 new tests (config defaults + env overrides, endpoint INIT/data_exchange/BACK, flow-JSON validity, leak gate). Full suite: **70 suites / 934 passing**. Bot-only deps mocked for the root-before-`bot/`-ci test ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)