### PR TITLE
feat(student-videos): Student Video Library flow + feedback survey — Phase 4E

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -157,6 +157,9 @@ EXAM_CHECKER_STUDENTS_FLOW_ID=
 SETTINGS_FLOW_ID=
 # Status flow — empty makes /status fall back to a plain-text summary.
 STATUS_FLOW_ID=
+# Student Video Library flow — when set, /video opens the library picker;
+# when empty, /video uses the runtime video generator.
+STUDENT_VIDEOS_FLOW_ID=
 
 # --- Optional: BullMQ Worker --------------------------------------------------
 # Configuration for background job processing

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -249,6 +249,23 @@ async function handleTextMessage(message, from, messageBody, user = null) {
   // ============================================================
   const trimmedMessage = messageBody.trim().toLowerCase();
 
+  // Student Video feedback reason capture — if the teacher tapped "Not really"
+  // on a recent video survey and is within the 10-min reason window, capture
+  // this text as the reason and short-circuit. Slash commands bypass this
+  // (handled inside consumeReasonIfPending).
+  if (user?.id && messageBody) {
+    try {
+      const StudentVideoFeedbackService = require('../services/student-video-feedback.service');
+      const consumed = await StudentVideoFeedbackService.consumeReasonIfPending(user.id, from, messageBody);
+      if (consumed) {
+        logToFile('Text consumed as Student Video feedback reason — short-circuit', { userId: user.id });
+        return;
+      }
+    } catch (svFbErr) {
+      logToFile('Student Video Feedback: consumeReasonIfPending error', { error: svFbErr.message });
+    }
+  }
+
   // When user taps ice breaker, WhatsApp sends the ice breaker text as message
   const iceBreakers = {
     'show menu - see all features i can help with': 'menu',
@@ -503,6 +520,28 @@ async function handleTextMessage(message, from, messageBody, user = null) {
         from,
         'Sorry, I could not find your account. Please send me a message first to register.\n\nمعذرت، میں آپ کا اکاؤنٹ نہیں مل سکا۔'
       );
+      return;
+    }
+
+    // Presence-gated: when STUDENT_VIDEOS_FLOW_ID is set, /video opens the
+    // pre-made Student Video Library picker. When it is empty, /video falls
+    // through to the runtime video generator below.
+    const STUDENT_VIDEOS_FLOW_ID = process.env.STUDENT_VIDEOS_FLOW_ID || '';
+    if (STUDENT_VIDEOS_FLOW_ID) {
+      typingController.stop();
+      const flowToken = `${user?.id || 'anon'}:student-videos:${Date.now()}`;
+      await WhatsAppService.sendFlow(from, {
+        flowId: STUDENT_VIDEOS_FLOW_ID,
+        header: '🎬 Student Videos',
+        body: ({
+          ur: 'اپنی کلاس، مضمون اور موضوع چنیں — میں ویڈیو آپ کی چیٹ میں بھیج دوں گا۔',
+        })[responseLanguage] || 'Pick a class, subject and topic — I will send the video to your chat.',
+        buttonText: ({
+          ur: 'تلاش کریں',
+        })[responseLanguage] || 'Browse',
+        flowToken,
+      });
+      logToFile('🎬 Sent student videos flow (/video)', { userId: user?.id });
       return;
     }
 

--- a/bot/shared/routes/flow-endpoint.routes.js
+++ b/bot/shared/routes/flow-endpoint.routes.js
@@ -45,6 +45,11 @@ const {
   handleStatusFlowDataExchange,
   handleStatusFlowBack
 } = require('./status-flow-endpoint');
+const {
+  handleStudentVideosInit,
+  handleStudentVideosDataExchange,
+  handleStudentVideosBack
+} = require('./student-videos-endpoint');
 
 /**
  * Handle attendance marking flow data requests
@@ -681,6 +686,43 @@ async function handleStatusFlowRequest(data) {
   if (action === 'BACK')                      return await handleStatusFlowBack(userId, screen, flow_token);
 
   logToFile('Unknown status flow action', { action });
+  return FlowEncryptionService.createErrorResponse('Unknown action');
+}
+
+// ============================================================
+// STUDENT VIDEOS FLOW ENDPOINT — browse the library + deliver to chat
+// ============================================================
+
+router.post('/student-videos', async (req, res) => {
+  try {
+    if (!FlowEncryptionService.isConfigured()) {
+      logToFile('Flow encryption not configured', { endpoint: 'student-videos' });
+      return res.status(500).json({ error: 'Flow encryption not configured' });
+    }
+    const encryptedResponse = await FlowEncryptionService.processEncryptedRequest(
+      req.body,
+      async (decryptedData) => handleStudentVideosFlow(decryptedData)
+    );
+    res.set('Content-Type', 'text/plain');
+    res.send(encryptedResponse);
+  } catch (error) {
+    logToFile('Student Videos flow endpoint error', {
+      endpoint: 'student-videos',
+      error: error.message,
+      stack: error.stack,
+    });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+async function handleStudentVideosFlow(data) {
+  const { action, flow_token, screen, data: screenData } = data;
+  logToFile('Handling Student Videos flow', { action, screen, hasFlowToken: !!flow_token });
+  if (action === 'ping') return FlowEncryptionService.handlePing();
+  if (action === 'INIT' || action === 'init') return await handleStudentVideosInit(flow_token);
+  if (action === 'data_exchange')             return await handleStudentVideosDataExchange(flow_token, screen, screenData);
+  if (action === 'BACK')                      return await handleStudentVideosBack(flow_token, screen);
+  logToFile('Unknown student-videos flow action', { action });
   return FlowEncryptionService.createErrorResponse('Unknown action');
 }
 

--- a/bot/shared/routes/student-videos-endpoint.js
+++ b/bot/shared/routes/student-videos-endpoint.js
@@ -1,0 +1,266 @@
+/**
+ * Student Videos Flow Endpoint
+ *
+ * Screens: SELECT_GRADE → SELECT_SUBJECT → SELECT_TOPIC → SUCCESS
+ *
+ * Lets a teacher browse the student_videos library by grade → subject →
+ * video, then delivers the chosen video to their chat and schedules a
+ * post-delivery 👍/👎 survey.
+ *
+ * The video list is labelled by `subtopic` (falling back to `topic`), grouped
+ * by `topic`; the chapter prefix is shown only when ≥ 2 videos share a topic.
+ * SELECT_TOPIC's payload carries the video row id directly (no fragile text
+ * re-resolution). A "Sending your video…" ack is dispatched before the async
+ * upload so the teacher sees instant acknowledgement during the upload window.
+ */
+
+const supabase = require('../config/supabase');
+const { logToFile } = require('../utils/logger');
+const { logEvent } = require('../utils/structured-logger');
+const WhatsAppService = require('../services/whatsapp.service');
+const StudentVideoFeedbackService = require('../services/student-video-feedback.service');
+
+const GRADE_ORDER = ['NURSERY', 'KG', '1', '2', '3', '4', '5', '6'];
+const gradeRank = (g) => {
+  const i = GRADE_ORDER.indexOf(String(g));
+  return i === -1 ? 99 : i;
+};
+const gradeTitle = (g) => {
+  const s = String(g);
+  if (s === 'NURSERY') return 'Nursery';
+  if (s === 'KG') return 'KG';
+  return `Grade ${s}`;
+};
+
+// The per-video display label: the specific subtopic when present, else the topic.
+const videoTitle = (r) => (r.subtopic && r.subtopic.trim()) ? r.subtopic : (r.topic || 'Untitled');
+
+async function fetchVideos(filter = {}) {
+  let q = supabase
+    .from('student_videos')
+    .select('id,grade,subject,topic,subtopic,video_url');
+  for (const [k, v] of Object.entries(filter)) q = q.eq(k, v);
+  const { data, error } = await q;
+  if (error) {
+    logToFile('Student Videos: supabase error', { error: error.message, filter });
+    return [];
+  }
+  // Only rows with a playable URL are deliverable.
+  return (data || []).filter((r) => r.video_url);
+}
+
+function distinct(rows, key) {
+  return [...new Set(rows.map((r) => r[key]).filter((v) => v != null && v !== ''))];
+}
+
+async function getPhoneForUser(userId) {
+  if (!userId) return null;
+  const { data } = await supabase
+    .from('users')
+    .select('phone_number')
+    .eq('id', userId)
+    .single();
+  return data?.phone_number || null;
+}
+
+// ---------- INIT ----------
+async function handleStudentVideosInit(flowToken) {
+  logToFile('Student Videos Flow INIT', { flowToken });
+  const rows = await fetchVideos();
+  const grades = distinct(rows, 'grade')
+    .sort((a, b) => gradeRank(a) - gradeRank(b))
+    .map((g) => ({ id: String(g), title: gradeTitle(g) }));
+  if (grades.length === 0) {
+    return { screen: 'SELECT_GRADE', data: { grades: [], error: { message: 'The video library is being prepared. Please try again later.' } } };
+  }
+  return { screen: 'SELECT_GRADE', data: { grades } };
+}
+
+// ---------- DATA EXCHANGE ----------
+async function handleStudentVideosDataExchange(flowToken, screen, screenData) {
+  logToFile('Student Videos data_exchange', { flowToken, screen, screenData });
+  if (screen === 'SELECT_GRADE') return selectGrade(screenData);
+  if (screen === 'SELECT_SUBJECT') return selectSubject(screenData);
+  if (screen === 'SELECT_TOPIC') return selectTopic(flowToken, screenData);
+  logToFile('Student Videos: unknown screen', { screen });
+  return { data: { error: { message: 'Something went wrong.' } } };
+}
+
+// SELECT_GRADE → SELECT_SUBJECT
+async function selectGrade(screenData) {
+  const grade = screenData && screenData.grade;
+  if (!grade) return { data: { error: { message: 'Please select a class.' } } };
+  const rows = await fetchVideos({ grade });
+  const subjects = distinct(rows, 'subject')
+    .sort()
+    .map((s) => ({ id: s, title: s }));
+  if (subjects.length === 0) {
+    return { data: { error: { message: `No videos available for ${gradeTitle(grade)} yet.` } } };
+  }
+  return {
+    screen: 'SELECT_SUBJECT',
+    data: { subjects, grade_value: String(grade), grade_display: gradeTitle(grade) },
+  };
+}
+
+// SELECT_SUBJECT → SELECT_TOPIC (single combined list, topic as inline prefix)
+async function selectSubject(screenData) {
+  const grade = screenData && screenData.grade;
+  const subject = screenData && screenData.subject;
+  if (!grade || !subject) return { data: { error: { message: 'Please select a subject.' } } };
+  const rows = await fetchVideos({ grade, subject });
+  if (rows.length === 0) {
+    return { data: { error: { message: `No ${subject} videos for ${gradeTitle(grade)} yet.` } } };
+  }
+
+  // Count topic sizes so we know whether to render the topic prefix.
+  // Prefix shown ONLY when ≥ 2 videos share the topic (otherwise it's noise).
+  const topicCount = new Map();
+  for (const r of rows) {
+    const t = r.topic || '';
+    topicCount.set(t, (topicCount.get(t) || 0) + 1);
+  }
+
+  // Sort by (topic, title) so grouped videos cluster visually.
+  rows.sort((a, b) => {
+    const at = (a.topic || '').toLowerCase();
+    const bt = (b.topic || '').toLowerCase();
+    if (at !== bt) return at < bt ? -1 : 1;
+    const al = videoTitle(a).toLowerCase();
+    const bl = videoTitle(b).toLowerCase();
+    return al < bl ? -1 : al > bl ? 1 : 0;
+  });
+
+  const videos = rows.map((r) => {
+    const title = videoTitle(r);
+    const topic = r.topic;
+    const show_prefix = topic && topic.toLowerCase() !== title.toLowerCase() &&
+      (topicCount.get(topic) || 0) >= 2;
+    return {
+      id: r.id, // pass the row id directly — no fragile text re-resolution.
+      title: show_prefix ? `${topic} · ${title}` : title,
+    };
+  });
+
+  return {
+    screen: 'SELECT_TOPIC',
+    data: {
+      videos,
+      grade_value: String(grade),
+      subject_value: subject,
+      header_text: `${gradeTitle(grade)} — ${subject}`,
+    },
+  };
+}
+
+// SELECT_TOPIC → SUCCESS (resolve by row id; ack + deliver)
+async function selectTopic(flowToken, screenData) {
+  const grade = screenData && screenData.grade;
+  const subject = screenData && screenData.subject;
+  const videoId = screenData && screenData.video;
+  if (!grade || !subject || !videoId) {
+    return { data: { error: { message: 'Please pick a video.' } } };
+  }
+  const { data: row, error } = await supabase
+    .from('student_videos')
+    .select('id,grade,subject,topic,subtopic,video_url')
+    .eq('id', videoId)
+    .single();
+  if (error || !row || !row.video_url) {
+    logToFile('Student Videos: row lookup failed', { videoId, error: error?.message });
+    return { data: { error: { message: 'That video is not available right now.' } } };
+  }
+
+  await sendPreDeliveryAck(flowToken, row);
+  deliverVideoAsync(flowToken, row);
+
+  return {
+    screen: 'SUCCESS',
+    data: {
+      message: `Your video "${videoTitle(row)}" (${gradeTitle(row.grade)} ${row.subject}) is on its way!`,
+    },
+  };
+}
+
+// Immediate chat ack so the teacher sees feedback during the upload window.
+async function sendPreDeliveryAck(flowToken, row) {
+  const userId = (flowToken || '').split(':')[0];
+  try {
+    const phone = await getPhoneForUser(userId);
+    if (!phone) return;
+    await WhatsAppService.sendMessage(
+      phone,
+      `🎬 Sending your video: ${gradeTitle(row.grade)} ${row.subject} — ${videoTitle(row)} …`
+    );
+  } catch (err) {
+    logToFile('Student Videos: pre-delivery ack failed', { error: err.message });
+  }
+}
+
+// Fire-and-forget upload. Schedules the 30s post-delivery survey ONLY when the
+// upload succeeds — a failed upload should not ask the teacher to rate a video
+// they never received.
+function deliverVideoAsync(flowToken, row) {
+  const userId = (flowToken || '').split(':')[0];
+  (async () => {
+    let phone;
+    try {
+      phone = await getPhoneForUser(userId);
+      if (!phone) {
+        logToFile('Student Videos: no phone for user', { userId });
+        return;
+      }
+      const caption = `📚 ${gradeTitle(row.grade)} · ${row.subject}\n${videoTitle(row)}`;
+      await WhatsAppService.sendVideoFromUrl(phone, row.video_url, caption);
+      logEvent('student_videos.delivered', {
+        userId,
+        videoId: row.id,
+        grade: row.grade,
+        subject: row.subject,
+        topic: row.topic,
+        subtopic: row.subtopic,
+      });
+    } catch (err) {
+      logToFile('Student Videos: delivery failed', { userId, videoId: row.id, error: err.message });
+      return; // don't schedule feedback for a delivery that failed
+    }
+    // Post-delivery survey — 30s after upload completes.
+    try {
+      const { data: userRow } = await supabase
+        .from('users')
+        .select('preferred_language')
+        .eq('id', userId)
+        .maybeSingle();
+      const language = userRow?.preferred_language || 'en';
+      StudentVideoFeedbackService.scheduleFeedbackPrompt({
+        videoId: row.id,
+        userId,
+        phone,
+        context: {
+          grade: row.grade,
+          subject: row.subject,
+          topic: row.topic,
+          subtopic: row.subtopic,
+          language,
+        },
+      });
+    } catch (err) {
+      logToFile('Student Videos: scheduleFeedbackPrompt threw', { userId, videoId: row.id, error: err.message });
+    }
+  })();
+}
+
+// Back navigation: return to the first screen's data.
+async function handleStudentVideosBack(flowToken, screen) {
+  return handleStudentVideosInit(flowToken);
+}
+
+module.exports = {
+  handleStudentVideosInit,
+  handleStudentVideosDataExchange,
+  handleStudentVideosBack,
+  // exported for tests
+  gradeTitle,
+  gradeRank,
+  videoTitle,
+};

--- a/bot/shared/services/student-video-feedback.service.js
+++ b/bot/shared/services/student-video-feedback.service.js
@@ -1,0 +1,348 @@
+/**
+ * Student Video Feedback Service
+ *
+ * Post-delivery thumbs-up / thumbs-down micro-survey for the Student Video
+ * Library:
+ *
+ *  1. scheduleFeedbackPrompt(...) — called from student-videos-endpoint
+ *     deliverVideoAsync(...) AFTER the video is sent successfully.
+ *  2. sendFeedbackPrompt(...) — fires `delayMs` (30s) later via setTimeout;
+ *     sends a 2-button interactive message (👍 Yes / 👎 Not really).
+ *  3. handleFeedbackButton(...) — webhook button handler for
+ *     student_video_feedback_yes_* / student_video_feedback_no_* button ids.
+ *     - Inserts a row into student_video_feedback (or no-ops on duplicate).
+ *     - On "no": sets Redis flag student_video_feedback_pending:{userId} and
+ *       sends a "What didn't work?" follow-up.
+ *  4. consumeReasonIfPending(...) — called from text-message.handler BEFORE
+ *     any routing; if the Redis flag is set, captures the next inbound text
+ *     as the reason and returns true so the handler short-circuits.
+ *
+ * Design tradeoffs:
+ *  - Detached setTimeout for the 30s delay (lost on bot restart; acceptable
+ *    at low-volume scale — upgrade to a delayed queue message if loss > 5%).
+ *  - Redis flag with TTL = 600s = 10-min reason-capture window.
+ *  - Single row per (user, video) — duplicate taps update `useful` and re-arm
+ *    the Redis flag if the user toggles their answer.
+ */
+
+const supabase = require('../config/supabase');
+const redisService = require('./cache/railway-redis.service');
+const WhatsAppService = require('./whatsapp.service');
+const { logEvent } = require('../utils/structured-logger');
+const { logToFile } = require('../utils/logger');
+
+// 30s after video delivery.
+const FEEDBACK_DELAY_MS = 30 * 1000;
+const REASON_WINDOW_SECS = 600;                // 10-min reason-capture window
+const REDIS_REASON_KEY = (userId) => `student_video_feedback_pending:${userId}`;
+
+const BUTTON_RX = /^student_video_feedback_(yes|no)_([0-9a-f-]{36})$/;
+
+function gradeTitle(g) {
+  const s = String(g || '');
+  if (s === 'NURSERY') return 'Nursery';
+  if (s === 'KG') return 'KG';
+  if (!s) return '';
+  return `Grade ${s}`;
+}
+
+/**
+ * Localized final ack after the teacher sends a reason.
+ * Falls back to detected reasonLanguage then to English.
+ */
+async function _localizedFinalAck(userId, reasonLanguage) {
+  let lang = reasonLanguage || 'en';
+  try {
+    const { data: userRow } = await supabase
+      .from('users')
+      .select('preferred_language')
+      .eq('id', userId)
+      .maybeSingle();
+    if (userRow?.preferred_language) lang = userRow.preferred_language;
+  } catch (_) { /* fall through to reasonLanguage */ }
+  switch (lang) {
+    case 'ur': return 'سمجھ گئی، شکریہ — یہ ہمیں ویڈیو لائبریری بہتر بنانے میں مدد کرے گا۔';
+    case 'sd': return 'سمجھ ۾ آيو، مهرباني — اھو اسان کي وڊيو لائبريري بهتر ڪرڻ ۾ مدد ڪندو۔';
+    case 'pa': return 'سمجھ گئی، شکریہ — ایہ سانوں ویڈیو لائبریری بہتر بنان وچ مدد کرے گا۔';
+    default: return 'Got it, thanks — this helps us improve the video library.';
+  }
+}
+
+/**
+ * Schedule a feedback prompt to fire `delayMs` after delivery.
+ * Non-blocking — returns immediately; the prompt fires via setTimeout.
+ *
+ * @param {Object} opts
+ * @param {string} opts.videoId - UUID of the student_videos row delivered
+ * @param {string} opts.userId  - Teacher's user_id (UUID)
+ * @param {string} opts.phone   - Teacher's phone (for sendInteractiveButtons)
+ * @param {Object} opts.context - { grade, subject, topic, subtopic, language }
+ * @param {number} [opts.delayMs=30000] - Delay before sending prompt
+ */
+function scheduleFeedbackPrompt(opts) {
+  const { videoId, userId, phone, context = {}, delayMs = FEEDBACK_DELAY_MS } = opts;
+  if (!videoId || !userId || !phone) {
+    logToFile('Student Video Feedback: scheduleFeedbackPrompt missing field', { videoId, userId, phone });
+    return;
+  }
+  logEvent('student_video.feedback_prompt.scheduled', {
+    videoId, userId, phone, delayMs, ...context,
+  });
+  setTimeout(() => {
+    sendFeedbackPrompt({ videoId, userId, phone, context }).catch((err) => {
+      logToFile('Student Video Feedback: sendFeedbackPrompt threw', { error: err.message, videoId });
+    });
+  }, delayMs).unref?.();
+}
+
+/**
+ * Send the 2-button "Did you like the video?" message.
+ */
+async function sendFeedbackPrompt({ videoId, userId, phone, context }) {
+  const language = (context && context.language) || 'en';
+  const isUrduLike = language === 'ur' || language === 'sd' || language === 'pa';
+
+  let body;
+  if (language === 'ur') {
+    body = 'کیا آپ کو یہ ویڈیو پسند آئی؟';
+  } else if (language === 'sd') {
+    body = 'ڇا توھان کي اھا وڊيو پسند آئي؟';
+  } else if (language === 'pa') {
+    body = 'کیہہ تہانوں ایہ ویڈیو پسند آئی؟';
+  } else {
+    body = 'Did you like that video?';
+  }
+
+  // 20-char button cap; emoji counts as 2.
+  const buttonYes = isUrduLike ? '👍 ہاں' : '👍 Yes';
+  const buttonNo  = isUrduLike ? '👎 نہیں' : '👎 Not really';
+  const buttons = [
+    { id: `student_video_feedback_yes_${videoId}`, title: buttonYes },
+    { id: `student_video_feedback_no_${videoId}`,  title: buttonNo  },
+  ];
+
+  const ok = await WhatsAppService.sendInteractiveButtons(phone, { body, buttons });
+
+  logEvent('student_video.feedback_prompt.sent', {
+    videoId, userId, phone, ok, ...context,
+  });
+}
+
+/**
+ * Handle a student_video_feedback_{yes,no}_* button reply.
+ * Called from whatsapp-bot.js button_reply router.
+ *
+ * @param {string} buttonId Full button id (e.g. "student_video_feedback_yes_<uuid>")
+ * @param {string} phone Teacher phone (sender of the tap)
+ * @returns {Promise<boolean>} true if matched & handled, false otherwise
+ */
+async function handleFeedbackButton(buttonId, phone) {
+  const match = BUTTON_RX.exec(buttonId || '');
+  if (!match) return false;
+
+  const useful = match[1] === 'yes';
+  const videoId = match[2];
+
+  // Look up the video row + the user (resolve user_id from phone)
+  const { data: video, error: videoError } = await supabase
+    .from('student_videos')
+    .select('id, grade, subject, topic, subtopic')
+    .eq('id', videoId)
+    .maybeSingle();
+  if (videoError || !video) {
+    logToFile('Student Video Feedback: button tap for unknown video id', { videoId, err: videoError?.message });
+    await WhatsAppService.sendMessage(phone, 'Thanks for the feedback!');
+    return true;
+  }
+
+  const { data: userRow, error: userError } = await supabase
+    .from('users')
+    .select('id, preferred_language')
+    .eq('phone_number', phone)
+    .maybeSingle();
+  if (userError || !userRow) {
+    logToFile('Student Video Feedback: phone → user lookup failed', { phone, err: userError?.message });
+    await WhatsAppService.sendMessage(phone, 'Thanks for the feedback!');
+    return true;
+  }
+  const userId = userRow.id;
+  const language = userRow.preferred_language || 'en';
+
+  // Idempotent: check for an existing row for (user, video).
+  const { data: existing } = await supabase
+    .from('student_video_feedback')
+    .select('id, useful')
+    .eq('user_id', userId)
+    .eq('video_id', videoId)
+    .maybeSingle();
+
+  if (existing) {
+    if (existing.useful !== useful) {
+      await supabase.from('student_video_feedback').update({ useful }).eq('id', existing.id);
+    }
+    logEvent('student_video.feedback.button_tapped_duplicate', {
+      videoId, userId, phone, useful, existingId: existing.id,
+    });
+    if (useful) {
+      await WhatsAppService.sendMessage(phone, _ackYes(language));
+    } else {
+      await redisService.set(
+        REDIS_REASON_KEY(userId),
+        { feedbackId: existing.id, polarity: 'disliked', promptedAt: Date.now() },
+        REASON_WINDOW_SECS
+      );
+      await WhatsAppService.sendMessage(phone, _ackNoReasonPrompt(language));
+    }
+    return true;
+  }
+
+  // Insert the feedback row
+  const { data: inserted, error: insertError } = await supabase
+    .from('student_video_feedback')
+    .insert({
+      user_id: userId,
+      video_id: videoId,
+      useful,
+      grade: video.grade,
+      subject: video.subject,
+      topic: video.topic,
+      subtopic: video.subtopic,
+    })
+    .select('id')
+    .single();
+
+  if (insertError || !inserted) {
+    logEvent('student_video.feedback.insert_failed', {
+      videoId, userId, phone, useful, error: insertError?.message || 'insert returned no row',
+    });
+    if (useful) {
+      await WhatsAppService.sendMessage(phone, _ackYes(language));
+    } else {
+      await redisService.set(
+        REDIS_REASON_KEY(userId),
+        { feedbackId: '__orphan__', videoId, promptedAt: Date.now() },
+        REASON_WINDOW_SECS
+      );
+      await WhatsAppService.sendMessage(phone, _ackNoReasonPrompt(language));
+    }
+    return true;
+  }
+
+  logEvent('student_video.feedback.button_tapped', {
+    videoId, userId, phone, useful, feedbackId: inserted.id,
+  });
+
+  if (useful) {
+    await WhatsAppService.sendMessage(phone, _ackYes(language));
+  } else {
+    await redisService.set(
+      REDIS_REASON_KEY(userId),
+      { feedbackId: inserted.id, polarity: 'disliked', promptedAt: Date.now() },
+      REASON_WINDOW_SECS
+    );
+    await WhatsAppService.sendMessage(phone, _ackNoReasonPrompt(language));
+  }
+  return true;
+}
+
+function _ackYes(language) {
+  switch (language) {
+    case 'ur': return 'شکریہ — خوشی ہے یہ مفید تھی!';
+    case 'sd': return 'مهرباني — خوشي آھي ته اھا مفيد ھئي!';
+    case 'pa': return 'شکریہ — خوشی اے ایہ فائدہ مند سی!';
+    default:   return 'Thanks — glad it helped!';
+  }
+}
+
+function _ackNoReasonPrompt(language) {
+  switch (language) {
+    case 'ur': return 'بتانے کا شکریہ۔ کیا چیز کام نہیں آئی؟ (ایک سطر کا جواب کافی ہے)';
+    case 'sd': return 'ٻڌائڻ جو شڪريو۔ ڪھڙي شيءَ ڪم نه آئي؟ (ھڪ لائين ڪافي آھي)';
+    case 'pa': return 'دسن دا شکریہ۔ کیہڑی شے کم نہیں آئی؟ (اک لائن کافی اے)';
+    default:   return "Thanks for letting us know. What didn't work? (one line is enough)";
+  }
+}
+
+/**
+ * Capture the next inbound text as the reason if the Redis flag is set.
+ * Returns true if consumed (so the caller short-circuits).
+ */
+async function consumeReasonIfPending(userId, phone, text) {
+  if (!userId || !text || !text.trim()) return false;
+
+  let pending;
+  try {
+    pending = await redisService.get(REDIS_REASON_KEY(userId));
+  } catch (err) {
+    logToFile('Student Video Feedback: Redis get error (reason consumer)', { error: err.message });
+    return false;
+  }
+  if (!pending || !pending.feedbackId) return false;
+
+  // Slash commands → let the router handle
+  if (text.trim().startsWith('/')) {
+    logEvent('student_video.feedback.reason_skipped_slash_command', {
+      userId, phone, feedbackId: pending.feedbackId,
+    });
+    return false;
+  }
+
+  // Clear flag first so a failed UPDATE doesn't trap the user
+  try { await redisService.delete(REDIS_REASON_KEY(userId)); } catch (_) { /* non-fatal */ }
+
+  // Heuristic: Arabic/Urdu/Persian script blocks → 'ur', else 'en'.
+  const hasUrduScript = /[؀-ۿݐ-ݿﭐ-﷿ﹰ-﻿]/.test(text);
+  const reasonLanguage = hasUrduScript ? 'ur' : 'en';
+  const reasonTrimmed = text.trim().slice(0, 2000);
+
+  if (pending.feedbackId === '__orphan__') {
+    logEvent('student_video.feedback.reason_received_orphan', {
+      userId, phone, reasonLanguage, reasonLength: reasonTrimmed.length,
+      reasonText: reasonTrimmed, videoId: pending.videoId || null,
+    });
+    await WhatsAppService.sendMessage(phone, await _localizedFinalAck(userId, reasonLanguage));
+    return true;
+  }
+
+  const reasonPolarity =
+    pending.polarity === 'liked' ? 'liked' :
+    pending.polarity === 'disliked' ? 'disliked' :
+    'disliked';
+
+  const { error: updateError } = await supabase
+    .from('student_video_feedback')
+    .update({
+      reason_text: reasonTrimmed,
+      reason_received_at: new Date().toISOString(),
+      reason_language: reasonLanguage,
+      reason_polarity: reasonPolarity,
+    })
+    .eq('id', pending.feedbackId);
+
+  if (updateError) {
+    logToFile('Student Video Feedback: reason UPDATE failed', {
+      error: updateError.message, feedbackId: pending.feedbackId,
+    });
+    return false;
+  }
+
+  logEvent('student_video.feedback.reason_received', {
+    userId, phone, feedbackId: pending.feedbackId, reasonLanguage,
+    reasonLength: reasonTrimmed.length,
+  });
+  await WhatsAppService.sendMessage(phone, await _localizedFinalAck(userId, reasonLanguage));
+  return true;
+}
+
+module.exports = {
+  scheduleFeedbackPrompt,
+  sendFeedbackPrompt,
+  handleFeedbackButton,
+  consumeReasonIfPending,
+  // exported for tests:
+  FEEDBACK_DELAY_MS,
+  REASON_WINDOW_SECS,
+  REDIS_REASON_KEY,
+  BUTTON_RX,
+  gradeTitle,
+};

--- a/bot/shared/utils/constants.js
+++ b/bot/shared/utils/constants.js
@@ -26,6 +26,9 @@ const SETTINGS_FLOW_ID = process.env.SETTINGS_FLOW_ID || '';
 // WhatsApp Flow ID for the /status snapshot (empty → /status falls back to a
 // plain-text summary instead of the interactive Flow).
 const STATUS_FLOW_ID = process.env.STATUS_FLOW_ID || '';
+// WhatsApp Flow ID for the Student Video Library picker. When set, /video
+// opens the library; when empty, /video uses the runtime video generator.
+const STUDENT_VIDEOS_FLOW_ID = process.env.STUDENT_VIDEOS_FLOW_ID || '';
 
 // Pic-to-LP (photo → illustrated lesson plan)
 const KIE_API_KEY = process.env.KIE_API_KEY;
@@ -127,6 +130,7 @@ module.exports = {
   ATTENDANCE_MARKING_FLOW_ID,
   SETTINGS_FLOW_ID,
   STATUS_FLOW_ID,
+  STUDENT_VIDEOS_FLOW_ID,
 
   // Pic-to-LP
   KIE_API_KEY,

--- a/bot/whatsapp-bot.js
+++ b/bot/whatsapp-bot.js
@@ -797,6 +797,10 @@ app.post('/webhook', async (req, res) => {
         } catch (err) {
           logToFile('❌ quiz intent button routing failed', { buttonId, error: err.message });
         }
+      // Student Video Library post-delivery survey (👍 Yes / 👎 Not really).
+      else if (buttonId.startsWith('student_video_feedback_yes_') || buttonId.startsWith('student_video_feedback_no_')) {
+        const StudentVideoFeedbackService = require('./shared/services/student-video-feedback.service');
+        await StudentVideoFeedbackService.handleFeedbackButton(buttonId, from);
       } else {
         logToFile('⚠️ Unknown button ID', { buttonId });
       }

--- a/docs/flows/student-videos-flow.json
+++ b/docs/flows/student-videos-flow.json
@@ -1,0 +1,112 @@
+{
+  "version": "6.3",
+  "data_api_version": "3.0",
+  "routing_model": {
+    "SELECT_GRADE": ["SELECT_SUBJECT"],
+    "SELECT_SUBJECT": ["SELECT_TOPIC"],
+    "SELECT_TOPIC": ["SUCCESS"],
+    "SUCCESS": []
+  },
+  "screens": [
+    {
+      "id": "SELECT_GRADE",
+      "title": "Student Videos",
+      "data": {
+        "grades": {
+          "type": "array",
+          "items": { "type": "object", "properties": { "id": { "type": "string" }, "title": { "type": "string" } } },
+          "__example__": [ { "id": "NURSERY", "title": "Nursery" }, { "id": "1", "title": "Grade 1" } ]
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "grade_form",
+            "children": [
+              { "type": "TextHeading", "text": "Student Learning Videos" },
+              { "type": "TextBody", "text": "Free educational videos for your students. Pick a class to begin." },
+              { "type": "Dropdown", "name": "grade", "label": "Class / Grade", "required": true, "data-source": "${data.grades}" },
+              { "type": "Footer", "label": "Next", "on-click-action": { "name": "data_exchange", "payload": { "grade": "${form.grade}" } } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SELECT_SUBJECT",
+      "title": "Select Subject",
+      "data": {
+        "subjects": {
+          "type": "array",
+          "items": { "type": "object", "properties": { "id": { "type": "string" }, "title": { "type": "string" } } },
+          "__example__": [ { "id": "English", "title": "English" }, { "id": "Maths", "title": "Maths" } ]
+        },
+        "grade_value": { "type": "string", "__example__": "1" },
+        "grade_display": { "type": "string", "__example__": "Grade 1" }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "subject_form",
+            "children": [
+              { "type": "TextHeading", "text": "${data.grade_display}" },
+              { "type": "TextBody", "text": "Choose a subject." },
+              { "type": "Dropdown", "name": "subject", "label": "Subject", "required": true, "data-source": "${data.subjects}" },
+              { "type": "Footer", "label": "Next", "on-click-action": { "name": "data_exchange", "payload": { "grade": "${data.grade_value}", "subject": "${form.subject}" } } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SELECT_TOPIC",
+      "title": "Pick a Video",
+      "data": {
+        "videos": {
+          "type": "array",
+          "items": { "type": "object", "properties": { "id": { "type": "string" }, "title": { "type": "string" } } },
+          "__example__": [ { "id": "row-uuid-1", "title": "Numbers · Identifying Even and Odd Numbers" } ]
+        },
+        "grade_value": { "type": "string", "__example__": "3" },
+        "subject_value": { "type": "string", "__example__": "Maths" },
+        "header_text": { "type": "string", "__example__": "Grade 3 — Maths" }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "video_form",
+            "children": [
+              { "type": "TextHeading", "text": "${data.header_text}" },
+              { "type": "TextBody", "text": "Pick a video — it will land in your chat in a few seconds." },
+              { "type": "Dropdown", "name": "video", "label": "Video", "required": true, "data-source": "${data.videos}" },
+              { "type": "Footer", "label": "Send Video", "on-click-action": { "name": "data_exchange", "payload": { "grade": "${data.grade_value}", "subject": "${data.subject_value}", "video": "${form.video}" } } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SUCCESS",
+      "title": "Video On The Way",
+      "terminal": true,
+      "data": {
+        "message": { "type": "string", "__example__": "Your video \"Identifying Even and Odd Numbers\" (Grade 3 Maths) is on its way!" }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          { "type": "TextHeading", "text": "Sent!" },
+          { "type": "TextBody", "text": "${data.message}" },
+          { "type": "TextBody", "text": "Check your chat — the video will arrive in a few seconds. You can close this form now." },
+          { "type": "Footer", "label": "Done", "on-click-action": { "name": "complete", "payload": {} } }
+        ]
+      }
+    }
+  ]
+}

--- a/infrastructure/supabase/00_complete-schema.sql
+++ b/infrastructure/supabase/00_complete-schema.sql
@@ -567,6 +567,32 @@ CREATE TABLE IF NOT EXISTS student_videos (
     PRIMARY KEY (id)
 );
 
+-- Post-delivery thumbs-up / thumbs-down micro-survey on Student Video Library
+-- deliveries. One row per (user, video) button tap; reason_text is UPDATEd on
+-- the same row when the teacher replies to the follow-up within the 10-min window.
+CREATE TABLE IF NOT EXISTS student_video_feedback (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    video_id UUID REFERENCES student_videos(id) ON DELETE SET NULL,
+    useful BOOLEAN NOT NULL,
+    reason_text TEXT,
+    reason_received_at TIMESTAMPTZ,
+    reason_language TEXT,
+    reason_polarity TEXT CHECK (reason_polarity IN ('liked', 'disliked', 'unknown')),
+    -- Snapshot of the video context so feedback stays queryable if the
+    -- student_videos row is later updated.
+    grade VARCHAR(50),
+    subject VARCHAR(100),
+    topic VARCHAR(200),
+    subtopic VARCHAR(200),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_student_video_feedback_user_time
+    ON student_video_feedback (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_student_video_feedback_useful_time
+    ON student_video_feedback (useful, created_at DESC);
+
 -- ---------------------------------------------------------------------------
 -- Attendance
 -- ---------------------------------------------------------------------------

--- a/tests/student-videos/student-videos-flow.test.js
+++ b/tests/student-videos/student-videos-flow.test.js
@@ -1,0 +1,268 @@
+/**
+ * Student Videos flow — endpoint (grade→subject→video browse + deliver) and
+ * the feedback service (schedule / button / reason capture). Adapted to the
+ * open-source student_videos schema (topic / subtopic / video_url). Bot-only
+ * deps mocked for the root-before-bot-ci test ordering.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// A supabase mock that honours .eq() filtering, .single/.maybeSingle, insert,
+// and update over in-memory datasets keyed by table name.
+function makeSupabase(datasets) {
+  const store = JSON.parse(JSON.stringify(datasets));
+  function builder(table) {
+    let rows = (store[table] || []).slice();
+    const filters = [];
+    const api = {
+      select() { return api; },
+      eq(k, v) { filters.push([k, v]); rows = rows.filter(r => String(r[k]) === String(v)); return api; },
+      in(k, vs) { rows = rows.filter(r => vs.includes(r[k])); return api; },
+      not() { return api; },
+      gte() { return api; },
+      order() { return api; },
+      limit() { return api; },
+      maybeSingle() { return Promise.resolve({ data: rows[0] || null, error: null }); },
+      single() { return Promise.resolve({ data: rows[0] || null, error: rows[0] ? null : { message: 'no rows' } }); },
+      insert(payload) {
+        const row = { id: `gen-${(store[table] || []).length + 1}`, ...payload };
+        store[table] = store[table] || [];
+        store[table].push(row);
+        return {
+          select() { return { single: () => Promise.resolve({ data: { id: row.id }, error: null }) }; },
+          then: (res) => res({ data: row, error: null }),
+        };
+      },
+      update(patch) {
+        return {
+          eq(k, v) {
+            (store[table] || []).forEach(r => { if (String(r[k]) === String(v)) Object.assign(r, patch); });
+            return Promise.resolve({ data: null, error: null });
+          },
+        };
+      },
+      then(resolve) { return resolve({ data: rows, error: null }); },
+    };
+    return api;
+  }
+  return { from: jest.fn((t) => builder(t)), __store: store };
+}
+
+const VIDEOS = [
+  { id: 'v1', grade: '3', subject: 'Maths', topic: 'Numbers', subtopic: 'Even and Odd', video_url: 'https://x/v1.mp4' },
+  { id: 'v2', grade: '3', subject: 'Maths', topic: 'Numbers', subtopic: 'Place Value', video_url: 'https://x/v2.mp4' },
+  { id: 'v3', grade: '3', subject: 'English', topic: 'Phonics', subtopic: null, video_url: 'https://x/v3.mp4' },
+  { id: 'v4', grade: '1', subject: 'Maths', topic: 'Counting', subtopic: null, video_url: null }, // no url → excluded
+];
+
+// ── endpoint ──────────────────────────────────────────────────────────────
+describe('student-videos-endpoint', () => {
+  let ep, scheduleSpy, sendMsgSpy, sendVideoSpy;
+
+  function load(videos = VIDEOS) {
+    jest.resetModules();
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/utils/structured-logger', () => ({ logEvent: jest.fn() }));
+    const supa = makeSupabase({
+      student_videos: videos,
+      users: [{ id: 'u1', phone_number: '15551230000', preferred_language: 'en' }],
+    });
+    jest.doMock('../../bot/shared/config/supabase', () => supa);
+    sendMsgSpy = jest.fn().mockResolvedValue(true);
+    sendVideoSpy = jest.fn().mockResolvedValue(true);
+    jest.doMock('../../bot/shared/services/whatsapp.service', () => ({
+      sendMessage: sendMsgSpy, sendVideoFromUrl: sendVideoSpy,
+    }));
+    scheduleSpy = jest.fn();
+    jest.doMock('../../bot/shared/services/student-video-feedback.service', () => ({
+      scheduleFeedbackPrompt: scheduleSpy,
+    }));
+    ep = require('../../bot/shared/routes/student-videos-endpoint');
+  }
+
+  it('INIT lists grades sorted, excluding rows without a video_url', async () => {
+    load();
+    const res = await ep.handleStudentVideosInit('u1:student-videos:1');
+    expect(res.screen).toBe('SELECT_GRADE');
+    // grade 1's only video has no url → grade 1 dropped; only grade 3 remains
+    expect(res.data.grades.map(g => g.id)).toEqual(['3']);
+  });
+
+  it('INIT with an empty library returns an error message', async () => {
+    load([]);
+    const res = await ep.handleStudentVideosInit('u1');
+    expect(res.data.error).toBeDefined();
+  });
+
+  it('SELECT_GRADE → subjects for that grade', async () => {
+    load();
+    const res = await ep.handleStudentVideosDataExchange('u1', 'SELECT_GRADE', { grade: '3' });
+    expect(res.screen).toBe('SELECT_SUBJECT');
+    expect(res.data.subjects.map(s => s.id).sort()).toEqual(['English', 'Maths']);
+    expect(res.data.grade_display).toBe('Grade 3');
+  });
+
+  it('SELECT_SUBJECT → videos, prefixing the topic only when ≥2 share it', async () => {
+    load();
+    const res = await ep.handleStudentVideosDataExchange('u1', 'SELECT_SUBJECT', { grade: '3', subject: 'Maths' });
+    expect(res.screen).toBe('SELECT_TOPIC');
+    const titles = res.data.videos.map(v => v.title);
+    // both Maths videos share topic "Numbers" (≥2) → prefixed
+    expect(titles).toContain('Numbers · Even and Odd');
+    expect(titles).toContain('Numbers · Place Value');
+  });
+
+  it('SELECT_SUBJECT → singleton topic uses the bare title (subtopic null → topic)', async () => {
+    load();
+    const res = await ep.handleStudentVideosDataExchange('u1', 'SELECT_SUBJECT', { grade: '3', subject: 'English' });
+    expect(res.data.videos[0].title).toBe('Phonics'); // subtopic null → falls back to topic, no prefix
+  });
+
+  it('SELECT_TOPIC delivers the video, returns SUCCESS, and schedules feedback', async () => {
+    load();
+    const res = await ep.handleStudentVideosDataExchange('u1:student-videos:1', 'SELECT_TOPIC', { grade: '3', subject: 'Maths', video: 'v1' });
+    expect(res.screen).toBe('SUCCESS');
+    expect(res.data.message).toContain('Even and Odd');
+    // deliverVideoAsync runs on next tick — flush microtasks
+    await new Promise(r => setImmediate(r));
+    expect(sendVideoSpy).toHaveBeenCalledWith('15551230000', 'https://x/v1.mp4', expect.stringContaining('Even and Odd'));
+    expect(scheduleSpy).toHaveBeenCalledWith(expect.objectContaining({ videoId: 'v1', userId: 'u1' }));
+  });
+
+  it('SELECT_TOPIC with an unknown video id errors', async () => {
+    load();
+    const res = await ep.handleStudentVideosDataExchange('u1', 'SELECT_TOPIC', { grade: '3', subject: 'Maths', video: 'nope' });
+    expect(res.data.error).toBeDefined();
+  });
+
+  it('gradeTitle / videoTitle helpers', () => {
+    load();
+    expect(ep.gradeTitle('NURSERY')).toBe('Nursery');
+    expect(ep.gradeTitle('4')).toBe('Grade 4');
+    expect(ep.videoTitle({ subtopic: 'Sub', topic: 'Top' })).toBe('Sub');
+    expect(ep.videoTitle({ subtopic: null, topic: 'Top' })).toBe('Top');
+  });
+});
+
+// ── feedback service ────────────────────────────────────────────────────────
+describe('student-video-feedback.service', () => {
+  let svc, supa, redisStore, sendMsgSpy, sendBtnSpy;
+
+  function load({ videos, users, feedback = [], redis = {} } = {}) {
+    jest.resetModules();
+    // The endpoint describe doMock'd this module; make sure we get the REAL one.
+    jest.dontMock('../../bot/shared/services/student-video-feedback.service');
+    jest.useFakeTimers();
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/utils/structured-logger', () => ({ logEvent: jest.fn() }));
+    supa = makeSupabase({
+      student_videos: videos || [{ id: 'v1', grade: '3', subject: 'Maths', topic: 'Numbers', subtopic: 'Even and Odd' }],
+      users: users || [{ id: 'u1', phone_number: '15551230000', preferred_language: 'en' }],
+      student_video_feedback: feedback,
+    });
+    jest.doMock('../../bot/shared/config/supabase', () => supa);
+    redisStore = { ...redis };
+    jest.doMock('../../bot/shared/services/cache/railway-redis.service', () => ({
+      isAvailable: () => true,
+      set: jest.fn((k, v) => { redisStore[k] = v; return Promise.resolve(true); }),
+      get: jest.fn((k) => Promise.resolve(redisStore[k] || null)),
+      delete: jest.fn((k) => { delete redisStore[k]; return Promise.resolve(true); }),
+    }));
+    sendMsgSpy = jest.fn().mockResolvedValue(true);
+    sendBtnSpy = jest.fn().mockResolvedValue(true);
+    jest.doMock('../../bot/shared/services/whatsapp.service', () => ({
+      sendMessage: sendMsgSpy, sendInteractiveButtons: sendBtnSpy,
+    }));
+    svc = require('../../bot/shared/services/student-video-feedback.service');
+  }
+  afterEach(() => { jest.useRealTimers(); });
+
+  it('BUTTON_RX matches yes/no with a uuid', () => {
+    load();
+    expect(svc.BUTTON_RX.test('student_video_feedback_yes_123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+    expect(svc.BUTTON_RX.test('student_video_feedback_maybe_x')).toBe(false);
+  });
+
+  it('scheduleFeedbackPrompt fires the 2-button prompt after the delay', async () => {
+    load();
+    svc.scheduleFeedbackPrompt({ videoId: 'v1', userId: 'u1', phone: '15551230000', context: { language: 'en' } });
+    jest.advanceTimersByTime(svc.FEEDBACK_DELAY_MS);
+    await Promise.resolve(); await Promise.resolve();
+    expect(sendBtnSpy).toHaveBeenCalled();
+    const arg = sendBtnSpy.mock.calls[0][1];
+    expect(arg.buttons.map(b => b.id)).toEqual(['student_video_feedback_yes_v1', 'student_video_feedback_no_v1']);
+  });
+
+  it('scheduleFeedbackPrompt no-ops when a field is missing', () => {
+    load();
+    svc.scheduleFeedbackPrompt({ videoId: 'v1', userId: 'u1' }); // no phone
+    jest.advanceTimersByTime(svc.FEEDBACK_DELAY_MS);
+    expect(sendBtnSpy).not.toHaveBeenCalled();
+  });
+
+  const VID = '123e4567-e89b-12d3-a456-426614174000'; // 36-char uuid (BUTTON_RX requires it)
+
+  it('handleFeedbackButton "yes" inserts a row and acks', async () => {
+    load({ videos: [{ id: VID, grade: '3', subject: 'Maths', topic: 'Numbers', subtopic: 'Even and Odd' }] });
+    const ok = await svc.handleFeedbackButton(`student_video_feedback_yes_${VID}`, '15551230000');
+    expect(ok).toBe(true);
+    expect(supa.__store.student_video_feedback.length).toBe(1);
+    expect(supa.__store.student_video_feedback[0].useful).toBe(true);
+    expect(sendMsgSpy).toHaveBeenCalled();
+  });
+
+  it('handleFeedbackButton "no" sets the reason flag and prompts', async () => {
+    load({ videos: [{ id: VID, grade: '3', subject: 'Maths', topic: 'Numbers', subtopic: 'Even and Odd' }] });
+    await svc.handleFeedbackButton(`student_video_feedback_no_${VID}`, '15551230000');
+    expect(redisStore['student_video_feedback_pending:u1']).toBeDefined();
+    expect(sendMsgSpy).toHaveBeenCalled();
+  });
+
+  it('handleFeedbackButton returns false for a non-matching id', async () => {
+    load();
+    expect(await svc.handleFeedbackButton('something_else', '15551230000')).toBe(false);
+  });
+
+  it('consumeReasonIfPending captures the reason text and updates the row', async () => {
+    load({
+      feedback: [{ id: 'f1', user_id: 'u1', video_id: 'v1', useful: false }],
+      redis: { 'student_video_feedback_pending:u1': { feedbackId: 'f1', polarity: 'disliked', promptedAt: Date.now() } },
+    });
+    const consumed = await svc.consumeReasonIfPending('u1', '15551230000', 'audio was muffled');
+    expect(consumed).toBe(true);
+    const row = supa.__store.student_video_feedback.find(r => r.id === 'f1');
+    expect(row.reason_text).toBe('audio was muffled');
+    expect(redisStore['student_video_feedback_pending:u1']).toBeUndefined();
+  });
+
+  it('consumeReasonIfPending returns false with no pending flag, and skips slash commands', async () => {
+    load();
+    expect(await svc.consumeReasonIfPending('u1', '15551230000', 'hello')).toBe(false);
+    // with a flag but a slash command → not consumed
+    redisStore['student_video_feedback_pending:u1'] = { feedbackId: 'f1', polarity: 'disliked' };
+    expect(await svc.consumeReasonIfPending('u1', '15551230000', '/menu')).toBe(false);
+  });
+});
+
+// ── flow JSON + leak gate ─────────────────────────────────────────────────────
+describe('student-videos-flow.json', () => {
+  const flowPath = path.join(__dirname, '../../docs/flows/student-videos-flow.json');
+
+  it('is valid JSON with grade → subject → topic → success routing', () => {
+    const flow = JSON.parse(fs.readFileSync(flowPath, 'utf8'));
+    expect(flow.routing_model.SELECT_GRADE).toEqual(['SELECT_SUBJECT']);
+    expect(flow.routing_model.SELECT_TOPIC).toEqual(['SUCCESS']);
+  });
+
+  it('is leak-free (no internal phone/name/path/bead tokens)', () => {
+    const raw = fs.readFileSync(flowPath, 'utf8');
+    const epSrc = fs.readFileSync(path.join(__dirname, '../../bot/shared/routes/student-videos-endpoint.js'), 'utf8');
+    const svcSrc = fs.readFileSync(path.join(__dirname, '../../bot/shared/services/student-video-feedback.service.js'), 'utf8');
+    for (const banned of ['+92', '+255', '0329', '5012345', 'Taleemabad', 'Rawalpindi', 'TaleemHub', 'bd-', 'PROJ-', 'Silverleaf', 'Sindh broadcast']) {
+      expect(raw).not.toContain(banned);
+      expect(epSrc).not.toContain(banned);
+      expect(svcSrc).not.toContain(banned);
+    }
+  });
+});


### PR DESCRIPTION
## Phase 4E — student-videos flow (3 of 5)

Ports the pre-made **Student Video Library** picker and its post-delivery 👍/👎 micro-survey, adapted to the open-source `student_videos` schema (`topic`/`subtopic`/`video_url` — the prod `clean_*`/`migration_status`/`r2_url` columns don't exist here).

### What's added
- **student-videos-endpoint.js** — `SELECT_GRADE → SELECT_SUBJECT → SELECT_TOPIC → SUCCESS`. Lists videos labelled by `subtopic` (falls back to `topic`), grouped by `topic` with a prefix only when ≥2 share it. Resolves by row id, sends a pre-delivery chat ack, delivers async, and schedules feedback **only** on a successful upload.
- **student-video-feedback.service.js** — 30s `setTimeout`-scheduled 2-button survey, idempotent button handler (insert/update `student_video_feedback`), 10-min Redis reason-capture window, `consumeReasonIfPending` short-circuit.
- `student_video_feedback` table → `00_complete-schema.sql`.
- `POST /student-videos` mounted in flow-endpoint.routes.js.
- **/video presence-gated**: opens the library when `STUDENT_VIDEOS_FLOW_ID` is set, otherwise uses the runtime generator (replaces prod's region check with presence gating).
- Reason-consumer intercept in text-message.handler.js + 👍/👎 button branch in whatsapp-bot.js.
- `STUDENT_VIDEOS_FLOW_ID` constant + `.env.template`.
- **docs/flows/student-videos-flow.json**.

### Tests
18 new tests (browse/deliver, feedback schedule/button/reason capture, flow-JSON validity, leak gate). Full suite: **72 suites / 970 passing**. Bot-only deps mocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)