### PR TITLE
feat(homework): homework request flow + pdf-lib bundle worker — Phase 4E

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -160,6 +160,8 @@ STATUS_FLOW_ID=
 # Student Video Library flow — when set, /video opens the library picker;
 # when empty, /video uses the runtime video generator.
 STUDENT_VIDEOS_FLOW_ID=
+# Homework request flow — empty disables the /homework command.
+HOMEWORK_FLOW_ID=
 
 # --- Optional: BullMQ Worker --------------------------------------------------
 # Configuration for background job processing

--- a/bot/shared/handlers/homework-trigger.js
+++ b/bot/shared/handlers/homework-trigger.js
@@ -1,0 +1,26 @@
+'use strict';
+/**
+ * Pure, dependency-free decision helper for the homework hot-trigger.
+ * Kept separate from text-message.handler so it is unit-testable without the
+ * handler's full dependency graph.
+ */
+
+// Whole message "homework" / "home work" / "hw" / "/homework" (any case), or
+// the Urdu equivalents. Anchored so it never collides with the LP trigger
+// (e.g. "lesson plan for homework" must NOT fire).
+const HOMEWORK_TRIGGER_RX = /^\s*\/?\s*(home\s?work|hw|ہوم\s*ورک|گھر\s*کا\s*کام)\s*$/i;
+
+/**
+ * Region-agnostic / presence-gated: the flow is offered iff HOMEWORK_FLOW_ID
+ * is configured and we have a user. Side-effect-free.
+ * @returns {{match:false}} | {{match:true, action:'send_flow'|'guard'}}
+ */
+function evaluateHomeworkTrigger({ messageBody, user, homeworkFlowId }) {
+  if (!HOMEWORK_TRIGGER_RX.test(messageBody || '')) return { match: false };
+  if (homeworkFlowId && user) {
+    return { match: true, action: 'send_flow' };
+  }
+  return { match: true, action: 'guard' };
+}
+
+module.exports = { HOMEWORK_TRIGGER_RX, evaluateHomeworkTrigger };

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -79,6 +79,9 @@ async function tryCurriculumLessonPlanServe(from, topic, user, language) {
  * @param {Object|null} user - User object from database (optional for backwards compatibility)
  * @returns {Promise<void>}
  */
+
+const { evaluateHomeworkTrigger } = require('./homework-trigger');
+
 async function handleTextMessage(message, from, messageBody, user = null) {
   logToFile(`Processing TEXT message: ${messageBody}`);
 
@@ -1271,6 +1274,40 @@ async function handleTextMessage(message, from, messageBody, user = null) {
   }
 
   // ============================================================
+  // HOMEWORK hot trigger — "homework" / "home work" / "hw" / "/homework".
+  // Anchored so it never collides with the LP trigger. Presence-gated on
+  // HOMEWORK_FLOW_ID; offers the homework request flow.
+  // ============================================================
+  {
+    const HOMEWORK_FLOW_ID = process.env.HOMEWORK_FLOW_ID || '';
+    const hwDecision = evaluateHomeworkTrigger({ messageBody, user, homeworkFlowId: HOMEWORK_FLOW_ID });
+    if (hwDecision.match) {
+      typingController.stop();
+      if (hwDecision.action === 'send_flow' && user) {
+        const flowToken = `${user.id}:homework:${Date.now()}`;
+        await WhatsAppService.sendFlow(from, {
+          flowId: HOMEWORK_FLOW_ID,
+          header: 'Homework',
+          body: ({
+            ur: 'اپنی جماعت، مضمون اور وہ ابواب منتخب کریں جو آپ پڑھا چکے ہیں۔',
+          })[responseLanguage] || 'Pick your class, subject and the chapters you have already taught.',
+          buttonText: ({
+            ur: 'ہوم ورک حاصل کریں',
+          })[responseLanguage] || 'Get Homework',
+          flowToken,
+        });
+        logToFile('📚 Homework flow offered (hot trigger)', { userId: user.id });
+        return;
+      }
+      // Guard: unregistered user or flow id not configured.
+      await WhatsAppService.sendMessage(from, ({
+        ur: 'ہوم ورک فی الحال دستیاب نہیں ہے۔ براہ کرم بعد میں دوبارہ کوشش کریں۔',
+      })[responseLanguage] || 'Homework is not available right now. Please try again later.');
+      return;
+    }
+  }
+
+  // ============================================================
   // ATTENDANCE SYSTEM INTEGRATION (bd-060)
   // ============================================================
   // Check if user is in an active attendance session
@@ -2268,5 +2305,6 @@ function parseStyleFromButtonId(buttonId) {
 
 module.exports = {
   handleTextMessage,
-  parseStyleFromButtonId
+  parseStyleFromButtonId,
+  evaluateHomeworkTrigger, // exported for trigger unit tests
 };

--- a/bot/shared/routes/flow-endpoint.routes.js
+++ b/bot/shared/routes/flow-endpoint.routes.js
@@ -50,6 +50,11 @@ const {
   handleStudentVideosDataExchange,
   handleStudentVideosBack
 } = require('./student-videos-endpoint');
+const {
+  handleHomeworkInit,
+  handleHomeworkDataExchange,
+  handleHomeworkBack
+} = require('./homework-request-endpoint');
 
 /**
  * Handle attendance marking flow data requests
@@ -723,6 +728,43 @@ async function handleStudentVideosFlow(data) {
   if (action === 'data_exchange')             return await handleStudentVideosDataExchange(flow_token, screen, screenData);
   if (action === 'BACK')                      return await handleStudentVideosBack(flow_token, screen);
   logToFile('Unknown student-videos flow action', { action });
+  return FlowEncryptionService.createErrorResponse('Unknown action');
+}
+
+// ============================================================
+// HOMEWORK REQUEST FLOW ENDPOINT — browse chapters + enqueue bundle jobs
+// ============================================================
+
+router.post('/homework-request', async (req, res) => {
+  try {
+    if (!FlowEncryptionService.isConfigured()) {
+      logToFile('Flow encryption not configured', { endpoint: 'homework-request' });
+      return res.status(500).json({ error: 'Flow encryption not configured' });
+    }
+    const encryptedResponse = await FlowEncryptionService.processEncryptedRequest(
+      req.body,
+      async (decryptedData) => handleHomeworkFlow(decryptedData)
+    );
+    res.set('Content-Type', 'text/plain');
+    res.send(encryptedResponse);
+  } catch (error) {
+    logToFile('Homework flow endpoint error', {
+      endpoint: 'homework-request',
+      error: error.message,
+      stack: error.stack,
+    });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+async function handleHomeworkFlow(data) {
+  const { action, flow_token, screen, data: screenData } = data;
+  logToFile('Handling Homework flow', { action, screen, hasFlowToken: !!flow_token });
+  if (action === 'ping') return FlowEncryptionService.handlePing();
+  if (action === 'INIT' || action === 'init') return await handleHomeworkInit(flow_token);
+  if (action === 'data_exchange')             return await handleHomeworkDataExchange(flow_token, screen, screenData);
+  if (action === 'BACK')                      return await handleHomeworkBack(flow_token, screen);
+  logToFile('Unknown homework flow action', { action });
   return FlowEncryptionService.createErrorResponse('Unknown action');
 }
 

--- a/bot/shared/routes/homework-request-endpoint.js
+++ b/bot/shared/routes/homework-request-endpoint.js
@@ -1,0 +1,295 @@
+/**
+ * Homework Request Flow Endpoint
+ *
+ * Multi-select (grade + subject + chapters). Submission does NOT deliver
+ * inline — it enqueues `homework_bundle_generation` jobs (one per grade×subject
+ * group) which the homework-bundle worker pdf-lib-merges and streams
+ * asynchronously. The Flow returns an immediate SUCCESS ack.
+ *
+ * Screens: SELECT_GRADE → SELECT_CHAPTERS → SUCCESS
+ *  (grade + subject picked on screen 1; chapters multi-checkbox on screen 2)
+ *
+ * Region-agnostic: the feature is gated by the presence of HOMEWORK_FLOW_ID
+ * (set in the bot) and populated homework_chapters rows — no region check here.
+ *
+ * Flow token format: `${userId}:homework:${ts}`.
+ */
+
+const supabase = require('../config/supabase');
+const { logToFile } = require('../utils/logger');
+const { logEvent } = require('../utils/structured-logger');
+const SQSQueueService = require('../services/queue/sqs-queue.service');
+const HomeworkLookup = require('../services/homework-lookup.service');
+
+// Soft cap = 12 chapters/request (~36 MB) — validated client + server. Over →
+// friendly "request fewer" screen; NOT a hard block.
+const HOMEWORK_SOFT_CAP = 12;
+
+const GRADES = [
+  { id: '1', title: 'Grade 1' },
+  { id: '2', title: 'Grade 2' },
+  { id: '3', title: 'Grade 3' },
+  { id: '4', title: 'Grade 4' },
+  { id: '5', title: 'Grade 5' },
+];
+
+const SUBJECTS = [
+  { id: 'maths', title: 'Maths' },
+  { id: 'english', title: 'English' },
+  { id: 'urdu', title: 'Urdu' },
+];
+
+const SUBJECT_DISPLAY = { maths: 'Maths', english: 'English', urdu: 'Urdu' };
+
+async function getPhoneForUser(userId) {
+  if (!userId) return null;
+  const { data } = await supabase
+    .from('users')
+    .select('phone_number')
+    .eq('id', userId)
+    .maybeSingle();
+  return data?.phone_number || null;
+}
+
+/**
+ * INIT — first screen with grade + subject options.
+ */
+async function handleHomeworkInit(flowToken) {
+  logToFile('Homework Request Flow INIT', { flowToken });
+  return {
+    screen: 'SELECT_GRADE',
+    data: { grades: GRADES, subjects: SUBJECTS },
+  };
+}
+
+/**
+ * Parse the screen's chapter selection into normalized selection groups.
+ * Accepts either:
+ *  - { selections_json: '[{grade,subject,chapters:[..]}]' } (multi-group)
+ *  - { grade, subject, chapters:[..] } (single group convenience)
+ */
+function parseSelections(screenData) {
+  if (screenData && typeof screenData.selections_json === 'string') {
+    try {
+      const parsed = JSON.parse(screenData.selections_json);
+      if (Array.isArray(parsed)) return parsed;
+    } catch (_) { /* fall through */ }
+  }
+  if (screenData && screenData.grade && screenData.subject) {
+    const chapters = Array.isArray(screenData.chapters)
+      ? screenData.chapters.map(Number)
+      : [];
+    return [{
+      grade: parseInt(screenData.grade, 10),
+      subject: String(screenData.subject),
+      chapters,
+    }];
+  }
+  return [];
+}
+
+function totalChapters(selections) {
+  return selections.reduce(
+    (n, g) => n + (Array.isArray(g.chapters) ? new Set(g.chapters.map(Number)).size : 0),
+    0
+  );
+}
+
+/**
+ * data_exchange — route by screen.
+ */
+async function handleHomeworkDataExchange(flowToken, screen, screenData) {
+  logToFile('Homework Request data_exchange', { flowToken, screen });
+  const userId = (flowToken || '').split(':')[0];
+
+  if (screen === 'SELECT_GRADE') {
+    return handleSelectGrade(screenData);
+  }
+  if (screen === 'SELECT_CHAPTERS') {
+    return handleSelectChapters(userId, screenData, flowToken);
+  }
+
+  logToFile('Homework Request: unknown screen', { screen });
+  return { data: { error: { message: 'Something went wrong.' } } };
+}
+
+/**
+ * SELECT_GRADE → SELECT_CHAPTERS: build the dynamic chapter checklist.
+ */
+async function handleSelectGrade(screenData) {
+  const grade = parseInt(screenData.grade, 10);
+  const subject = screenData.subject;
+
+  if (!grade || !subject) {
+    return { data: { error: { message: 'Please select both grade and subject.' } } };
+  }
+
+  const chapters = await HomeworkLookup.findHomeworkChapters({ grade, subject });
+  if (!chapters.length) {
+    return {
+      data: {
+        error: {
+          message: `No homework found for Grade ${grade} ${SUBJECT_DISPLAY[subject] || subject} yet.`,
+        },
+      },
+    };
+  }
+
+  const chapterOptions = chapters.map(ch => ({
+    id: String(ch.chapter_number),
+    title: `Ch${ch.chapter_number}: ${ch.chapter_title || ''}`.trim(),
+  }));
+
+  return {
+    screen: 'SELECT_CHAPTERS',
+    data: {
+      chapters: chapterOptions,
+      grade_display: `Grade ${grade} — ${SUBJECT_DISPLAY[subject] || subject}`,
+      grade_value: String(grade),
+      subject_value: subject,
+      soft_cap: HOMEWORK_SOFT_CAP,
+    },
+  };
+}
+
+/**
+ * SELECT_CHAPTERS submit → enqueue one bundle job per (grade×subject),
+ * write the tracking row, return the immediate ack SUCCESS screen.
+ */
+async function handleSelectChapters(userId, screenData, flowToken) {
+  const selections = parseSelections(screenData);
+
+  if (!selections.length || totalChapters(selections) === 0) {
+    return { data: { error: { message: 'Please select at least one chapter.' } } };
+  }
+
+  // Soft cap (server-side; client also enforces). Friendly screen, NOT a hard block.
+  const count = totalChapters(selections);
+  if (count > HOMEWORK_SOFT_CAP) {
+    logEvent('homework.flow.soft_cap_hit', { userId, requested: count, cap: HOMEWORK_SOFT_CAP });
+    return {
+      screen: 'SELECT_CHAPTERS',
+      data: {
+        error: {
+          message: `You picked ${count} chapters. To keep the files quick to download, please request up to ${HOMEWORK_SOFT_CAP} chapters at a time — then send "homework" again for the rest.`,
+        },
+      },
+    };
+  }
+
+  // Resolve to deliverable chapters with R2 keys, grouped per grade×subject.
+  const resolved = await HomeworkLookup.resolveSelection(selections);
+  if (!resolved.length) {
+    return {
+      data: {
+        error: { message: 'Those chapters are not available yet. Please try a different selection.' },
+      },
+    };
+  }
+
+  const phone = await getPhoneForUser(userId);
+
+  // Group by (grade × subject) — one PDF + one SQS job per group.
+  const groups = new Map();
+  for (const r of resolved) {
+    const key = `${r.grade}::${r.subject}`;
+    if (!groups.has(key)) groups.set(key, { grade: r.grade, subject: r.subject, chapters: [] });
+    groups.get(key).chapters.push({
+      chapter: r.chapter, chapter_title: r.chapter_title, r2_key: r.r2_key,
+    });
+  }
+  const groupList = Array.from(groups.values());
+
+  // Tracking row: one lesson_plan_requests per request. The selection detail
+  // travels in the SQS job payload; the row only needs to carry status.
+  let requestId = null;
+  try {
+    const { data: lprRow, error: lprErr } = await supabase
+      .from('lesson_plan_requests')
+      .insert({
+        user_id: userId,
+        phone_number: phone,
+        topic: 'Homework',
+        full_message: 'homework_flow',
+        language: 'en',
+        content_type: 'homework',
+        status: 'pending',
+      })
+      .select('id')
+      .single();
+    if (lprErr) {
+      logToFile('Homework: lesson_plan_requests insert error', { error: lprErr.message });
+    } else {
+      requestId = lprRow?.id || null;
+    }
+  } catch (e) {
+    logToFile('Homework: lesson_plan_requests insert threw', { error: e.message });
+  }
+
+  // Enqueue one bundle job per (grade × subject) group. groupCount + groupIndex
+  // let the worker fire the single post-delivery feedback survey only after the
+  // LAST group's file.
+  let enqueued = 0;
+  for (let i = 0; i < groupList.length; i++) {
+    const g = groupList[i];
+    try {
+      await SQSQueueService.queueJob(
+        userId,
+        'homework_bundle_generation',
+        {
+          userId,
+          phone,
+          requestId,
+          grade: g.grade,
+          subject: g.subject,
+          chapters: g.chapters,
+          groupIndex: i,
+          groupCount: groupList.length,
+          isLastGroup: i === groupList.length - 1,
+        }
+      );
+      enqueued += 1;
+    } catch (e) {
+      logToFile('Homework: queueJob failed for group', {
+        error: e.message, grade: g.grade, subject: g.subject,
+      });
+    }
+  }
+
+  logEvent('homework.flow.submitted', {
+    userId, phone, requestId,
+    groupCount: groupList.length,
+    enqueued,
+    totalChapters: count,
+  });
+
+  return {
+    screen: 'SUCCESS',
+    data: {
+      message: 'Your homework is being prepared — it will arrive in a few moments.',
+      extension_message_response: {
+        params: { flow_token: flowToken || `${userId}:homework` },
+      },
+    },
+  };
+}
+
+/**
+ * BACK — return to the grade/subject screen.
+ */
+async function handleHomeworkBack(flowToken, screen) {
+  logToFile('Homework Request BACK', { flowToken, screen });
+  return {
+    screen: 'SELECT_GRADE',
+    data: { grades: GRADES, subjects: SUBJECTS },
+  };
+}
+
+module.exports = {
+  handleHomeworkInit,
+  handleHomeworkDataExchange,
+  handleHomeworkBack,
+  HOMEWORK_SOFT_CAP,
+  GRADES,
+  SUBJECTS,
+};

--- a/bot/shared/services/homework-lookup.service.js
+++ b/bot/shared/services/homework-lookup.service.js
@@ -1,0 +1,95 @@
+/**
+ * Homework Chapter Lookup Service
+ *
+ * Supabase read with soft-fail. Resolves a teacher's homework selection
+ * (grade × subject × chapters) to the R2 keys the bundle worker will
+ * pdf-lib-merge. Source table: homework_chapters.
+ */
+
+const supabase = require('../config/supabase');
+const { logToFile } = require('../utils/logger');
+
+const DEFAULT_VERSION = 'v7';
+
+class HomeworkLookupService {
+  /**
+   * Find all available homework chapters for a grade/subject, ordered by
+   * chapter_number. Soft-fails to [] on any error.
+   *
+   * @param {Object} input
+   * @param {number} input.grade
+   * @param {string} input.subject
+   * @param {string} [input.version='v7']
+   * @returns {Promise<Array>} rows: {grade, subject, chapter_number, chapter_title, lang, r2_key, version}
+   */
+  static async findHomeworkChapters({ grade, subject, version = DEFAULT_VERSION }) {
+    try {
+      const { data, error } = await supabase
+        .from('homework_chapters')
+        .select('grade, subject, chapter_number, chapter_title, lang, r2_key, version')
+        .eq('grade', grade)
+        .eq('subject', subject)
+        .eq('version', version)
+        .order('chapter_number');
+
+      if (error || !data) {
+        logToFile('Homework lookup: no rows / error', {
+          grade, subject, version, error: error?.message || null,
+        });
+        return [];
+      }
+      return data;
+    } catch (err) {
+      logToFile('Homework lookup error', { error: err.message, grade, subject });
+      return [];
+    }
+  }
+
+  /**
+   * Resolve a multi-select submission to a flat, ordered, deduped list of
+   * deliverable chapters with their R2 keys.
+   *
+   * @param {Array} selections - [{ grade, subject, chapters:[chNum,...] }]
+   * @param {string} [version='v7']
+   * @returns {Promise<Array>} [{ grade, subject, chapter, chapter_title, r2_key }]
+   *          Order: selection group order, then chapter ascending. Unknown
+   *          chapters (no matching r2 row) are dropped.
+   */
+  static async resolveSelection(selections, version = DEFAULT_VERSION) {
+    if (!Array.isArray(selections) || selections.length === 0) return [];
+
+    const resolved = [];
+    for (const group of selections) {
+      if (!group || group.grade == null || !group.subject) continue;
+
+      const available = await this.findHomeworkChapters({
+        grade: group.grade,
+        subject: group.subject,
+        version,
+      });
+      if (!available.length) continue;
+
+      const byChapter = new Map();
+      for (const row of available) byChapter.set(Number(row.chapter_number), row);
+
+      // Dedup requested chapters, preserve ascending order for stable bundles.
+      const wanted = Array.from(new Set((group.chapters || []).map(Number)))
+        .sort((a, b) => a - b);
+
+      for (const ch of wanted) {
+        const row = byChapter.get(ch);
+        if (!row || !row.r2_key) continue; // unknown / missing key → drop
+        resolved.push({
+          grade: Number(row.grade),
+          subject: row.subject,
+          chapter: Number(row.chapter_number),
+          chapter_title: row.chapter_title,
+          r2_key: row.r2_key,
+        });
+      }
+    }
+    return resolved;
+  }
+}
+
+module.exports = HomeworkLookupService;

--- a/bot/shared/utils/constants.js
+++ b/bot/shared/utils/constants.js
@@ -29,6 +29,9 @@ const STATUS_FLOW_ID = process.env.STATUS_FLOW_ID || '';
 // WhatsApp Flow ID for the Student Video Library picker. When set, /video
 // opens the library; when empty, /video uses the runtime video generator.
 const STUDENT_VIDEOS_FLOW_ID = process.env.STUDENT_VIDEOS_FLOW_ID || '';
+// WhatsApp Flow ID for the homework request flow (empty → /homework replies
+// that the feature is not configured).
+const HOMEWORK_FLOW_ID = process.env.HOMEWORK_FLOW_ID || '';
 
 // Pic-to-LP (photo → illustrated lesson plan)
 const KIE_API_KEY = process.env.KIE_API_KEY;
@@ -131,6 +134,7 @@ module.exports = {
   SETTINGS_FLOW_ID,
   STATUS_FLOW_ID,
   STUDENT_VIDEOS_FLOW_ID,
+  HOMEWORK_FLOW_ID,
 
   // Pic-to-LP
   KIE_API_KEY,

--- a/bot/workers/homework-bundle.worker.js
+++ b/bot/workers/homework-bundle.worker.js
@@ -1,0 +1,236 @@
+/**
+ * Homework Bundle Worker
+ *
+ * Consumes a `homework_bundle_generation` SQS job. ONE job == ONE
+ * (grade × subject) group (the endpoint enqueues one job per group). For the
+ * group:
+ *   1. downloadFromR2() each chapter PDF.
+ *   2. pdf-lib MERGE via PDFDocument.copyPages (these are already-rendered
+ *      PDFs; we stitch pages, preserving chapter order). A missing/failed
+ *      chapter soft-fails that chapter; the rest still merge. All-missing →
+ *      group soft-fails (no doc), no throw.
+ *   3. WhatsAppService.sendDocument (file path, not buffer).
+ *   4. INSERT one lesson_plans row (type='homework_bundle').
+ *   5. After the LAST group of the request, schedule the post-delivery survey
+ *      via lp-feedback (optional — no-op if that service isn't present).
+ *
+ * Dispatched from workers/sqs-worker.js (v2 generic envelope, body.payload).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { PDFDocument } = require('pdf-lib');
+
+const supabase = require('../shared/config/supabase');
+const WhatsAppService = require('../shared/services/whatsapp.service');
+const { downloadFromR2 } = require('../shared/storage/r2');
+const { logToFile } = require('../shared/utils/logger');
+const { logEvent } = require('../shared/utils/structured-logger');
+
+const SUBJECT_DISPLAY = { maths: 'Maths', english: 'English', urdu: 'Urdu' };
+
+/**
+ * Build the delivered filename.
+ *   "Homework - Grade {g} {Subject} (Ch {list}).pdf"
+ */
+function makeFilename({ grade, subject, chapterNumbers }) {
+  const subj = SUBJECT_DISPLAY[subject] || subject;
+  const chList = chapterNumbers.join(', ');
+  const raw = `Homework - Grade ${grade} ${subj} (Ch ${chList}).pdf`;
+  return raw.replace(/[\\/:*?"<>|]+/g, '-');
+}
+
+/**
+ * Bilingual delivery caption stating grade/subject/chapters.
+ */
+function localizedDeliveryCaption({ grade, subject, chapterNumbers, language }) {
+  const subj = SUBJECT_DISPLAY[subject] || subject;
+  const chList = chapterNumbers.join(', ');
+  const isUrduLike = language === 'ur' || language === 'sd' || language === 'pa';
+  if (isUrduLike) {
+    return `📄 ہوم ورک — جماعت ${grade} ${subj} (ابواب ${chList})`;
+  }
+  return `📄 Homework — Grade ${grade} ${subj} (Chapters ${chList})`;
+}
+
+/**
+ * Merge chapter PDFs (in the given order) into one pdf-lib document.
+ * Soft-fails a chapter whose R2 fetch or parse fails; returns the list of
+ * chapters actually included so the filename/caption stay truthful.
+ *
+ * @returns {Promise<{ buffer:Buffer|null, included:Array }>}
+ */
+async function mergeChapters(chapters) {
+  const merged = await PDFDocument.create();
+  const included = [];
+
+  for (const ch of chapters) {
+    try {
+      const buf = await downloadFromR2(ch.r2_key);
+      const src = await PDFDocument.load(buf);
+      const pages = await merged.copyPages(src, src.getPageIndices());
+      pages.forEach((p) => merged.addPage(p));
+      included.push(ch);
+    } catch (err) {
+      logEvent('homework.bundle.chapter_skipped', {
+        chapter: ch.chapter, r2Key: ch.r2_key, error: err.message,
+      });
+      logToFile('Homework bundle: chapter soft-failed', {
+        chapter: ch.chapter, r2Key: ch.r2_key, error: err.message,
+      });
+      // soft-fail this chapter; keep merging the rest
+    }
+  }
+
+  if (included.length === 0) return { buffer: null, included };
+  const buffer = Buffer.from(await merged.save());
+  return { buffer, included };
+}
+
+/**
+ * Main entry — called by workers/sqs-worker.js for a
+ * homework_bundle_generation job. One job = one (grade × subject) group.
+ */
+async function process(args) {
+  const {
+    userId, phone, requestId, grade, subject, chapters = [],
+    isLastGroup = true,
+  } = args;
+  const t0 = Date.now();
+  let tempPath = null;
+
+  if (!phone) {
+    logEvent('homework.bundle.failed', { userId, requestId, grade, subject, error: 'no_phone' });
+    return { success: false, error: 'no_phone' };
+  }
+
+  try {
+    const { buffer, included } = await mergeChapters(chapters);
+
+    if (!buffer || included.length === 0) {
+      logEvent('homework.bundle.empty', { userId, requestId, grade, subject });
+      if (requestId && isLastGroup) {
+        try {
+          await supabase.from('lesson_plan_requests').update({ status: 'failed' }).eq('id', requestId);
+        } catch (_) { /* best-effort */ }
+      }
+      return { success: false, error: 'all_chapters_missing' };
+    }
+
+    const chapterNumbers = included.map((c) => c.chapter);
+
+    // Teacher's system-message language for the caption.
+    let language = 'en';
+    try {
+      const { data: userRow } = await supabase
+        .from('users')
+        .select('preferred_language')
+        .eq('id', userId)
+        .maybeSingle();
+      if (userRow?.preferred_language) language = userRow.preferred_language;
+    } catch (_) { /* default en */ }
+
+    const filename = makeFilename({ grade, subject, chapterNumbers });
+    const caption = localizedDeliveryCaption({ grade, subject, chapterNumbers, language });
+
+    tempPath = path.join(os.tmpdir(), `homework_${userId}_${grade}_${subject}_${Date.now()}.pdf`);
+    fs.writeFileSync(tempPath, buffer);
+
+    const sendResult = await WhatsAppService.sendDocument(phone, tempPath, filename, caption);
+    if (!sendResult) throw new Error('WhatsApp returned false from sendDocument');
+
+    const deliveryMs = Date.now() - t0;
+
+    // One lesson_plans row per delivered bundle. The bundle manifest (source
+    // chapter keys, counts, timing) is stored in the existing `content` JSONB
+    // column since the merged PDF itself is ephemeral.
+    const bundleManifest = {
+      grade,
+      subject,
+      chapters: included.map((c) => ({ chapter: c.chapter, chapter_title: c.chapter_title, r2_key: c.r2_key })),
+      requested_count: chapters.length,
+      delivered_count: included.length,
+      delivery_time_ms: deliveryMs,
+      trigger_mode: 'after_pdf_only',
+      homework_request_id: requestId || null,
+    };
+    let lessonPlanId = null;
+    try {
+      const { data: lpRow, error: insertError } = await supabase
+        .from('lesson_plans')
+        .insert({
+          user_id: userId,
+          topic: `Homework - Grade ${grade} ${SUBJECT_DISPLAY[subject] || subject}`,
+          grade: String(grade),
+          subject,
+          type: 'homework_bundle',
+          content: bundleManifest,
+        })
+        .select('id')
+        .single();
+      if (insertError) {
+        logToFile('Homework bundle: lesson_plans insert error', { error: insertError.message });
+      } else {
+        lessonPlanId = lpRow?.id || null;
+      }
+    } catch (e) {
+      logToFile('Homework bundle: lesson_plans insert threw', { error: e.message });
+    }
+
+    logEvent('homework.bundle.delivered', {
+      userId, phone, requestId, grade, subject,
+      deliveredChapters: chapterNumbers,
+      deliveryTimeMs: deliveryMs,
+      lessonPlanId,
+    });
+
+    // After the LAST group, schedule the post-delivery feedback survey ONCE.
+    // The lp-feedback service is optional in the open-source build — no-op if absent.
+    if (isLastGroup && lessonPlanId) {
+      try {
+        const LpFeedbackService = require('../shared/services/lp-feedback.service');
+        if (LpFeedbackService && typeof LpFeedbackService.scheduleFeedbackPrompt === 'function') {
+          LpFeedbackService.scheduleFeedbackPrompt({
+            lessonPlanId,
+            userId,
+            phone,
+            context: {
+              grade,
+              subject,
+              topic: `Homework Grade ${grade} ${SUBJECT_DISPLAY[subject] || subject}`,
+              lpVariant: 'homework',
+              triggerMode: 'after_pdf_only',
+              language,
+              askReasonOnYes: true,
+            },
+          });
+        }
+      } catch (_) { /* lp-feedback survey is optional in the open-source build */ }
+    }
+
+    // Mark the request completed when the last group ships.
+    if (requestId && isLastGroup) {
+      try {
+        await supabase.from('lesson_plan_requests').update({ status: 'completed' }).eq('id', requestId);
+      } catch (_) { /* best-effort — delivery already happened */ }
+    }
+
+    return { success: true, lessonPlanId, deliveredChapters: chapterNumbers };
+  } catch (e) {
+    logToFile('Homework bundle worker threw', { userId, requestId, error: e.message });
+    logEvent('homework.bundle.failed', { userId, requestId, grade, subject, error: e.message });
+    if (requestId && isLastGroup) {
+      try {
+        await supabase.from('lesson_plan_requests').update({ status: 'failed' }).eq('id', requestId);
+      } catch (_) { /* best-effort */ }
+    }
+    throw e; // SQS DLQ handles retry for transient errors
+  } finally {
+    if (tempPath && fs.existsSync(tempPath)) {
+      try { fs.unlinkSync(tempPath); } catch (_) { /* best-effort */ }
+    }
+  }
+}
+
+module.exports = { process, makeFilename, localizedDeliveryCaption, mergeChapters };

--- a/bot/workers/sqs-worker.js
+++ b/bot/workers/sqs-worker.js
@@ -336,6 +336,15 @@ class SQSCoachingWorker {
         break;
       }
 
+      case 'homework_bundle_generation': {
+        // One job = one (grade × subject) group: R2 fetch + pdf-lib merge +
+        // WhatsApp document send. 5-min extension covers a 12-chapter bundle.
+        await SQSQueueService.extendJobTimeout(receiptHandle, 300);
+        const HomeworkBundleWorker = require('./homework-bundle.worker');
+        await HomeworkBundleWorker.process(payload);
+        break;
+      }
+
       // Quiz jobs (v2 envelope with body.groupId). Producers enqueue via
       // SQSQueueService.queueJob(); each handler in quiz-job-handler does a
       // cancel-flag check, an optional cascade re-queue (quiz_report/quiz_expire),

--- a/docs/flows/homework-request-flow.json
+++ b/docs/flows/homework-request-flow.json
@@ -1,0 +1,107 @@
+{
+  "_comment": "WhatsApp Flow for Homework. Pick grade + subject, then multi-select the chapters you have already taught; the bundle worker fetch-merges per-(grade×subject) PDFs from R2 and streams them async.",
+  "_instructions": [
+    "1. Register this Flow with Meta and set its ID as HOMEWORK_FLOW_ID.",
+    "2. Endpoint: POST /api/flows/homework-request (data_api_version 3.0, data_exchange).",
+    "3. SELECT_GRADE: Grade (1-5) + Subject dropdowns.",
+    "4. SELECT_CHAPTERS: dynamic CheckboxGroup of chapters from homework_chapters; client soft cap = 12 via max-selected-items (server also enforces).",
+    "5. SUCCESS: immediate ack — files stream to chat async via the SQS bundle worker."
+  ],
+  "version": "6.3",
+  "data_api_version": "3.0",
+  "routing_model": {
+    "SELECT_GRADE": ["SELECT_CHAPTERS"],
+    "SELECT_CHAPTERS": ["SUCCESS"],
+    "SUCCESS": []
+  },
+  "screens": [
+    {
+      "id": "SELECT_GRADE",
+      "title": "Homework",
+      "data": {
+        "grades": {
+          "type": "array",
+          "items": { "type": "object", "properties": { "id": { "type": "string" }, "title": { "type": "string" } } },
+          "__example__": [ { "id": "1", "title": "Grade 1" }, { "id": "2", "title": "Grade 2" } ]
+        },
+        "subjects": {
+          "type": "array",
+          "items": { "type": "object", "properties": { "id": { "type": "string" }, "title": { "type": "string" } } },
+          "__example__": [ { "id": "maths", "title": "Maths" }, { "id": "english", "title": "English" }, { "id": "urdu", "title": "Urdu" } ]
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "grade_form",
+            "children": [
+              { "type": "TextHeading", "text": "Homework" },
+              { "type": "TextBody", "text": "Ready-made homework. Pick your class and subject, then choose the chapters you have already taught." },
+              { "type": "Dropdown", "name": "grade", "label": "Grade", "required": true, "data-source": "${data.grades}" },
+              { "type": "Dropdown", "name": "subject", "label": "Subject", "required": true, "data-source": "${data.subjects}" },
+              { "type": "Footer", "label": "Show Chapters", "on-click-action": { "name": "data_exchange", "payload": { "grade": "${form.grade}", "subject": "${form.subject}" } } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SELECT_CHAPTERS",
+      "title": "Choose Chapters",
+      "data": {
+        "chapters": {
+          "type": "array",
+          "items": { "type": "object", "properties": { "id": { "type": "string" }, "title": { "type": "string" } } },
+          "__example__": [ { "id": "1", "title": "Ch1: Place Value" }, { "id": "2", "title": "Ch2: Addition" } ]
+        },
+        "grade_display": { "type": "string", "__example__": "Grade 2 — Maths" },
+        "grade_value": { "type": "string", "__example__": "2" },
+        "subject_value": { "type": "string", "__example__": "maths" },
+        "soft_cap": { "type": "number", "__example__": 12 },
+        "error": { "type": "object", "properties": { "message": { "type": "string" } }, "__example__": { "message": "" } }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "chapters_form",
+            "children": [
+              { "type": "TextHeading", "text": "${data.grade_display}" },
+              { "type": "TextBody", "text": "Tick the chapters you have already taught (up to 12). Send \"homework\" again any time for more." },
+              {
+                "type": "CheckboxGroup",
+                "name": "chapters",
+                "label": "Chapters",
+                "required": true,
+                "min-selected-items": 1,
+                "max-selected-items": 12,
+                "data-source": "${data.chapters}"
+              },
+              { "type": "Footer", "label": "Get Homework", "on-click-action": { "name": "data_exchange", "payload": { "grade": "${data.grade_value}", "subject": "${data.subject_value}", "chapters": "${form.chapters}" } } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SUCCESS",
+      "title": "Homework On Its Way",
+      "terminal": true,
+      "data": {
+        "message": { "type": "string", "__example__": "Your homework is being prepared — it will arrive in a few moments." }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          { "type": "TextHeading", "text": "Homework On Its Way!" },
+          { "type": "TextBody", "text": "${data.message}" },
+          { "type": "TextBody", "text": "Check your chat — the file(s) will arrive in a few seconds. You can close this form now." },
+          { "type": "Footer", "label": "Done", "on-click-action": { "name": "complete", "payload": {} } }
+        ]
+      }
+    }
+  ]
+}

--- a/infrastructure/supabase/00_complete-schema.sql
+++ b/infrastructure/supabase/00_complete-schema.sql
@@ -593,6 +593,25 @@ CREATE INDEX IF NOT EXISTS idx_student_video_feedback_user_time
 CREATE INDEX IF NOT EXISTS idx_student_video_feedback_useful_time
     ON student_video_feedback (useful, created_at DESC);
 
+-- Pre-rendered homework chapter PDFs (one row per grade × subject × chapter).
+-- The homework request flow looks these up and the bundle worker pdf-lib-merges
+-- the selected chapters' r2_key files into one document.
+CREATE TABLE IF NOT EXISTS homework_chapters (
+    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    grade INTEGER NOT NULL,
+    subject VARCHAR(100) NOT NULL,
+    chapter_number INTEGER NOT NULL,
+    chapter_title VARCHAR(300),
+    lang VARCHAR(20) DEFAULT 'en',
+    r2_key TEXT NOT NULL,
+    version VARCHAR(20) DEFAULT 'v7',
+    created_at TIMESTAMPTZ DEFAULT now(),
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_homework_chapters_lookup
+    ON homework_chapters (grade, subject, version, chapter_number);
+
 -- ---------------------------------------------------------------------------
 -- Attendance
 -- ---------------------------------------------------------------------------

--- a/tests/homework/homework-flow.test.js
+++ b/tests/homework/homework-flow.test.js
@@ -1,0 +1,252 @@
+/**
+ * Homework flow — lookup service, request endpoint (browse + enqueue), bundle
+ * worker (pdf-lib merge + deliver), and the pure trigger helper. Bot-only deps
+ * (supabase, pdf-lib, r2, whatsapp, sqs-queue, loggers) mocked for the
+ * root-before-bot-ci test ordering.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Filtering supabase mock (honours .eq/.order, insert→{id}, update, await).
+function makeSupabase(datasets) {
+  const store = JSON.parse(JSON.stringify(datasets));
+  function builder(table) {
+    let rows = (store[table] || []).slice();
+    const api = {
+      select() { return api; },
+      eq(k, v) { rows = rows.filter(r => String(r[k]) === String(v)); return api; },
+      in(k, vs) { rows = rows.filter(r => vs.includes(r[k])); return api; },
+      order() { return api; },
+      maybeSingle() { return Promise.resolve({ data: rows[0] || null, error: null }); },
+      single() { return Promise.resolve({ data: rows[0] || null, error: rows[0] ? null : { message: 'no rows' } }); },
+      insert(payload) {
+        const row = { id: `gen-${(store[table] || []).length + 1}`, ...payload };
+        store[table] = store[table] || [];
+        store[table].push(row);
+        return { select() { return { single: () => Promise.resolve({ data: { id: row.id }, error: null }) }; } };
+      },
+      update(patch) {
+        return { eq(k, v) { (store[table] || []).forEach(r => { if (String(r[k]) === String(v)) Object.assign(r, patch); }); return Promise.resolve({ data: null, error: null }); } };
+      },
+      then(resolve) { return resolve({ data: rows, error: null }); },
+    };
+    return api;
+  }
+  return { from: jest.fn((t) => builder(t)), __store: store };
+}
+
+const CHAPTERS = [
+  { id: 'h1', grade: 3, subject: 'maths', chapter_number: 1, chapter_title: 'Place Value', lang: 'en', r2_key: 'hw/g3/m/1.pdf', version: 'v7' },
+  { id: 'h2', grade: 3, subject: 'maths', chapter_number: 2, chapter_title: 'Addition', lang: 'en', r2_key: 'hw/g3/m/2.pdf', version: 'v7' },
+  { id: 'h3', grade: 3, subject: 'maths', chapter_number: 3, chapter_title: 'Subtraction', lang: 'en', r2_key: 'hw/g3/m/3.pdf', version: 'v7' },
+];
+
+// ── lookup service ────────────────────────────────────────────────────────
+describe('homework-lookup.service', () => {
+  function load(chapters = CHAPTERS) {
+    jest.resetModules();
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/config/supabase', () => makeSupabase({ homework_chapters: chapters }));
+    return require('../../bot/shared/services/homework-lookup.service');
+  }
+
+  it('findHomeworkChapters returns the grade/subject/version rows', async () => {
+    const svc = load();
+    const rows = await svc.findHomeworkChapters({ grade: 3, subject: 'maths' });
+    expect(rows.map(r => r.chapter_number)).toEqual([1, 2, 3]);
+  });
+
+  it('resolveSelection dedups + orders chapters and drops unknown ones', async () => {
+    const svc = load();
+    const resolved = await svc.resolveSelection([{ grade: 3, subject: 'maths', chapters: [3, 1, 1, 99] }]);
+    expect(resolved.map(r => r.chapter)).toEqual([1, 3]); // 99 dropped, dedup, ascending
+    expect(resolved[0].r2_key).toBe('hw/g3/m/1.pdf');
+  });
+
+  it('resolveSelection returns [] for empty input', async () => {
+    const svc = load();
+    expect(await svc.resolveSelection([])).toEqual([]);
+  });
+});
+
+// ── request endpoint ──────────────────────────────────────────────────────
+describe('homework-request-endpoint', () => {
+  let ep, supa, queueSpy;
+
+  function load(chapters = CHAPTERS) {
+    jest.resetModules();
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/utils/structured-logger', () => ({ logEvent: jest.fn() }));
+    supa = makeSupabase({
+      homework_chapters: chapters,
+      users: [{ id: 'u1', phone_number: '15551230000' }],
+      lesson_plan_requests: [],
+    });
+    jest.doMock('../../bot/shared/config/supabase', () => supa);
+    queueSpy = jest.fn().mockResolvedValue(true);
+    jest.doMock('../../bot/shared/services/queue/sqs-queue.service', () => ({ queueJob: queueSpy }));
+    ep = require('../../bot/shared/routes/homework-request-endpoint');
+  }
+
+  it('INIT returns grade + subject options', async () => {
+    load();
+    const res = await ep.handleHomeworkInit('u1:homework:1');
+    expect(res.screen).toBe('SELECT_GRADE');
+    expect(res.data.grades.length).toBeGreaterThan(0);
+    expect(res.data.subjects.map(s => s.id)).toContain('maths');
+  });
+
+  it('SELECT_GRADE returns the chapter checklist', async () => {
+    load();
+    const res = await ep.handleHomeworkDataExchange('u1:homework:1', 'SELECT_GRADE', { grade: '3', subject: 'maths' });
+    expect(res.screen).toBe('SELECT_CHAPTERS');
+    expect(res.data.chapters.map(c => c.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('SELECT_GRADE with no chapters returns an error', async () => {
+    load();
+    const res = await ep.handleHomeworkDataExchange('u1:homework:1', 'SELECT_GRADE', { grade: '9', subject: 'maths' });
+    expect(res.data.error).toBeDefined();
+  });
+
+  it('SELECT_CHAPTERS enqueues a bundle job per group + returns SUCCESS', async () => {
+    load();
+    const res = await ep.handleHomeworkDataExchange('u1:homework:1', 'SELECT_CHAPTERS', { grade: '3', subject: 'maths', chapters: [1, 2] });
+    expect(res.screen).toBe('SUCCESS');
+    expect(queueSpy).toHaveBeenCalledTimes(1);
+    const [groupId, jobType, payload] = queueSpy.mock.calls[0];
+    expect(groupId).toBe('u1');
+    expect(jobType).toBe('homework_bundle_generation');
+    expect(payload.chapters.map(c => c.chapter)).toEqual([1, 2]);
+    expect(payload.isLastGroup).toBe(true);
+  });
+
+  it('SELECT_CHAPTERS with no selection errors', async () => {
+    load();
+    const res = await ep.handleHomeworkDataExchange('u1:homework:1', 'SELECT_CHAPTERS', { grade: '3', subject: 'maths', chapters: [] });
+    expect(res.data.error).toBeDefined();
+    expect(queueSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ── bundle worker ─────────────────────────────────────────────────────────
+describe('homework-bundle.worker', () => {
+  let worker, supa, sendDocSpy, downloadSpy;
+
+  function load({ chapters, downloadImpl } = {}) {
+    jest.resetModules();
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/utils/structured-logger', () => ({ logEvent: jest.fn() }));
+    // pdf-lib is a bot-only dep — mock it (CI runs root tests before bot npm ci).
+    let pageCounter = 0;
+    jest.doMock('pdf-lib', () => ({
+      PDFDocument: {
+        create: async () => ({
+          copyPages: async (src, idxs) => idxs.map(() => ({})),
+          addPage: () => { pageCounter += 1; },
+          save: async () => new Uint8Array([1, 2, 3]),
+        }),
+        load: async () => ({ getPageIndices: () => [0] }),
+      },
+    }), { virtual: true });
+    downloadSpy = jest.fn(downloadImpl || (() => Promise.resolve(Buffer.from('pdf'))));
+    jest.doMock('../../bot/shared/storage/r2', () => ({ downloadFromR2: downloadSpy }));
+    supa = makeSupabase({
+      users: [{ id: 'u1', phone_number: '15551230000', preferred_language: 'en' }],
+      lesson_plans: [],
+      lesson_plan_requests: [{ id: 'req1', status: 'pending' }],
+    });
+    jest.doMock('../../bot/shared/config/supabase', () => supa);
+    sendDocSpy = jest.fn().mockResolvedValue(true);
+    jest.doMock('../../bot/shared/services/whatsapp.service', () => ({ sendDocument: sendDocSpy }));
+    worker = require('../../bot/workers/homework-bundle.worker');
+  }
+
+  it('makeFilename + caption are readable and filesystem-safe', () => {
+    load();
+    expect(worker.makeFilename({ grade: 3, subject: 'maths', chapterNumbers: [1, 2] }))
+      .toBe('Homework - Grade 3 Maths (Ch 1, 2).pdf');
+    expect(worker.localizedDeliveryCaption({ grade: 3, subject: 'maths', chapterNumbers: [1], language: 'en' }))
+      .toContain('Homework');
+  });
+
+  it('process merges, delivers, inserts a lesson_plans row, marks request completed', async () => {
+    load();
+    const res = await worker.process({
+      userId: 'u1', phone: '15551230000', requestId: 'req1', grade: 3, subject: 'maths',
+      chapters: [{ chapter: 1, chapter_title: 'Place Value', r2_key: 'k1' }, { chapter: 2, chapter_title: 'Addition', r2_key: 'k2' }],
+      isLastGroup: true,
+    });
+    expect(res.success).toBe(true);
+    expect(sendDocSpy).toHaveBeenCalled();
+    expect(supa.__store.lesson_plans.length).toBe(1);
+    expect(supa.__store.lesson_plan_requests[0].status).toBe('completed');
+  });
+
+  it('process soft-fails when every chapter download fails', async () => {
+    load({ downloadImpl: () => Promise.reject(new Error('404')) });
+    const res = await worker.process({
+      userId: 'u1', phone: '15551230000', requestId: 'req1', grade: 3, subject: 'maths',
+      chapters: [{ chapter: 1, r2_key: 'k1' }], isLastGroup: true,
+    });
+    expect(res.success).toBe(false);
+    expect(res.error).toBe('all_chapters_missing');
+    expect(supa.__store.lesson_plan_requests[0].status).toBe('failed');
+    expect(sendDocSpy).not.toHaveBeenCalled();
+  });
+
+  it('process returns no_phone when phone is missing', async () => {
+    load();
+    const res = await worker.process({ userId: 'u1', grade: 3, subject: 'maths', chapters: [] });
+    expect(res.success).toBe(false);
+    expect(res.error).toBe('no_phone');
+  });
+});
+
+// ── trigger helper ─────────────────────────────────────────────────────────
+describe('evaluateHomeworkTrigger', () => {
+  const { evaluateHomeworkTrigger } = require('../../bot/shared/handlers/homework-trigger');
+
+  it('matches the homework keywords (anchored)', () => {
+    for (const m of ['homework', 'home work', 'hw', '/homework', 'HOMEWORK']) {
+      expect(evaluateHomeworkTrigger({ messageBody: m, user: { id: 'u' }, homeworkFlowId: 'F' }).match).toBe(true);
+    }
+  });
+
+  it('does NOT match substrings (no collision with LP trigger)', () => {
+    expect(evaluateHomeworkTrigger({ messageBody: 'lesson plan for homework', user: { id: 'u' }, homeworkFlowId: 'F' }).match).toBe(false);
+  });
+
+  it('send_flow only when flow id + user present, else guard', () => {
+    expect(evaluateHomeworkTrigger({ messageBody: 'homework', user: { id: 'u' }, homeworkFlowId: 'F' }).action).toBe('send_flow');
+    expect(evaluateHomeworkTrigger({ messageBody: 'homework', user: { id: 'u' }, homeworkFlowId: '' }).action).toBe('guard');
+    expect(evaluateHomeworkTrigger({ messageBody: 'homework', user: null, homeworkFlowId: 'F' }).action).toBe('guard');
+  });
+});
+
+// ── flow JSON + leak gate ─────────────────────────────────────────────────────
+describe('homework-request-flow.json', () => {
+  const flowPath = path.join(__dirname, '../../docs/flows/homework-request-flow.json');
+
+  it('is valid JSON with grade → chapters → success routing', () => {
+    const flow = JSON.parse(fs.readFileSync(flowPath, 'utf8'));
+    expect(flow.routing_model.SELECT_GRADE).toEqual(['SELECT_CHAPTERS']);
+    expect(flow.routing_model.SELECT_CHAPTERS).toEqual(['SUCCESS']);
+  });
+
+  it('is leak-free (no internal phone/name/path/bead tokens)', () => {
+    const files = [
+      flowPath,
+      path.join(__dirname, '../../bot/shared/routes/homework-request-endpoint.js'),
+      path.join(__dirname, '../../bot/workers/homework-bundle.worker.js'),
+      path.join(__dirname, '../../bot/shared/services/homework-lookup.service.js'),
+    ];
+    for (const f of files) {
+      const raw = fs.readFileSync(f, 'utf8');
+      for (const banned of ['+92', '+255', '0329', '5012345', 'Taleemabad', 'Rawalpindi', 'TaleemHub', 'bd-', 'PROJ-', 'Silverleaf']) {
+        expect(raw).not.toContain(banned);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Phase 4E — homework flow (4 of 5, the heaviest)

Ports the homework request flow: a teacher picks grade + subject + chapters, and the bundle worker merges the selected pre-rendered chapter PDFs from R2 into one document delivered to chat.

### What's added
- **homework-lookup.service.js** — `homework_chapters` lookup + multi-select resolution (dedup, ascending order, drop unknown), soft-fail.
- **homework-request-endpoint.js** — `SELECT_GRADE → SELECT_CHAPTERS → SUCCESS`; enqueues one `homework_bundle_generation` job per (grade × subject) group via the existing `queueJob` v2 envelope; 12-chapter soft cap; immediate ack.
- **homework-bundle.worker.js** — pdf-lib `copyPages` merge (soft-fails a missing chapter, keeps the rest), `sendDocument`, persists a `lesson_plans` row (manifest in the existing `content` JSONB), marks the request completed/failed; optional lp-feedback survey (lazy require, no-op if absent).
- `homework_chapters` table → `00_complete-schema.sql`.
- `homework_bundle_generation` dispatch case in sqs-worker.js (additive).
- `/homework` + `homework`/`home work`/`hw` hot trigger via a new pure `homework-trigger.js` helper (presence-gated, unit-testable).
- `HOMEWORK_FLOW_ID` constant + `.env.template`; `POST /homework-request` mount.
- **docs/flows/homework-request-flow.json**.

### Region-agnostic + schema-faithful
- Prod's `region !== 'punjab'` gate is **dropped** — the feature is gated by `HOMEWORK_FLOW_ID` presence + populated `homework_chapters`.
- Inserts are **trimmed to columns that exist in the OSS schema** — OSS `lesson_plans` / `lesson_plan_requests` diverge from prod (no `lp_variant`/`pdf_r2_key`/`textbook_metadata`/`source`), so the manifest is stored in the existing `content` JSONB. Verified against the live schema, not assumed.

### Tests
17 new tests (lookup, endpoint browse/enqueue, worker merge/deliver/soft-fail, trigger helper, flow JSON, leak gate). Full suite: **73 suites / 987 passing**. Bot-only deps incl. `pdf-lib` mocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)