### PR TITLE
feat(status): /status cross-feature snapshot + cancel flow — Phase 4E

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -155,6 +155,8 @@ REGISTRATION_FLOW_ID=
 EXAM_CHECKER_STUDENTS_FLOW_ID=
 # Settings flow — empty disables the /settings command.
 SETTINGS_FLOW_ID=
+# Status flow — empty makes /status fall back to a plain-text summary.
+STATUS_FLOW_ID=
 
 # --- Optional: BullMQ Worker --------------------------------------------------
 # Configuration for background job processing

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -1192,6 +1192,46 @@ async function handleTextMessage(message, from, messageBody, user = null) {
   }
 
   // ============================================================
+  // /status COMMAND: cross-feature snapshot of what's running + cancel
+  // ============================================================
+  if (/^\/status\b/i.test(trimmedMessage)) {
+    logToFile('📋 /status command detected', { userId: user?.id, phoneNumber: from });
+    if (!user) {
+      await WhatsAppService.sendMessage(from,
+        'Sorry, I could not find your account. Please send me a message first.');
+      typingController.stop();
+      return;
+    }
+    try {
+      typingController.stop();
+      const STATUS_FLOW_ID = process.env.STATUS_FLOW_ID || '';
+      if (STATUS_FLOW_ID) {
+        await WhatsAppService.sendFlow(from, {
+          flowId: STATUS_FLOW_ID,
+          flowToken: user.id,
+          header: "What's running",
+          body: "See everything you have in flight — and stop any of it.",
+          footer: 'Powered by Rumi',
+          buttonText: 'Open status'
+        });
+        logToFile('✅ Status flow sent', { userId: user.id });
+      } else {
+        // Fallback before STATUS_FLOW_ID is published — render a plain-text
+        // summary inline so the command at least answers the question.
+        const TeacherStateService = require('../services/teacher-state.service');
+        const items = await TeacherStateService.listActiveResources(user.id);
+        const summary = items.length === 0
+          ? "Nothing's running right now."
+          : `Running for you:\n${items.map(it => `• ${it.title}`).join('\n')}`;
+        await WhatsAppService.sendMessage(from, summary);
+      }
+    } catch (error) {
+      logToFile('❌ Error starting /status', { userId: user?.id, error: error.message });
+    }
+    return;
+  }
+
+  // ============================================================
   // ATTENDANCE SYSTEM INTEGRATION (bd-060)
   // ============================================================
   // Check if user is in an active attendance session

--- a/bot/shared/routes/flow-endpoint.routes.js
+++ b/bot/shared/routes/flow-endpoint.routes.js
@@ -40,6 +40,11 @@ const {
   handleSettingsDataExchange,
   handleSettingsBack
 } = require('./settings-endpoint');
+const {
+  handleStatusFlowInit,
+  handleStatusFlowDataExchange,
+  handleStatusFlowBack
+} = require('./status-flow-endpoint');
 
 /**
  * Handle attendance marking flow data requests
@@ -636,6 +641,46 @@ async function handleSettingsRequest(data) {
   }
 
   logToFile('Unknown settings flow action', { action });
+  return FlowEncryptionService.createErrorResponse('Unknown action');
+}
+
+// ============================================================
+// STATUS FLOW ENDPOINT — cross-feature snapshot + cancel
+// ============================================================
+
+router.post('/status', async (req, res) => {
+  try {
+    if (!FlowEncryptionService.isConfigured()) {
+      logToFile('Flow encryption not configured', { endpoint: 'status' });
+      return res.status(500).json({ error: 'Flow encryption not configured' });
+    }
+    const encryptedResponse = await FlowEncryptionService.processEncryptedRequest(
+      req.body,
+      async (decryptedData) => await handleStatusFlowRequest(decryptedData)
+    );
+    res.set('Content-Type', 'text/plain');
+    res.send(encryptedResponse);
+  } catch (error) {
+    logToFile('Flow endpoint error', { endpoint: 'status', error: error.message, stack: error.stack });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+async function handleStatusFlowRequest(data) {
+  const { action, flow_token, screen, data: screenData } = data;
+  logToFile('Handling status flow request', {
+    action, screen, hasFlowToken: !!flow_token,
+    screenDataKeys: screenData ? Object.keys(screenData) : []
+  });
+
+  if (action === 'ping') return FlowEncryptionService.handlePing();
+  const userId = (flow_token || '').split(':')[0];
+
+  if (action === 'INIT' || action === 'init') return await handleStatusFlowInit(userId, flow_token);
+  if (action === 'data_exchange')             return await handleStatusFlowDataExchange(userId, screen, screenData, flow_token);
+  if (action === 'BACK')                      return await handleStatusFlowBack(userId, screen, flow_token);
+
+  logToFile('Unknown status flow action', { action });
   return FlowEncryptionService.createErrorResponse('Unknown action');
 }
 

--- a/bot/shared/routes/status-flow-endpoint.js
+++ b/bot/shared/routes/status-flow-endpoint.js
@@ -1,0 +1,151 @@
+'use strict';
+/**
+ * Status Flow Endpoint Handler
+ *
+ * /status opens this Flow. The teacher sees every active resource
+ * (quizzes / coaching / LPs / video / reading / attendance) with one-line
+ * descriptions and can pick one to cancel.
+ *
+ * Routing (forward-only):
+ *   MAIN → CONFIRM_CANCEL | SUCCESS
+ *   CONFIRM_CANCEL → SUCCESS
+ *
+ * 10-second timeout consideration: listActiveResources is a few cheap
+ * supabase reads + a Redis MGET. Fast.
+ */
+
+const { logToFile } = require('../utils/logger');
+const TeacherStateService = require('../services/teacher-state.service');
+
+async function handleStatusFlowInit(userId /*, flowToken */) {
+  logToFile('📋 Status Flow INIT', { userId });
+  return await buildMainScreen(userId);
+}
+
+async function handleStatusFlowDataExchange(userId, screen, screenData /*, flowToken */) {
+  logToFile('📋 Status Flow data_exchange', { userId, screen, screenData });
+
+  if (screen === 'MAIN') {
+    const action = screenData._action;
+    if (!action) return createErrorResponse('No action selected');
+    if (action === 'done') {
+      return buildSuccessScreen('Done — your /status is up to date.', { statusAction: 'done' });
+    }
+    // action is a row id like 'cancel_quiz_<uuid>' / 'cancel_video' etc.
+    const parsed = TeacherStateService.parseResourceId(action);
+    if (parsed.kind === 'unknown') return createErrorResponse('Unknown action');
+
+    // Re-derive the label so CONFIRM_CANCEL shows it without trusting client state
+    const items = await TeacherStateService.listActiveResources(userId);
+    const matched = items.find(it => it.id === action);
+    const label = matched?.title || 'this resource';
+    return {
+      screen: 'CONFIRM_CANCEL',
+      data: {
+        resource_id: action,
+        resource_label: label
+      }
+    };
+  }
+
+  if (screen === 'CONFIRM_CANCEL') {
+    const rowId = screenData.resource_id;
+    if (!rowId) return createErrorResponse('Missing resource id');
+    const items = await TeacherStateService.listActiveResources(userId);
+    const matched = items.find(it => it.id === rowId);
+    if (!matched) {
+      return buildSuccessScreen(
+        'That resource is no longer active — nothing to stop.',
+        { statusAction: 'noop', resourceLabel: 'unknown' }
+      );
+    }
+    const result = await TeacherStateService.cancelResource(matched, userId);
+    if (result.ok) {
+      return buildSuccessScreen(result.message, {
+        statusAction: 'cancelled',
+        resourceKind: matched.kind,
+        resourceLabel: matched.title
+      });
+    }
+    return createErrorResponse(`Couldn't stop that — ${result.reason || 'unknown error'}`);
+  }
+
+  logToFile('⚠️ Unknown screen in status flow', { screen });
+  return createErrorResponse('Unknown screen');
+}
+
+async function handleStatusFlowBack(userId, screen /*, flowToken */) {
+  logToFile('📋 Status Flow BACK', { userId, screen });
+  return await buildMainScreen(userId);
+}
+
+// ─── Builders ──────────────────────────────────────────────────────────────
+
+async function buildMainScreen(userId) {
+  try {
+    const items = await TeacherStateService.listActiveResources(userId);
+
+    if (items.length === 0) {
+      // Nothing active — go straight to a polite SUCCESS screen.
+      return buildSuccessScreen(
+        'Nothing\'s running right now. Type /quiz, /reading test, or describe a lesson topic to start something.',
+        { statusAction: 'idle' }
+      );
+    }
+
+    const summaryHeading = items.length === 1
+      ? 'You have 1 thing running right now.'
+      : `You have ${items.length} things running right now.`;
+
+    const summaryBody = items.map(it => `• ${it.title}`).join('\n');
+
+    const resources = items.map(it => ({
+      id: it.id,
+      title: it.title.length > 30 ? it.title.slice(0, 27) + '...' : it.title
+    }));
+    resources.push({ id: 'done', title: 'Done — close' });
+
+    return {
+      screen: 'MAIN',
+      data: {
+        summary_heading: summaryHeading,
+        summary_body: summaryBody,
+        resources
+      }
+    };
+  } catch (err) {
+    logToFile('❌ buildMainScreen error', { error: err.message });
+    return createErrorResponse('Could not load /status menu');
+  }
+}
+
+/**
+ * SUCCESS screen with extension_message_response params so the chat-side
+ * nfm_reply branch can dispatch a contextual ack instead of the generic
+ * unknown-flow fallback.
+ */
+function buildSuccessScreen(message, { statusAction = 'done', resourceKind = '', resourceLabel = '' } = {}) {
+  return {
+    screen: 'SUCCESS',
+    data: {
+      success_message: message,
+      extension_message_response: {
+        params: {
+          status_action: statusAction,
+          ...(resourceKind ? { resource_kind: resourceKind } : {}),
+          ...(resourceLabel ? { resource_label: resourceLabel } : {})
+        }
+      }
+    }
+  };
+}
+
+function createErrorResponse(message) {
+  return { data: { error: { message } } };
+}
+
+module.exports = {
+  handleStatusFlowInit,
+  handleStatusFlowDataExchange,
+  handleStatusFlowBack
+};

--- a/bot/shared/services/teacher-state.service.js
+++ b/bot/shared/services/teacher-state.service.js
@@ -1,0 +1,328 @@
+'use strict';
+// Cross-feature "is the teacher busy right now?" probe + the cancellable
+// resource list that powers the /status flow.
+//
+// probeTeacherBusy is lazy: invoked when a scheduled quiz_report job is about
+// to fire, so the report can be deferred a few minutes when the teacher is
+// mid-coaching/LP/video/reading/attendance.
+//
+// Sources of state checked:
+// - Coaching:   Postgres `coaching_sessions` rows, non-terminal, last hour
+// - LP request: Postgres `lesson_plan_requests` rows in pending/processing/extracting
+// - Video:      Redis keys `user:{id}:awaiting_video_*`
+// - Reading:    Redis key `reading:user:{id}:current_assessment`
+// - Attendance: Redis key `attendance:session:{id}`
+//
+// Defaults to "not busy" on any probe error so a Redis/DB blip never blocks
+// reports forever.
+
+const supabase = require('../config/supabase');
+const redisService = require('./cache/railway-redis.service');
+const { logToFile } = require('../utils/logger');
+
+const ONE_HOUR_AGO = () => new Date(Date.now() - 60 * 60 * 1000).toISOString();
+const THIRTY_MIN_AGO = () => new Date(Date.now() - 30 * 60 * 1000).toISOString();
+
+const COACHING_TERMINAL = ['completed', 'failed', 'cancelled', 'report_sent'];
+const LP_IN_FLIGHT = ['pending', 'processing', 'extracting'];
+
+/**
+ * @returns {Promise<{busy: boolean, feature: string|null, etaSeconds: number|null}>}
+ *   busy=false       → the scheduler delivers the report immediately
+ *   busy=true,
+ *     feature=string  → which feature is occupying her right now
+ *     etaSeconds=N|null → hint for how long to defer; scheduler uses
+ *                          a default (10 min) when null
+ */
+async function probeTeacherBusy(userId) {
+  if (!userId) return { busy: false, feature: null, etaSeconds: null };
+
+  // 1. Coaching session in flight
+  try {
+    const { data: coachingRows } = await supabase
+      .from('coaching_sessions')
+      .select('id, status, created_at')
+      .eq('user_id', userId)
+      .not('status', 'in', `(${COACHING_TERMINAL.join(',')})`)
+      .gte('created_at', ONE_HOUR_AGO())
+      .limit(1);
+    if (coachingRows && coachingRows.length > 0) {
+      return { busy: true, feature: 'coaching', etaSeconds: null };
+    }
+  } catch (err) {
+    logToFile('⚠️ probeTeacherBusy: coaching probe failed (defaulting to not-busy)', { userId, error: err.message });
+  }
+
+  // 2. LP request currently being processed
+  try {
+    const { data: lpRows } = await supabase
+      .from('lesson_plan_requests')
+      .select('id, status, created_at')
+      .eq('user_id', userId)
+      .in('status', LP_IN_FLIGHT)
+      .gte('created_at', THIRTY_MIN_AGO())
+      .limit(1);
+    if (lpRows && lpRows.length > 0) {
+      // LPs typically finish within 30-60s; defer 5 min as a safety
+      return { busy: true, feature: 'lesson_plan', etaSeconds: 300 };
+    }
+  } catch (err) {
+    logToFile('⚠️ probeTeacherBusy: LP probe failed (defaulting to not-busy)', { userId, error: err.message });
+  }
+
+  // 3. Video flow open (any of the four awaiting-* states)
+  try {
+    if (redisService.isAvailable && redisService.isAvailable()) {
+      const videoKeys = [
+        `user:${userId}:awaiting_video_topic`,
+        `user:${userId}:awaiting_video_language`,
+        `user:${userId}:awaiting_video_customization`,
+        `user:${userId}:awaiting_video_style`,
+      ];
+      for (const k of videoKeys) {
+        const v = await redisService.redis.get(k);
+        if (v) {
+          return { busy: true, feature: 'video', etaSeconds: 900 }; // 15 min — matches video state TTL
+        }
+      }
+    }
+  } catch (err) {
+    logToFile('⚠️ probeTeacherBusy: video probe failed (defaulting to not-busy)', { userId, error: err.message });
+  }
+
+  // 4. Reading assessment in flight
+  try {
+    if (redisService.isAvailable && redisService.isAvailable()) {
+      const readingState = await redisService.redis.get(`reading:user:${userId}:current_assessment`);
+      if (readingState) {
+        return { busy: true, feature: 'reading', etaSeconds: null };
+      }
+    }
+  } catch (err) {
+    logToFile('⚠️ probeTeacherBusy: reading probe failed (defaulting to not-busy)', { userId, error: err.message });
+  }
+
+  // 5. Attendance flow open
+  try {
+    if (redisService.isAvailable && redisService.isAvailable()) {
+      const attState = await redisService.redis.get(`attendance:session:${userId}`);
+      if (attState) {
+        return { busy: true, feature: 'attendance', etaSeconds: null };
+      }
+    }
+  } catch (err) {
+    logToFile('⚠️ probeTeacherBusy: attendance probe failed (defaulting to not-busy)', { userId, error: err.message });
+  }
+
+  return { busy: false, feature: null, etaSeconds: null };
+}
+
+/**
+ * listActiveResources(userId)
+ *   Returns an ordered array of cancellable items for the /status flow.
+ *   Each item: { id, title, kind, refId }
+ *     id     → the radio-row id ('cancel_quiz_<uuid>' / 'cancel_lp_<uuid>' / 'cancel_coaching_<uuid>' / 'cancel_video' / 'cancel_reading' / 'cancel_attendance')
+ *     title  → human-friendly label shown to the teacher
+ *     kind   → one of 'quiz' | 'lesson_plan' | 'coaching' | 'video' | 'reading' | 'attendance'
+ *     refId  → UUID where applicable, else null
+ *
+ *   Cancel coverage:
+ *     ✅ quiz        — QuizOrchestrator.cancelQuiz (orchestrator path)
+ *     ⚠ coaching    — DB status flip + Redis state delete (teacher-only)
+ *     ⚠ lesson_plan — DB status='cancelled' (background job continues, result discarded)
+ *     ⚠ video       — Redis state delete only (running job continues)
+ *     ⚠ reading     — Redis flow delete only
+ *     ⚠ attendance  — Redis state delete only
+ */
+async function listActiveResources(userId) {
+  if (!userId) return [];
+  const items = [];
+
+  // Quizzes — pull active ones for this teacher
+  try {
+    const { data: quizzes } = await supabase
+      .from('quizzes')
+      .select(`
+        id, topic, list_id,
+        student_lists ( class_name, section )
+      `)
+      .eq('teacher_id', userId)
+      .in('status', ['sent', 'ready', 'completed'])
+      .gte('created_at', new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString())
+      .order('created_at', { ascending: false })
+      .limit(5);
+    for (const q of (quizzes || [])) {
+      const cls = q.student_lists
+        ? (q.student_lists.section ? `${q.student_lists.class_name}-${q.student_lists.section}` : q.student_lists.class_name)
+        : '?';
+      // Skip quizzes whose every session is already terminal
+      const { data: peers } = await supabase
+        .from('quiz_sessions').select('status').eq('quiz_id', q.id);
+      const allDone = (peers || []).length > 0 && peers.every(s =>
+        ['completed', 'incomplete', 'expired', 'cancelled'].includes(s.status)
+      );
+      if (allDone) continue;
+      items.push({
+        id: `cancel_quiz_${q.id}`,
+        title: `Quiz · ${cls} · ${q.topic}`.slice(0, 70),
+        kind: 'quiz',
+        refId: q.id
+      });
+    }
+  } catch (err) {
+    logToFile('⚠️ listActiveResources: quiz probe failed', { error: err.message });
+  }
+
+  // Coaching sessions
+  try {
+    const { data: coachingRows } = await supabase
+      .from('coaching_sessions')
+      .select('id, created_at, status')
+      .eq('user_id', userId)
+      .not('status', 'in', `(${COACHING_TERMINAL.join(',')})`)
+      .gte('created_at', ONE_HOUR_AGO())
+      .limit(2);
+    for (const c of (coachingRows || [])) {
+      items.push({
+        id: `cancel_coaching_${c.id}`,
+        title: 'Coaching session in progress',
+        kind: 'coaching',
+        refId: c.id
+      });
+    }
+  } catch (err) {
+    logToFile('⚠️ listActiveResources: coaching probe failed', { error: err.message });
+  }
+
+  // LP requests
+  try {
+    const { data: lpRows } = await supabase
+      .from('lesson_plan_requests')
+      .select('id, topic, created_at, status')
+      .eq('user_id', userId)
+      .in('status', LP_IN_FLIGHT)
+      .gte('created_at', THIRTY_MIN_AGO())
+      .limit(2);
+    for (const lp of (lpRows || [])) {
+      items.push({
+        id: `cancel_lp_${lp.id}`,
+        title: `Lesson plan · ${lp.topic || 'in progress'}`.slice(0, 70),
+        kind: 'lesson_plan',
+        refId: lp.id
+      });
+    }
+  } catch (err) {
+    logToFile('⚠️ listActiveResources: LP probe failed', { error: err.message });
+  }
+
+  // Redis-backed flows: video / reading / attendance
+  try {
+    if (redisService.isAvailable && redisService.isAvailable()) {
+      const videoKeys = [
+        `user:${userId}:awaiting_video_topic`,
+        `user:${userId}:awaiting_video_language`,
+        `user:${userId}:awaiting_video_customization`,
+        `user:${userId}:awaiting_video_style`
+      ];
+      for (const k of videoKeys) {
+        const v = await redisService.redis.get(k);
+        if (v) {
+          items.push({ id: 'cancel_video', title: 'Video generation', kind: 'video', refId: null });
+          break;
+        }
+      }
+      const readingState = await redisService.redis.get(`reading:user:${userId}:current_assessment`);
+      if (readingState) {
+        items.push({ id: 'cancel_reading', title: 'Reading assessment in progress', kind: 'reading', refId: null });
+      }
+      const attState = await redisService.redis.get(`attendance:session:${userId}`);
+      if (attState) {
+        items.push({ id: 'cancel_attendance', title: 'Attendance flow open', kind: 'attendance', refId: null });
+      }
+    }
+  } catch (err) {
+    logToFile('⚠️ listActiveResources: redis probe failed', { error: err.message });
+  }
+
+  return items;
+}
+
+/**
+ * cancelResource(item, userId)
+ *   Routes cancel by kind. Quizzes go through the full orchestrator;
+ *   the others do a state-delete with a polite acknowledgement.
+ */
+async function cancelResource(item, userId) {
+  if (!item || !item.kind) return { ok: false, reason: 'invalid resource' };
+  try {
+    if (item.kind === 'quiz' && item.refId) {
+      const QuizOrchestrator = require('./quiz/quiz-orchestrator.service');
+      await QuizOrchestrator.cancelQuiz(item.refId, userId);
+      return { ok: true, message: `🛑 Quiz cancelled. The scheduled report won't be generated for it.` };
+    }
+    if (item.kind === 'coaching' && item.refId) {
+      await supabase
+        .from('coaching_sessions')
+        .update({ status: 'cancelled' })
+        .eq('id', item.refId)
+        .eq('user_id', userId);
+      return { ok: true, message: `🛑 Coaching session stopped on our end.` };
+    }
+    if (item.kind === 'lesson_plan' && item.refId) {
+      await supabase
+        .from('lesson_plan_requests')
+        .update({ status: 'cancelled' })
+        .eq('id', item.refId)
+        .eq('user_id', userId);
+      return {
+        ok: true,
+        message: `🛑 Lesson plan cancelled on our end. The background generation may still finish but you won't be notified.`
+      };
+    }
+    if (item.kind === 'video') {
+      const keys = [
+        `user:${userId}:awaiting_video_topic`,
+        `user:${userId}:awaiting_video_language`,
+        `user:${userId}:awaiting_video_customization`,
+        `user:${userId}:awaiting_video_style`
+      ];
+      for (const k of keys) await redisService.redis.del(k);
+      return {
+        ok: true,
+        message: `🛑 Video flow stopped on our end. The background generation may still finish but you won't be notified.`
+      };
+    }
+    if (item.kind === 'reading') {
+      await redisService.redis.del(`reading:user:${userId}:current_assessment`);
+      return { ok: true, message: `🛑 Reading assessment stopped. Tap /reading test to start a fresh one.` };
+    }
+    if (item.kind === 'attendance') {
+      await redisService.redis.del(`attendance:session:${userId}`);
+      return { ok: true, message: `🛑 Attendance flow closed. Tap "attendance" to start a new one.` };
+    }
+    return { ok: false, reason: 'unknown kind' };
+  } catch (err) {
+    logToFile('❌ cancelResource error', { kind: item.kind, refId: item.refId, error: err.message });
+    return { ok: false, reason: err.message };
+  }
+}
+
+/**
+ * Parse a status-flow row id like 'cancel_quiz_<uuid>' / 'cancel_video' /
+ * 'done' back into { kind, refId } or 'done'/'unknown'.
+ */
+function parseResourceId(rowId) {
+  if (!rowId) return { kind: 'unknown' };
+  if (rowId === 'done') return { kind: 'done' };
+  const m = rowId.match(/^cancel_(quiz|coaching|lp|video|reading|attendance)(?:_(.+))?$/);
+  if (!m) return { kind: 'unknown' };
+  const kindMap = { quiz: 'quiz', coaching: 'coaching', lp: 'lesson_plan', video: 'video', reading: 'reading', attendance: 'attendance' };
+  return { kind: kindMap[m[1]], refId: m[2] || null };
+}
+
+module.exports = {
+  probeTeacherBusy,
+  listActiveResources,
+  cancelResource,
+  parseResourceId
+};

--- a/bot/shared/utils/constants.js
+++ b/bot/shared/utils/constants.js
@@ -23,6 +23,9 @@ const ATTENDANCE_SETUP_FLOW_ID = process.env.ATTENDANCE_SETUP_FLOW_ID || '';
 const ATTENDANCE_MARKING_FLOW_ID = process.env.ATTENDANCE_MARKING_FLOW_ID || '';
 // WhatsApp Flow ID for the user settings form (empty → /settings is disabled).
 const SETTINGS_FLOW_ID = process.env.SETTINGS_FLOW_ID || '';
+// WhatsApp Flow ID for the /status snapshot (empty → /status falls back to a
+// plain-text summary instead of the interactive Flow).
+const STATUS_FLOW_ID = process.env.STATUS_FLOW_ID || '';
 
 // Pic-to-LP (photo → illustrated lesson plan)
 const KIE_API_KEY = process.env.KIE_API_KEY;
@@ -123,6 +126,7 @@ module.exports = {
   ATTENDANCE_SETUP_FLOW_ID,
   ATTENDANCE_MARKING_FLOW_ID,
   SETTINGS_FLOW_ID,
+  STATUS_FLOW_ID,
 
   // Pic-to-LP
   KIE_API_KEY,

--- a/docs/flows/status-flow.json
+++ b/docs/flows/status-flow.json
@@ -1,0 +1,153 @@
+{
+  "_comment": "WhatsApp Flow — /status — cross-feature snapshot of what's running for the teacher, with cancel",
+  "_instructions": [
+    "1. Register this Flow with Meta and set its ID as STATUS_FLOW_ID.",
+    "2. Endpoint: POST /api/flows/status",
+    "3. MAIN: Lists active resources (quizzes / coaching / LPs / video / reading / attendance) + radio + Done",
+    "4. CONFIRM_CANCEL: Confirms cancel of one resource selected from MAIN",
+    "5. SUCCESS: Acknowledgement screen",
+    "6. routing_model is forward-only (Meta rejects backward routes)",
+    "7. data_exchange MUST respond < 10s — listActiveResources is read-only and fast"
+  ],
+
+  "version": "6.3",
+  "data_api_version": "3.0",
+  "routing_model": {
+    "MAIN": ["CONFIRM_CANCEL", "SUCCESS"],
+    "CONFIRM_CANCEL": ["SUCCESS"],
+    "SUCCESS": []
+  },
+  "screens": [
+    {
+      "id": "MAIN",
+      "title": "What's running",
+      "data": {
+        "summary_heading": { "type": "string", "__example__": "You have 3 things running right now." },
+        "summary_body": {
+          "type": "string",
+          "__example__": "• Quiz · 5-A · Photosynthesis\n• Coaching · uploading audio\n• Lesson plan · Atomic Structures"
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "title": { "type": "string" }
+            }
+          },
+          "__example__": [
+            { "id": "cancel_quiz_uuid-1", "title": "Quiz · 5-A · Photosynthesis" },
+            { "id": "cancel_coaching_uuid-2", "title": "Coaching session" },
+            { "id": "done", "title": "Done — close" }
+          ]
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "main_form",
+            "children": [
+              { "type": "TextHeading", "text": "${data.summary_heading}" },
+              { "type": "TextBody", "text": "${data.summary_body}" },
+              {
+                "type": "RadioButtonsGroup",
+                "name": "action",
+                "label": "Want to stop one?",
+                "required": true,
+                "data-source": "${data.resources}"
+              },
+              {
+                "type": "Footer",
+                "label": "Continue",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": { "_action": "${form.action}" }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "CONFIRM_CANCEL",
+      "title": "Confirm",
+      "data": {
+        "resource_id":    { "type": "string", "__example__": "cancel_quiz_uuid-1" },
+        "resource_label": { "type": "string", "__example__": "Quiz · 5-A · Photosynthesis" }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "confirm_form",
+            "children": [
+              { "type": "TextHeading", "text": "Stop this?" },
+              { "type": "TextBody",    "text": "${data.resource_label}" },
+              {
+                "type": "Footer",
+                "label": "Yes, stop it",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "_action": "confirm_cancel",
+                    "resource_id": "${data.resource_id}"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SUCCESS",
+      "title": "Done",
+      "terminal": true,
+      "success": true,
+      "data": {
+        "success_message": { "type": "string", "__example__": "Done — your /status is up to date." },
+        "extension_message_response": {
+          "type": "object",
+          "properties": {
+            "params": {
+              "type": "object",
+              "properties": {
+                "status_action":      { "type": "string" },
+                "resource_kind":      { "type": "string" },
+                "resource_label":     { "type": "string" }
+              }
+            }
+          },
+          "__example__": {
+            "params": {
+              "status_action": "cancelled",
+              "resource_kind": "quiz",
+              "resource_label": "Quiz · 5-A · Photosynthesis"
+            }
+          }
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          { "type": "TextHeading", "text": "${data.success_message}" },
+          {
+            "type": "Footer",
+            "label": "Close",
+            "on-click-action": {
+              "name": "complete",
+              "payload": {
+                "extension_message_response": "${data.extension_message_response}"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/status/status-flow.test.js
+++ b/tests/status/status-flow.test.js
@@ -1,0 +1,237 @@
+/**
+ * Status flow — teacher-state.service (active-resource listing + cancel +
+ * id parsing) and the status-flow-endpoint INIT / data_exchange / BACK
+ * handlers. Bot-only deps (supabase, redis, logger, quiz-orchestrator) mocked
+ * for the root-before-bot-ci test ordering.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// A supabase chain whose terminal/await resolves to `result`.
+function chainResolving(result) {
+  const chain = {};
+  for (const m of ['select', 'insert', 'update', 'delete', 'eq', 'in', 'not', 'gte', 'order', 'limit']) {
+    chain[m] = jest.fn(() => chain);
+  }
+  chain.single = jest.fn().mockResolvedValue(result);
+  chain.then = (resolve) => resolve(result);
+  return chain;
+}
+
+// ── teacher-state.service ─────────────────────────────────────────────────────
+describe('teacher-state.service', () => {
+  function load({ tableResults = {}, redisAvailable = true, redisStore = {}, cancelQuiz } = {}) {
+    jest.resetModules();
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+
+    const supabaseFrom = jest.fn((t) => chainResolving(tableResults[t] || { data: [], error: null }));
+    const updateSpy = jest.fn(() => chainResolving({ data: null, error: null }));
+    jest.doMock('../../bot/shared/config/supabase', () => ({
+      from: jest.fn((t) => {
+        const chain = chainResolving(tableResults[t] || { data: [], error: null });
+        chain.update = updateSpy;
+        return chain;
+      }),
+    }));
+
+    const delSpy = jest.fn().mockResolvedValue(1);
+    jest.doMock('../../bot/shared/services/cache/railway-redis.service', () => ({
+      isAvailable: () => redisAvailable,
+      redis: {
+        get: jest.fn((k) => Promise.resolve(redisStore[k] || null)),
+        del: delSpy,
+      },
+    }));
+
+    const cancelQuizSpy = cancelQuiz || jest.fn().mockResolvedValue(true);
+    jest.doMock('../../bot/shared/services/quiz/quiz-orchestrator.service', () => ({ cancelQuiz: cancelQuizSpy }));
+
+    const svc = require('../../bot/shared/services/teacher-state.service');
+    return { svc, supabaseFrom, updateSpy, delSpy, cancelQuizSpy };
+  }
+
+  describe('parseResourceId', () => {
+    it('parses done / quiz-with-uuid / bare-kind / unknown', () => {
+      const { svc } = load();
+      expect(svc.parseResourceId('done')).toEqual({ kind: 'done' });
+      expect(svc.parseResourceId('cancel_quiz_abc-123')).toEqual({ kind: 'quiz', refId: 'abc-123' });
+      expect(svc.parseResourceId('cancel_lp_xyz')).toEqual({ kind: 'lesson_plan', refId: 'xyz' });
+      expect(svc.parseResourceId('cancel_video')).toEqual({ kind: 'video', refId: null });
+      expect(svc.parseResourceId('garbage')).toEqual({ kind: 'unknown' });
+      expect(svc.parseResourceId('')).toEqual({ kind: 'unknown' });
+    });
+  });
+
+  describe('listActiveResources', () => {
+    it('returns [] for a falsy userId', async () => {
+      const { svc } = load();
+      expect(await svc.listActiveResources(null)).toEqual([]);
+    });
+
+    it('lists an active quiz (skipping all-terminal ones), coaching, LP, and redis flows', async () => {
+      const { svc } = load({
+        tableResults: {
+          quizzes: { data: [{ id: 'q1', topic: 'Fractions', list_id: 'l1', student_lists: { class_name: '5', section: 'A' } }] },
+          quiz_sessions: { data: [{ status: 'sent' }] }, // not all terminal → keep
+          coaching_sessions: { data: [{ id: 'c1', status: 'analyzing', created_at: new Date().toISOString() }] },
+          lesson_plan_requests: { data: [{ id: 'lp1', topic: 'Atoms', status: 'processing', created_at: new Date().toISOString() }] },
+        },
+        redisStore: { 'user:u1:awaiting_video_topic': '1', 'reading:user:u1:current_assessment': '1' },
+      });
+      const items = await svc.listActiveResources('u1');
+      const kinds = items.map(i => i.kind);
+      expect(kinds).toEqual(expect.arrayContaining(['quiz', 'coaching', 'lesson_plan', 'video', 'reading']));
+      const quiz = items.find(i => i.kind === 'quiz');
+      expect(quiz.id).toBe('cancel_quiz_q1');
+      expect(quiz.title).toContain('5-A');
+    });
+
+    it('skips a quiz whose every session is terminal', async () => {
+      const { svc } = load({
+        tableResults: {
+          quizzes: { data: [{ id: 'q1', topic: 'X', student_lists: null }] },
+          quiz_sessions: { data: [{ status: 'completed' }, { status: 'expired' }] },
+        },
+      });
+      const items = await svc.listActiveResources('u1');
+      expect(items.find(i => i.kind === 'quiz')).toBeUndefined();
+    });
+  });
+
+  describe('cancelResource', () => {
+    it('cancels a quiz via the orchestrator', async () => {
+      const { svc, cancelQuizSpy } = load();
+      const res = await svc.cancelResource({ kind: 'quiz', refId: 'q1' }, 'u1');
+      expect(res.ok).toBe(true);
+      expect(cancelQuizSpy).toHaveBeenCalledWith('q1', 'u1');
+    });
+
+    it('cancels coaching + LP via supabase update', async () => {
+      const { svc, updateSpy } = load();
+      const c = await svc.cancelResource({ kind: 'coaching', refId: 'c1' }, 'u1');
+      const lp = await svc.cancelResource({ kind: 'lesson_plan', refId: 'lp1' }, 'u1');
+      expect(c.ok).toBe(true);
+      expect(lp.ok).toBe(true);
+      expect(updateSpy).toHaveBeenCalledWith({ status: 'cancelled' });
+    });
+
+    it('cancels redis-backed flows via del', async () => {
+      const { svc, delSpy } = load();
+      expect((await svc.cancelResource({ kind: 'video' }, 'u1')).ok).toBe(true);
+      expect((await svc.cancelResource({ kind: 'reading' }, 'u1')).ok).toBe(true);
+      expect((await svc.cancelResource({ kind: 'attendance' }, 'u1')).ok).toBe(true);
+      expect(delSpy).toHaveBeenCalled();
+    });
+
+    it('rejects an invalid resource', async () => {
+      const { svc } = load();
+      expect((await svc.cancelResource(null, 'u1')).ok).toBe(false);
+      expect((await svc.cancelResource({ kind: 'bogus' }, 'u1')).ok).toBe(false);
+    });
+  });
+});
+
+// ── status-flow-endpoint ──────────────────────────────────────────────────────
+describe('status-flow-endpoint', () => {
+  function load({ items = [], cancelResult } = {}) {
+    jest.resetModules();
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    const listMock = jest.fn().mockResolvedValue(items);
+    const cancelMock = jest.fn().mockResolvedValue(cancelResult || { ok: true, message: '🛑 stopped' });
+    const parseMock = jest.fn((id) => {
+      if (id === 'done') return { kind: 'done' };
+      const m = id.match(/^cancel_(quiz|coaching|lp|video|reading|attendance)/);
+      return m ? { kind: 'quiz' } : { kind: 'unknown' };
+    });
+    jest.doMock('../../bot/shared/services/teacher-state.service', () => ({
+      listActiveResources: listMock,
+      cancelResource: cancelMock,
+      parseResourceId: parseMock,
+    }));
+    const ep = require('../../bot/shared/routes/status-flow-endpoint');
+    return { ep, listMock, cancelMock };
+  }
+
+  it('INIT with no active resources returns a polite SUCCESS', async () => {
+    const { ep } = load({ items: [] });
+    const res = await ep.handleStatusFlowInit('u1');
+    expect(res.screen).toBe('SUCCESS');
+    expect(res.data.extension_message_response.params.status_action).toBe('idle');
+  });
+
+  it('INIT with active resources returns MAIN with a Done row appended', async () => {
+    const { ep } = load({ items: [{ id: 'cancel_video', title: 'Video generation', kind: 'video' }] });
+    const res = await ep.handleStatusFlowInit('u1');
+    expect(res.screen).toBe('MAIN');
+    expect(res.data.resources.map(r => r.id)).toContain('done');
+    expect(res.data.summary_heading).toContain('1 thing');
+  });
+
+  it('data_exchange MAIN with "done" returns SUCCESS', async () => {
+    const { ep } = load({ items: [] });
+    const res = await ep.handleStatusFlowDataExchange('u1', 'MAIN', { _action: 'done' });
+    expect(res.screen).toBe('SUCCESS');
+  });
+
+  it('data_exchange MAIN with a resource id returns CONFIRM_CANCEL carrying the label', async () => {
+    const { ep } = load({ items: [{ id: 'cancel_video', title: 'Video generation', kind: 'video' }] });
+    const res = await ep.handleStatusFlowDataExchange('u1', 'MAIN', { _action: 'cancel_video' });
+    expect(res.screen).toBe('CONFIRM_CANCEL');
+    expect(res.data.resource_id).toBe('cancel_video');
+    expect(res.data.resource_label).toBe('Video generation');
+  });
+
+  it('data_exchange MAIN with no action errors', async () => {
+    const { ep } = load();
+    const res = await ep.handleStatusFlowDataExchange('u1', 'MAIN', {});
+    expect(res.data.error).toBeDefined();
+  });
+
+  it('data_exchange CONFIRM_CANCEL cancels the matched resource', async () => {
+    const { ep, cancelMock } = load({
+      items: [{ id: 'cancel_video', title: 'Video generation', kind: 'video' }],
+      cancelResult: { ok: true, message: '🛑 Video flow stopped on our end.' },
+    });
+    const res = await ep.handleStatusFlowDataExchange('u1', 'CONFIRM_CANCEL', { resource_id: 'cancel_video' });
+    expect(res.screen).toBe('SUCCESS');
+    expect(res.data.extension_message_response.params.status_action).toBe('cancelled');
+    expect(cancelMock).toHaveBeenCalled();
+  });
+
+  it('data_exchange CONFIRM_CANCEL on a vanished resource returns a noop SUCCESS', async () => {
+    const { ep } = load({ items: [] });
+    const res = await ep.handleStatusFlowDataExchange('u1', 'CONFIRM_CANCEL', { resource_id: 'cancel_video' });
+    expect(res.screen).toBe('SUCCESS');
+    expect(res.data.extension_message_response.params.status_action).toBe('noop');
+  });
+
+  it('BACK returns the MAIN init payload', async () => {
+    const { ep } = load({ items: [{ id: 'cancel_video', title: 'Video generation', kind: 'video' }] });
+    const res = await ep.handleStatusFlowBack('u1', 'SUCCESS');
+    expect(res.screen).toBe('MAIN');
+  });
+});
+
+// ── flow JSON + leak gate ─────────────────────────────────────────────────────
+describe('status-flow.json', () => {
+  const flowPath = path.join(__dirname, '../../docs/flows/status-flow.json');
+
+  it('is valid JSON with forward-only MAIN → CONFIRM_CANCEL → SUCCESS routing', () => {
+    const flow = JSON.parse(fs.readFileSync(flowPath, 'utf8'));
+    expect(flow.routing_model.MAIN).toEqual(['CONFIRM_CANCEL', 'SUCCESS']);
+    expect(flow.routing_model.CONFIRM_CANCEL).toEqual(['SUCCESS']);
+    expect(flow.screens.map(s => s.id).sort()).toEqual(['CONFIRM_CANCEL', 'MAIN', 'SUCCESS']);
+  });
+
+  it('is leak-free (no internal phone/name/path/bead tokens)', () => {
+    const raw = fs.readFileSync(flowPath, 'utf8');
+    const svcSrc = fs.readFileSync(path.join(__dirname, '../../bot/shared/services/teacher-state.service.js'), 'utf8');
+    const epSrc = fs.readFileSync(path.join(__dirname, '../../bot/shared/routes/status-flow-endpoint.js'), 'utf8');
+    for (const banned of ['+92', '+255', '0329', '5012345', 'Taleemabad', 'Rawalpindi', 'TaleemHub', 'bd-', 'PROJ-', 'Silverleaf']) {
+      expect(raw).not.toContain(banned);
+      expect(svcSrc).not.toContain(banned);
+      expect(epSrc).not.toContain(banned);
+    }
+  });
+});


### PR DESCRIPTION
## Phase 4E — status flow (2 of 5)

Ports the **/status** WhatsApp Flow + its backing `teacher-state` service. A teacher sees everything in flight (quizzes / coaching / LPs / video / reading / attendance) and can cancel any of it.

### What's added
- **teacher-state.service.js** — `listActiveResources`, `cancelResource` (orchestrator path for quiz; DB status flip for coaching/LP; Redis delete for video/reading/attendance), `parseResourceId`, `probeTeacherBusy`. Every probe is fail-open so a DB/Redis blip never breaks the command.
- **status-flow-endpoint.js** — `INIT` / `data_exchange` / `BACK`; forward-only `MAIN → CONFIRM_CANCEL → SUCCESS`; labels re-derived server-side (no trust in client state).
- `POST /status` mounted in flow-endpoint.routes.js.
- **/status** command trigger in text-message.handler.js.
- `STATUS_FLOW_ID` constant + `.env.template` entry.
- **docs/flows/status-flow.json**.

### Presence gating
When `STATUS_FLOW_ID` is unset, `/status` still works — it renders a plain-text summary of active resources instead of the interactive Flow.

### Tests
18 new tests (service listing/cancel/parse, endpoint screens, flow-JSON validity, leak gate). Full suite: **71 suites / 952 passing**. Bot-only deps mocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)