### PR TITLE
feat(edit-class): edit-class roster flow + parent_phone column — Phase 4E (final)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -162,6 +162,11 @@ STATUS_FLOW_ID=
 STUDENT_VIDEOS_FLOW_ID=
 # Homework request flow — empty disables the /homework command.
 HOMEWORK_FLOW_ID=
+# Edit-class roster flow — empty disables the "edit class" command.
+EDIT_CLASS_FLOW_ID=
+# Optional: default country code (digits only, no +) for expanding locally-typed
+# phone numbers with a leading 0 to E.164. Leave empty to require international format.
+DEFAULT_PHONE_COUNTRY_CODE=
 
 # --- Optional: BullMQ Worker --------------------------------------------------
 # Configuration for background job processing

--- a/bot/shared/handlers/edit-class-trigger.js
+++ b/bot/shared/handlers/edit-class-trigger.js
@@ -1,0 +1,40 @@
+'use strict';
+/**
+ * Pure, dependency-free keyword detector for the "edit class" intent.
+ * Kept separate from text-message.handler so it is unit-testable.
+ */
+
+const EDIT_CLASS_KEYWORDS = [
+  'edit class',
+  'editclass',
+  '/editclass',
+  '/edit-class',
+  'edit roster',
+  'manage class',
+  'edit students',
+  'remove student',
+  'delete student',
+  'class edit',
+  'student edit',
+  // Urdu
+  'کلاس ایڈٹ',
+];
+
+/**
+ * @param {string} message
+ * @returns {{ detected:boolean, keyword?:string }}
+ */
+function detectEditClassIntent(message) {
+  if (!message || typeof message !== 'string' || message.trim() === '') {
+    return { detected: false };
+  }
+  const lower = message.toLowerCase();
+  for (const keyword of EDIT_CLASS_KEYWORDS) {
+    if (lower.includes(keyword.toLowerCase())) {
+      return { detected: true, keyword };
+    }
+  }
+  return { detected: false };
+}
+
+module.exports = { EDIT_CLASS_KEYWORDS, detectEditClassIntent };

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -81,6 +81,7 @@ async function tryCurriculumLessonPlanServe(from, topic, user, language) {
  */
 
 const { evaluateHomeworkTrigger } = require('./homework-trigger');
+const { detectEditClassIntent } = require('./edit-class-trigger');
 
 async function handleTextMessage(message, from, messageBody, user = null) {
   logToFile(`Processing TEXT message: ${messageBody}`);
@@ -1305,6 +1306,58 @@ async function handleTextMessage(message, from, messageBody, user = null) {
       })[responseLanguage] || 'Homework is not available right now. Please try again later.');
       return;
     }
+  }
+
+  // ============================================================
+  // EDIT CLASS detection — "edit class" / "edit roster" / "remove student".
+  // Checked BEFORE attendance so roster edits don't get captured by an
+  // attendance session. Presence-gated on EDIT_CLASS_FLOW_ID.
+  // ============================================================
+  if (user?.id && detectEditClassIntent(messageBody).detected) {
+    logToFile('📋 Edit class keyword detected', { userId: user.id });
+    typingController.stop();
+
+    const EDIT_CLASS_FLOW_ID = process.env.EDIT_CLASS_FLOW_ID || '';
+    if (!EDIT_CLASS_FLOW_ID) {
+      await WhatsAppService.sendMessage(from, 'Sorry, class editing is not available yet. Please try again later.');
+      return;
+    }
+
+    const { data: classes } = await supabase
+      .from('student_lists')
+      .select('id, class_name, section')
+      .eq('user_id', user.id)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false });
+
+    if (!classes || classes.length === 0) {
+      await WhatsAppService.sendMessage(from, "You don't have any classes yet. Say \"add class\" to create one first!");
+      return;
+    }
+
+    if (classes.length === 1) {
+      const cls = classes[0];
+      const flowToken = `${user.id}:${cls.id}`;
+      await WhatsAppService.sendFlow(from, {
+        flowId: EDIT_CLASS_FLOW_ID,
+        header: '📋 Edit Class',
+        body: `Edit roster for ${cls.section ? `${cls.class_name} - ${cls.section}` : cls.class_name}`,
+        buttonText: 'Edit Class',
+        flowToken
+      });
+    } else {
+      // Multiple classes → interactive buttons (max 3); each tap routes via
+      // the edit_class_<id> handler in whatsapp-bot.js.
+      const buttons = classes.slice(0, 3).map(cls => ({
+        id: `edit_class_${cls.id}`,
+        title: cls.section ? `${cls.class_name}-${cls.section}` : cls.class_name
+      }));
+      await WhatsAppService.sendInteractiveButtons(from, {
+        body: 'Which class would you like to edit?',
+        buttons
+      });
+    }
+    return;
   }
 
   // ============================================================

--- a/bot/shared/routes/edit-class-endpoint.js
+++ b/bot/shared/routes/edit-class-endpoint.js
@@ -1,0 +1,489 @@
+/**
+ * Edit Class Endpoint Handler
+ *
+ * Endpoint-based WhatsApp Flow for editing class rosters. data_api_version 3.0
+ * with encrypted data exchange.
+ *
+ * Flow screens (forward-only — Meta routing-model compliant):
+ *   ROSTER_VIEW → ADD_STUDENT | REMOVE_STUDENTS | SELECT_STUDENT_TO_EDIT | SUCCESS
+ *   ADD_STUDENT → ADD_STUDENT (self-loop: add & continue) | SUCCESS (done)
+ *   REMOVE_STUDENTS → SUCCESS
+ *   SELECT_STUDENT_TO_EDIT → EDIT_STUDENT
+ *   EDIT_STUDENT → SUCCESS
+ *
+ * Backward navigation is NOT allowed by Meta's routing model; ADD_STUDENT
+ * self-loops and the rest forward to SUCCESS.
+ */
+
+const { logToFile } = require('../utils/logger');
+const supabase = require('../config/supabase');
+const { validateAndNormalizePhone } = require('../utils/phone-validation');
+
+/**
+ * Handle INIT — return ROSTER_VIEW with class info.
+ * Flow token format: userId:listId
+ */
+async function handleEditClassInit(userId, flowToken) {
+  logToFile('📋 Edit class INIT', { userId, flowToken });
+
+  const listId = flowToken.split(':')[1];
+  if (!listId) {
+    return createErrorResponse('Invalid flow token — missing class ID');
+  }
+
+  return await buildRosterView(listId);
+}
+
+/**
+ * Handle data_exchange for edit class screens.
+ */
+async function handleEditClassDataExchange(userId, screen, screenData, flowToken) {
+  logToFile('📋 Edit class data_exchange', { userId, screen, screenData });
+
+  const listId = screenData._list_id || flowToken?.split(':')[1];
+  const classDisplay = screenData._class_display || '';
+
+  if (screen === 'ROSTER_VIEW') {
+    const action = screenData._action;
+    if (action === 'add') return await buildAddStudentScreen(listId, classDisplay);
+    if (action === 'edit') return await buildSelectStudentToEditScreen(listId, classDisplay);
+    if (action === 'remove') return await buildRemoveStudentsScreen(listId, classDisplay);
+    if (action === 'done') return await buildSuccessScreen(listId, classDisplay);
+    return createErrorResponse('Unknown action');
+  }
+
+  if (screen === 'ADD_STUDENT') {
+    const action = screenData._action;
+    if (action === 'done') return await buildSuccessScreen(listId, classDisplay);
+    // action === 'add': add student then self-loop to ADD_STUDENT
+    return await handleAddStudent(listId, classDisplay, screenData);
+  }
+
+  if (screen === 'REMOVE_STUDENTS') {
+    return await handleRemoveStudents(listId, classDisplay, screenData.students_to_remove);
+  }
+
+  if (screen === 'SELECT_STUDENT_TO_EDIT') {
+    return await buildEditStudentScreen(listId, classDisplay, screenData._student_id);
+  }
+
+  if (screen === 'EDIT_STUDENT') {
+    return await handleEditStudent(listId, classDisplay, screenData);
+  }
+
+  logToFile('⚠️ Unknown screen in edit class flow', { screen });
+  return createErrorResponse('Unknown screen');
+}
+
+/**
+ * Build ROSTER_VIEW screen data.
+ */
+async function buildRosterView(listId) {
+  try {
+    const { data: classList } = await supabase
+      .from('student_lists')
+      .select('id, class_name, section')
+      .eq('id', listId)
+      .single();
+
+    if (!classList) {
+      return createErrorResponse('Class not found');
+    }
+
+    const classDisplay = classList.section
+      ? `${classList.class_name} - ${classList.section}`
+      : classList.class_name;
+
+    const { data: students } = await supabase
+      .from('students')
+      .select('id, student_name, father_name, roll_number')
+      .eq('list_id', listId)
+      .eq('is_active', true)
+      .order('roll_number');
+
+    const studentCount = students?.length || 0;
+    const hasStudents = studentCount > 0;
+
+    const studentsList = hasStudents
+      ? students.map(s => (s.father_name
+          ? `${s.roll_number}. ${s.student_name} (${s.father_name})`
+          : `${s.roll_number}. ${s.student_name}`)).join('\n')
+      : 'No students in this class yet.';
+
+    return {
+      screen: 'ROSTER_VIEW',
+      data: {
+        class_info: `${classDisplay} | ${studentCount} student${studentCount !== 1 ? 's' : ''}`,
+        students_list: studentsList,
+        has_students: hasStudents,
+        list_id: listId,
+        class_display: classDisplay
+      }
+    };
+  } catch (error) {
+    logToFile('❌ Error building roster view', { listId, error: error.message });
+    return createErrorResponse('Failed to load class roster');
+  }
+}
+
+/**
+ * Build ADD_STUDENT screen (with student list summary for self-loop display).
+ */
+async function buildAddStudentScreen(listId, classDisplay) {
+  const { data: students } = await supabase
+    .from('students')
+    .select('id, student_name, father_name, roll_number')
+    .eq('list_id', listId)
+    .eq('is_active', true)
+    .order('roll_number');
+
+  const studentCount = students?.length || 0;
+  const studentsSummary = studentCount > 0
+    ? 'Added: ' + students.map(s => (s.father_name
+        ? `${s.roll_number}. ${s.student_name.split(' ')[0]} ${s.father_name}`
+        : `${s.roll_number}. ${s.student_name}`)).join(', ')
+    : '';
+
+  return {
+    screen: 'ADD_STUDENT',
+    data: {
+      list_id: listId,
+      class_display: classDisplay,
+      heading: `Add Student #${studentCount + 1}`,
+      class_info: `Class: ${classDisplay} | Students: ${studentCount}`,
+      students_list: studentsSummary,
+      form_init_values: { first_name: '', last_name: '', parent_phone: '' }
+    }
+  };
+}
+
+/**
+ * Build REMOVE_STUDENTS screen with student CheckboxGroup data.
+ */
+async function buildRemoveStudentsScreen(listId, classDisplay) {
+  const { data: students } = await supabase
+    .from('students')
+    .select('id, student_name, father_name, roll_number')
+    .eq('list_id', listId)
+    .eq('is_active', true)
+    .order('roll_number');
+
+  if (!students || students.length === 0) {
+    return await buildSuccessScreen(listId, classDisplay);
+  }
+
+  const studentOptions = students.map(s => ({
+    id: s.id,
+    title: s.father_name
+      ? `${s.roll_number}. ${s.student_name} (${s.father_name})`
+      : `${s.roll_number}. ${s.student_name}`
+  }));
+
+  return {
+    screen: 'REMOVE_STUDENTS',
+    data: {
+      list_id: listId,
+      class_display: classDisplay,
+      class_info: `Class: ${classDisplay} | Select students to remove`,
+      students: studentOptions
+    }
+  };
+}
+
+/**
+ * Handle adding a student — self-loop back to ADD_STUDENT with updated list.
+ */
+async function handleAddStudent(listId, classDisplay, screenData) {
+  const { first_name, last_name, parent_phone: rawPhone } = screenData;
+
+  if (!first_name || first_name.trim() === '') {
+    return {
+      screen: 'ADD_STUDENT',
+      data: {
+        list_id: listId,
+        class_display: classDisplay,
+        heading: 'Add Student',
+        class_info: `Class: ${classDisplay}`,
+        students_list: '',
+        form_init_values: { first_name: '', last_name: '', parent_phone: '' },
+        error: { message: 'Student name is required' }
+      }
+    };
+  }
+
+  try {
+    const { data: existing } = await supabase
+      .from('students')
+      .select('roll_number')
+      .eq('list_id', listId)
+      .order('roll_number', { ascending: false });
+
+    const nextRoll = (existing?.[0]?.roll_number || 0) + 1;
+
+    const studentName = last_name?.trim()
+      ? `${first_name.trim()} ${last_name.trim()}`
+      : first_name.trim();
+
+    // Surface phone validation errors to the teacher instead of silently dropping.
+    let normalizedPhone = null;
+    if (rawPhone && rawPhone.trim()) {
+      const phoneResult = validateAndNormalizePhone(rawPhone.trim());
+      if (phoneResult.valid) {
+        normalizedPhone = phoneResult.normalized;
+      } else {
+        logToFile('⚠️ Invalid parent phone in edit-class — returning error screen', { error: phoneResult.error });
+        return {
+          screen: 'ADD_STUDENT',
+          data: {
+            list_id: listId,
+            class_display: classDisplay,
+            heading: 'Add Student',
+            class_info: `Class: ${classDisplay}`,
+            students_list: '',
+            form_init_values: { first_name: first_name || '', last_name: last_name || '', parent_phone: rawPhone },
+            error: { message: phoneResult.error }
+          }
+        };
+      }
+    }
+
+    await supabase
+      .from('students')
+      .insert({
+        list_id: listId,
+        student_name: studentName,
+        father_name: last_name?.trim() || null,
+        roll_number: nextRoll,
+        is_active: true,
+        parent_phone: normalizedPhone
+      });
+
+    logToFile('✅ Student added via edit-class', { listId, rollNumber: nextRoll });
+
+    return await buildAddStudentScreen(listId, classDisplay);
+  } catch (error) {
+    logToFile('❌ Error adding student in edit-class', { error: error.message });
+    return createErrorResponse('Failed to add student');
+  }
+}
+
+/**
+ * Handle removing selected students (soft-delete) then forward to SUCCESS.
+ */
+async function handleRemoveStudents(listId, classDisplay, studentIds) {
+  if (!studentIds || !Array.isArray(studentIds) || studentIds.length === 0) {
+    return await buildSuccessScreen(listId, classDisplay);
+  }
+
+  try {
+    const { error } = await supabase
+      .from('students')
+      .update({ is_active: false })
+      .in('id', studentIds)
+      .eq('list_id', listId);
+
+    if (error) {
+      logToFile('❌ Error removing students', { error: error.message });
+      return createErrorResponse('Failed to remove students');
+    }
+
+    logToFile('✅ Students removed via edit-class', { listId, removedCount: studentIds.length });
+    return await buildSuccessScreen(listId, classDisplay);
+  } catch (error) {
+    logToFile('❌ Exception removing students', { error: error.message });
+    return createErrorResponse('Failed to remove students');
+  }
+}
+
+/**
+ * Build SUCCESS screen.
+ */
+async function buildSuccessScreen(listId, classDisplay) {
+  const { data: students } = await supabase
+    .from('students')
+    .select('id')
+    .eq('list_id', listId)
+    .eq('is_active', true);
+
+  const count = students?.length || 0;
+
+  return {
+    screen: 'SUCCESS',
+    data: {
+      success_message: `Class ${classDisplay} updated. ${count} student${count !== 1 ? 's' : ''} in roster.\n\nSay "edit class" to make more changes.`,
+      extension_message_response: {
+        params: { list_id: listId, class_display: classDisplay, student_count: count }
+      }
+    }
+  };
+}
+
+/**
+ * Handle BACK navigation — returns to ROSTER_VIEW with refreshed data.
+ */
+async function handleEditClassBack(userId, screen, flowToken) {
+  logToFile('📋 Edit class BACK', { userId, screen });
+  const listId = flowToken?.split(':')[1];
+  return await buildRosterView(listId);
+}
+
+// ─── Edit Student capability ───────────────────────────────────────────────
+
+/**
+ * Build SELECT_STUDENT_TO_EDIT screen — Dropdown of active students.
+ * No students → fall through to SUCCESS (forward-only routing).
+ */
+async function buildSelectStudentToEditScreen(listId, classDisplay) {
+  const { data: students } = await supabase
+    .from('students')
+    .select('id, student_name, father_name, roll_number')
+    .eq('list_id', listId)
+    .eq('is_active', true)
+    .order('roll_number');
+
+  if (!students || students.length === 0) {
+    return await buildSuccessScreen(listId, classDisplay);
+  }
+
+  return {
+    screen: 'SELECT_STUDENT_TO_EDIT',
+    data: {
+      list_id: listId,
+      class_display: classDisplay,
+      students: students.map(s => ({
+        id: s.id,
+        title: s.father_name
+          ? `${s.roll_number}. ${s.student_name} (${s.father_name})`
+          : `${s.roll_number}. ${s.student_name}`
+      }))
+    }
+  };
+}
+
+/**
+ * Build EDIT_STUDENT screen with the picked student's data pre-filled.
+ * Cross-class injection guard: requires both student.id AND list_id match.
+ */
+async function buildEditStudentScreen(listId, classDisplay, studentId) {
+  if (!studentId) {
+    return createErrorResponse('No student selected');
+  }
+
+  const { data: student } = await supabase
+    .from('students')
+    .select('id, student_name, father_name, parent_phone, roll_number')
+    .eq('id', studentId)
+    .eq('list_id', listId)        // defence-in-depth
+    .eq('is_active', true)
+    .single();
+
+  if (!student) {
+    return createErrorResponse('Student not found');
+  }
+
+  const fullName  = student.student_name || '';
+  const fatherTok = student.father_name || '';
+  let firstName = fullName;
+  if (fatherTok && fullName.endsWith(` ${fatherTok}`)) {
+    firstName = fullName.slice(0, -fatherTok.length - 1);
+  } else if (fatherTok && fullName === fatherTok) {
+    firstName = '';
+  }
+
+  return {
+    screen: 'EDIT_STUDENT',
+    data: {
+      list_id: listId,
+      student_id: studentId,
+      class_display: classDisplay,
+      heading: `Editing: ${fullName}`,
+      form_init_values: {
+        first_name: firstName,
+        last_name: fatherTok,
+        parent_phone: student.parent_phone || ''
+      }
+    }
+  };
+}
+
+/**
+ * Handle EDIT_STUDENT submission — UPDATE the row, then finish.
+ * Phone validation surfaces errors (does not silently drop). An empty
+ * parent_phone clears the existing value (explicit teacher choice).
+ */
+async function handleEditStudent(listId, classDisplay, screenData) {
+  const { _student_id, first_name, last_name, parent_phone: rawPhone } = screenData;
+
+  if (!_student_id) {
+    return createErrorResponse('Student ID missing');
+  }
+
+  if (!first_name || first_name.trim() === '') {
+    return {
+      screen: 'EDIT_STUDENT',
+      data: {
+        list_id: listId,
+        student_id: _student_id,
+        class_display: classDisplay,
+        heading: 'Edit Student',
+        form_init_values: { first_name: '', last_name: last_name || '', parent_phone: rawPhone || '' },
+        error: { message: 'Student name is required' }
+      }
+    };
+  }
+
+  let normalizedPhone = null;
+  if (rawPhone && rawPhone.trim()) {
+    const phoneResult = validateAndNormalizePhone(rawPhone.trim());
+    if (!phoneResult.valid) {
+      logToFile('⚠️ Invalid phone in edit-student — returning error screen', { error: phoneResult.error });
+      return {
+        screen: 'EDIT_STUDENT',
+        data: {
+          list_id: listId,
+          student_id: _student_id,
+          class_display: classDisplay,
+          heading: 'Edit Student',
+          form_init_values: { first_name, last_name: last_name || '', parent_phone: rawPhone },
+          error: { message: phoneResult.error }
+        }
+      };
+    }
+    normalizedPhone = phoneResult.normalized;
+  }
+
+  const studentName = last_name?.trim()
+    ? `${first_name.trim()} ${last_name.trim()}`
+    : first_name.trim();
+
+  const { error } = await supabase
+    .from('students')
+    .update({
+      student_name: studentName,
+      father_name: last_name?.trim() || null,
+      parent_phone: normalizedPhone   // null clears it; explicit teacher choice
+    })
+    .eq('id', _student_id)
+    .eq('list_id', listId);   // belt-and-braces
+
+  if (error) {
+    logToFile('❌ Error editing student', { studentId: _student_id, error: error.message });
+    return createErrorResponse('Failed to save changes');
+  }
+
+  logToFile('✅ Student edited via edit-class', { studentId: _student_id, listId });
+
+  // Forward-only routing: EDIT_STUDENT → SUCCESS.
+  return await buildSuccessScreen(listId, classDisplay);
+}
+
+function createErrorResponse(message) {
+  return { data: { error: { message } } };
+}
+
+module.exports = {
+  handleEditClassInit,
+  handleEditClassDataExchange,
+  handleEditClassBack,
+  createErrorResponse
+};

--- a/bot/shared/routes/flow-endpoint.routes.js
+++ b/bot/shared/routes/flow-endpoint.routes.js
@@ -55,6 +55,11 @@ const {
   handleHomeworkDataExchange,
   handleHomeworkBack
 } = require('./homework-request-endpoint');
+const {
+  handleEditClassInit,
+  handleEditClassDataExchange,
+  handleEditClassBack
+} = require('./edit-class-endpoint');
 
 /**
  * Handle attendance marking flow data requests
@@ -765,6 +770,40 @@ async function handleHomeworkFlow(data) {
   if (action === 'data_exchange')             return await handleHomeworkDataExchange(flow_token, screen, screenData);
   if (action === 'BACK')                      return await handleHomeworkBack(flow_token, screen);
   logToFile('Unknown homework flow action', { action });
+  return FlowEncryptionService.createErrorResponse('Unknown action');
+}
+
+// ============================================================
+// EDIT CLASS FLOW ENDPOINT — roster view / add / remove / edit students
+// ============================================================
+
+router.post('/edit-class', async (req, res) => {
+  try {
+    if (!FlowEncryptionService.isConfigured()) {
+      logToFile('Flow encryption not configured', { endpoint: 'edit-class' });
+      return res.status(500).json({ error: 'Flow encryption not configured' });
+    }
+    const encryptedResponse = await FlowEncryptionService.processEncryptedRequest(
+      req.body,
+      async (decryptedData) => await handleEditClassRequest(decryptedData)
+    );
+    res.set('Content-Type', 'text/plain');
+    res.send(encryptedResponse);
+  } catch (error) {
+    logToFile('Edit-class flow endpoint error', { endpoint: 'edit-class', error: error.message, stack: error.stack });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+async function handleEditClassRequest(data) {
+  const { action, flow_token, screen, data: screenData } = data;
+  logToFile('Handling edit-class request', { action, screen, hasFlowToken: !!flow_token });
+  if (action === 'ping') return FlowEncryptionService.handlePing();
+  const userId = (flow_token || '').split(':')[0];
+  if (action === 'INIT' || action === 'init') return await handleEditClassInit(userId, flow_token);
+  if (action === 'data_exchange')             return await handleEditClassDataExchange(userId, screen, screenData, flow_token);
+  if (action === 'BACK')                      return await handleEditClassBack(userId, screen, flow_token);
+  logToFile('Unknown edit-class flow action', { action });
   return FlowEncryptionService.createErrorResponse('Unknown action');
 }
 

--- a/bot/shared/utils/constants.js
+++ b/bot/shared/utils/constants.js
@@ -32,6 +32,9 @@ const STUDENT_VIDEOS_FLOW_ID = process.env.STUDENT_VIDEOS_FLOW_ID || '';
 // WhatsApp Flow ID for the homework request flow (empty → /homework replies
 // that the feature is not configured).
 const HOMEWORK_FLOW_ID = process.env.HOMEWORK_FLOW_ID || '';
+// WhatsApp Flow ID for the edit-class roster flow (empty → "edit class" replies
+// that the feature is not available).
+const EDIT_CLASS_FLOW_ID = process.env.EDIT_CLASS_FLOW_ID || '';
 
 // Pic-to-LP (photo → illustrated lesson plan)
 const KIE_API_KEY = process.env.KIE_API_KEY;
@@ -135,6 +138,7 @@ module.exports = {
   STATUS_FLOW_ID,
   STUDENT_VIDEOS_FLOW_ID,
   HOMEWORK_FLOW_ID,
+  EDIT_CLASS_FLOW_ID,
 
   // Pic-to-LP
   KIE_API_KEY,

--- a/bot/shared/utils/phone-validation.js
+++ b/bot/shared/utils/phone-validation.js
@@ -1,0 +1,71 @@
+'use strict';
+/**
+ * Phone number validation + normalization to E.164.
+ *
+ * Region-agnostic: teachers enter international format (e.g. +14155550123).
+ * A deployment that wants to accept a local format (e.g. a leading 0) can set
+ * DEFAULT_PHONE_COUNTRY_CODE (digits only, no +) — a leading 0 is then replaced
+ * with that country code. Numbers to Meta-blocked country codes are rejected.
+ */
+
+// Country codes WhatsApp cannot deliver to.
+const META_BLOCKED_COUNTRY_CODES = ['+53', '+98', '+850', '+963', '+7978'];
+
+/**
+ * @param {string|null|undefined} rawPhone
+ * @returns {{ valid: boolean, normalized?: string, error?: string }}
+ */
+function validateAndNormalizePhone(rawPhone) {
+  if (rawPhone === null || rawPhone === undefined || rawPhone === '') {
+    return { valid: false, error: 'Phone number is required' };
+  }
+
+  // Strip spaces, dashes, parentheses.
+  let phone = String(rawPhone).replace(/[\s\-()]/g, '');
+
+  if (/[a-zA-Z]/.test(phone)) {
+    return { valid: false, error: 'Invalid phone number — letters are not allowed' };
+  }
+
+  // Optional local-format expansion: a leading 0 → the deployment's default
+  // country code (digits only, no +). E.g. DEFAULT_PHONE_COUNTRY_CODE=44 turns
+  // 07911123456 into +447911123456.
+  const cc = (process.env.DEFAULT_PHONE_COUNTRY_CODE || '').replace(/\D/g, '');
+  if (cc && /^0\d{6,}$/.test(phone)) {
+    phone = `+${cc}${phone.substring(1)}`;
+  }
+
+  // A bare number with a + is assumed already-international.
+  if (!phone.startsWith('+')) {
+    // If it's all digits and long enough, treat it as already carrying a
+    // country code (prepend +). Otherwise it's ambiguous → error below.
+    if (/^\d{7,15}$/.test(phone)) {
+      phone = `+${phone}`;
+    }
+  }
+
+  // E.164: + followed by 7-15 digits, first digit 1-9.
+  if (!/^\+[1-9]\d{6,14}$/.test(phone)) {
+    const digits = phone.replace(/\D/g, '');
+    if (digits.length < 7) {
+      return { valid: false, error: 'Phone number is too short. Please include the country code.' };
+    }
+    if (digits.length > 15) {
+      return { valid: false, error: 'Phone number is too long. Maximum 15 digits allowed.' };
+    }
+    return { valid: false, error: 'Invalid phone number. Use international format, e.g. +14155550123' };
+  }
+
+  for (const blocked of META_BLOCKED_COUNTRY_CODES) {
+    if (phone.startsWith(blocked)) {
+      return {
+        valid: false,
+        error: `WhatsApp cannot send messages to this country code (${blocked}).`,
+      };
+    }
+  }
+
+  return { valid: true, normalized: phone };
+}
+
+module.exports = { validateAndNormalizePhone, META_BLOCKED_COUNTRY_CODES };

--- a/bot/whatsapp-bot.js
+++ b/bot/whatsapp-bot.js
@@ -801,6 +801,36 @@ app.post('/webhook', async (req, res) => {
       else if (buttonId.startsWith('student_video_feedback_yes_') || buttonId.startsWith('student_video_feedback_no_')) {
         const StudentVideoFeedbackService = require('./shared/services/student-video-feedback.service');
         await StudentVideoFeedbackService.handleFeedbackButton(buttonId, from);
+      }
+      // Edit-class multi-class picker: open the edit-class flow for the chosen class.
+      else if (buttonId.startsWith('edit_class_')) {
+        const listId = buttonId.replace('edit_class_', '');
+        logToFile('📋 Edit class button selected', { listId, userId: user?.id, from });
+        if (!user?.id) {
+          await WhatsAppService.sendMessage(from, 'Sorry, I could not identify your account. Please try "edit class" again.');
+        } else if (!constants.EDIT_CLASS_FLOW_ID) {
+          await WhatsAppService.sendMessage(from, 'Sorry, class editing is not available right now. Please try again later.');
+        } else {
+          const { data: classRow } = await supabase
+            .from('student_lists')
+            .select('id, class_name, section')
+            .eq('id', listId)
+            .eq('user_id', user.id)
+            .eq('is_active', true)
+            .single();
+          if (!classRow) {
+            await WhatsAppService.sendMessage(from, 'I could not find that class. Please say "edit class" to refresh your class list.');
+          } else {
+            const flowToken = `${user.id}:${classRow.id}`;
+            await WhatsAppService.sendFlow(from, {
+              flowId: constants.EDIT_CLASS_FLOW_ID,
+              header: '📋 Edit Class',
+              body: `Edit roster for ${classRow.section ? `${classRow.class_name} - ${classRow.section}` : classRow.class_name}`,
+              buttonText: 'Edit Class',
+              flowToken
+            });
+          }
+        }
       } else {
         logToFile('⚠️ Unknown button ID', { buttonId });
       }

--- a/docs/flows/edit-class-flow.json
+++ b/docs/flows/edit-class-flow.json
@@ -1,0 +1,278 @@
+{
+  "_comment": "WhatsApp Flow for Edit Class Roster — Endpoint-based",
+  "_instructions": [
+    "1. Register this Flow with Meta and set its ID as EDIT_CLASS_FLOW_ID.",
+    "2. Endpoint: POST /api/flows/edit-class",
+    "3. ROSTER_VIEW: Shows current students + actions (add/edit/remove/done)",
+    "4. ADD_STUDENT: Add new student with self-loop",
+    "5. SELECT_STUDENT_TO_EDIT: Pick a student to edit",
+    "6. EDIT_STUDENT: Pre-filled form for editing name / parent_phone",
+    "7. REMOVE_STUDENTS: CheckboxGroup to remove students",
+    "8. SUCCESS: Confirmation screen"
+  ],
+  "version": "6.3",
+  "data_api_version": "3.0",
+  "routing_model": {
+    "ROSTER_VIEW": ["ADD_STUDENT", "REMOVE_STUDENTS", "SELECT_STUDENT_TO_EDIT", "SUCCESS"],
+    "ADD_STUDENT": ["SUCCESS"],
+    "REMOVE_STUDENTS": ["SUCCESS"],
+    "SELECT_STUDENT_TO_EDIT": ["EDIT_STUDENT"],
+    "EDIT_STUDENT": ["SUCCESS"],
+    "SUCCESS": []
+  },
+  "screens": [
+    {
+      "id": "ROSTER_VIEW",
+      "title": "Edit Class",
+      "data": {
+        "class_info": { "type": "string", "__example__": "Grade 5 - A | 25 students" },
+        "students_list": { "type": "string", "__example__": "1. Student One\n2. Student Two\n3. Student Three" },
+        "has_students": { "type": "boolean", "__example__": true },
+        "list_id": { "type": "string", "__example__": "uuid-123" },
+        "class_display": { "type": "string", "__example__": "5 - A" }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "roster_form",
+            "children": [
+              { "type": "TextHeading", "text": "Class Roster" },
+              { "type": "TextSubheading", "text": "${data.class_info}" },
+              { "type": "TextBody", "text": "${data.students_list}" },
+              {
+                "type": "RadioButtonsGroup",
+                "name": "action",
+                "label": "What would you like to do?",
+                "required": true,
+                "data-source": [
+                  { "id": "add", "title": "Add Students" },
+                  { "id": "edit", "title": "Edit a Student" },
+                  { "id": "remove", "title": "Remove Students" },
+                  { "id": "done", "title": "Done Editing" }
+                ]
+              },
+              {
+                "type": "Footer",
+                "label": "Continue",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": { "_action": "${form.action}", "_list_id": "${data.list_id}", "_class_display": "${data.class_display}" }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ADD_STUDENT",
+      "title": "Add Student",
+      "refresh_on_back": true,
+      "data": {
+        "list_id": { "type": "string", "__example__": "uuid-123" },
+        "class_display": { "type": "string", "__example__": "5 - A" },
+        "heading": { "type": "string", "__example__": "Add Student #26" },
+        "class_info": { "type": "string", "__example__": "Class: 5 - A | Students: 25" },
+        "students_list": { "type": "string", "__example__": "Added: 1. Student One, 2. Student Two" },
+        "form_init_values": {
+          "type": "object",
+          "properties": {
+            "first_name": { "type": "string" },
+            "last_name": { "type": "string" },
+            "parent_phone": { "type": "string" }
+          },
+          "__example__": { "first_name": "", "last_name": "", "parent_phone": "" }
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "add_form",
+            "init-values": "${data.form_init_values}",
+            "children": [
+              { "type": "TextHeading", "text": "${data.heading}" },
+              { "type": "TextBody", "text": "${data.class_info}" },
+              { "type": "TextCaption", "text": "${data.students_list}" },
+              { "type": "TextInput", "name": "first_name", "label": "First Name", "required": false, "input-type": "text" },
+              { "type": "TextInput", "name": "last_name", "label": "Last Name / Father's Name", "required": false, "input-type": "text" },
+              { "type": "TextInput", "name": "parent_phone", "label": "Parent's WhatsApp (optional)", "required": false, "input-type": "phone", "helper-text": "International format, e.g. +14155550123" },
+              {
+                "type": "RadioButtonsGroup",
+                "name": "action",
+                "label": "What would you like to do?",
+                "required": true,
+                "data-source": [
+                  { "id": "add", "title": "Add this student & continue" },
+                  { "id": "done", "title": "Finish (no more students)" }
+                ]
+              },
+              {
+                "type": "Footer",
+                "label": "Continue",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "first_name": "${form.first_name}",
+                    "last_name": "${form.last_name}",
+                    "parent_phone": "${form.parent_phone}",
+                    "_action": "${form.action}",
+                    "_list_id": "${data.list_id}",
+                    "_class_display": "${data.class_display}"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "REMOVE_STUDENTS",
+      "title": "Remove Students",
+      "data": {
+        "list_id": { "type": "string", "__example__": "uuid-123" },
+        "class_display": { "type": "string", "__example__": "5 - A" },
+        "class_info": { "type": "string", "__example__": "Class: 5 - A | Select students to remove" },
+        "students": {
+          "type": "array",
+          "items": { "type": "object", "properties": { "id": { "type": "string" }, "title": { "type": "string" } } },
+          "__example__": [ { "id": "student-uuid-1", "title": "1. Student One" }, { "id": "student-uuid-2", "title": "2. Student Two" } ]
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "remove_form",
+            "children": [
+              { "type": "TextHeading", "text": "Remove Students" },
+              { "type": "TextBody", "text": "${data.class_info}" },
+              {
+                "type": "CheckboxGroup",
+                "name": "students_to_remove",
+                "label": "Select students to remove",
+                "required": true,
+                "min-selected-items": 1,
+                "max-selected-items": 50,
+                "data-source": "${data.students}"
+              },
+              {
+                "type": "Footer",
+                "label": "Remove Selected",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": { "students_to_remove": "${form.students_to_remove}", "_list_id": "${data.list_id}", "_class_display": "${data.class_display}" }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SELECT_STUDENT_TO_EDIT",
+      "title": "Choose Student",
+      "data": {
+        "list_id": { "type": "string", "__example__": "uuid-123" },
+        "class_display": { "type": "string", "__example__": "5 - A" },
+        "students": {
+          "type": "array",
+          "items": { "type": "object", "properties": { "id": { "type": "string" }, "title": { "type": "string" } } },
+          "__example__": [ { "id": "uuid-1", "title": "1. Student One" }, { "id": "uuid-2", "title": "2. Student Two" } ]
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "select_form",
+            "children": [
+              { "type": "TextHeading", "text": "Which student do you want to edit?" },
+              { "type": "Dropdown", "name": "student_id", "label": "Student", "required": true, "data-source": "${data.students}" },
+              {
+                "type": "Footer",
+                "label": "Continue",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": { "_student_id": "${form.student_id}", "_list_id": "${data.list_id}", "_class_display": "${data.class_display}" }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "EDIT_STUDENT",
+      "title": "Edit Student",
+      "data": {
+        "list_id": { "type": "string", "__example__": "uuid-123" },
+        "student_id": { "type": "string", "__example__": "uuid-1" },
+        "class_display": { "type": "string", "__example__": "5 - A" },
+        "heading": { "type": "string", "__example__": "Editing: Student One" },
+        "form_init_values": {
+          "type": "object",
+          "properties": {
+            "first_name": { "type": "string" },
+            "last_name": { "type": "string" },
+            "parent_phone": { "type": "string" }
+          },
+          "__example__": { "first_name": "Student", "last_name": "One", "parent_phone": "+14155550123" }
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "edit_form",
+            "init-values": "${data.form_init_values}",
+            "children": [
+              { "type": "TextHeading", "text": "${data.heading}" },
+              { "type": "TextInput", "name": "first_name", "label": "First Name", "required": false, "input-type": "text" },
+              { "type": "TextInput", "name": "last_name", "label": "Last Name / Father's Name", "required": false, "input-type": "text" },
+              { "type": "TextInput", "name": "parent_phone", "label": "Parent's WhatsApp (optional)", "required": false, "input-type": "phone", "helper-text": "Leave blank to remove the existing number" },
+              {
+                "type": "Footer",
+                "label": "Save Changes",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "first_name": "${form.first_name}",
+                    "last_name": "${form.last_name}",
+                    "parent_phone": "${form.parent_phone}",
+                    "_student_id": "${data.student_id}",
+                    "_list_id": "${data.list_id}",
+                    "_class_display": "${data.class_display}"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SUCCESS",
+      "title": "Edit Complete",
+      "terminal": true,
+      "data": {
+        "success_message": { "type": "string", "__example__": "Class 5 - A updated. 25 students." }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          { "type": "TextHeading", "text": "Class Updated!" },
+          { "type": "TextBody", "text": "${data.success_message}" },
+          { "type": "Footer", "label": "Done", "on-click-action": { "name": "complete", "payload": {} } }
+        ]
+      }
+    }
+  ]
+}

--- a/infrastructure/supabase/00_complete-schema.sql
+++ b/infrastructure/supabase/00_complete-schema.sql
@@ -546,6 +546,9 @@ CREATE TABLE IF NOT EXISTS students (
     father_name VARCHAR(200),
     student_name_urdu TEXT,
     father_name_urdu TEXT,
+    -- Optional parent/guardian contact (E.164). Used by the quiz subsystem to
+    -- deliver quizzes and by the edit-class flow's add/edit-student forms.
+    parent_phone TEXT,
     is_active BOOLEAN DEFAULT true,
     created_at TIMESTAMPTZ DEFAULT now(),
     updated_at TIMESTAMPTZ DEFAULT now(),

--- a/tests/edit-class/edit-class-flow.test.js
+++ b/tests/edit-class/edit-class-flow.test.js
@@ -1,0 +1,193 @@
+/**
+ * Edit-class flow — phone validation, the edit-class endpoint (roster CRUD),
+ * and the pure edit-class trigger helper. Bot-only deps mocked for the
+ * root-before-bot-ci test ordering.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function makeSupabase(datasets) {
+  const store = JSON.parse(JSON.stringify(datasets));
+  function builder(table) {
+    let rows = (store[table] || []).slice();
+    const api = {
+      select() { return api; },
+      eq(k, v) { rows = rows.filter(r => String(r[k]) === String(v)); return api; },
+      in(k, vs) { rows = rows.filter(r => vs.includes(r[k])); return api; },
+      order() { return api; },
+      maybeSingle() { return Promise.resolve({ data: rows[0] || null, error: null }); },
+      single() { return Promise.resolve({ data: rows[0] || null, error: rows[0] ? null : { message: 'no rows' } }); },
+      insert(payload) {
+        const row = { id: `gen-${(store[table] || []).length + 1}`, ...payload };
+        store[table] = store[table] || [];
+        store[table].push(row);
+        return { select() { return { single: () => Promise.resolve({ data: { id: row.id }, error: null }) }; }, then: (r) => r({ data: row, error: null }) };
+      },
+      update(patch) {
+        const matched = [];
+        const chain = {
+          eq(k, v) { rows = rows.filter(r => String(r[k]) === String(v)); chain._apply(); return chain; },
+          in(k, vs) { rows = rows.filter(r => vs.includes(r[k])); chain._apply(); return chain; },
+          _apply() { rows.forEach(r => { Object.assign(r, patch); matched.push(r); }); },
+          then(resolve) { return resolve({ data: null, error: null }); },
+        };
+        return chain;
+      },
+      then(resolve) { return resolve({ data: rows, error: null }); },
+    };
+    return api;
+  }
+  return { from: jest.fn((t) => builder(t)), __store: store };
+}
+
+// ── phone validation ──────────────────────────────────────────────────────
+describe('phone-validation', () => {
+  const ORIG = { ...process.env };
+  afterEach(() => { process.env = { ...ORIG }; jest.resetModules(); });
+
+  function load() {
+    jest.resetModules();
+    return require('../../bot/shared/utils/phone-validation').validateAndNormalizePhone;
+  }
+
+  it('accepts a clean E.164 number', () => {
+    const v = load();
+    expect(v('+14155550123')).toEqual({ valid: true, normalized: '+14155550123' });
+  });
+
+  it('prepends + to a bare international number', () => {
+    const v = load();
+    expect(v('14155550123').normalized).toBe('+14155550123');
+  });
+
+  it('rejects letters, empty, too-short, and blocked country codes', () => {
+    const v = load();
+    expect(v('').valid).toBe(false);
+    expect(v('abc123').valid).toBe(false);
+    expect(v('+12').valid).toBe(false);
+    expect(v('+9810000000').valid).toBe(false); // Iran (blocked)
+  });
+
+  it('expands a local 0-prefixed number using DEFAULT_PHONE_COUNTRY_CODE', () => {
+    process.env.DEFAULT_PHONE_COUNTRY_CODE = '44';
+    const v = load();
+    expect(v('07911123456').normalized).toBe('+447911123456');
+  });
+});
+
+// ── edit-class endpoint ─────────────────────────────────────────────────────
+describe('edit-class-endpoint', () => {
+  let ep, supa;
+
+  function load(students = [], lists = [{ id: 'L1', class_name: '5', section: 'A' }]) {
+    jest.resetModules();
+    delete process.env.DEFAULT_PHONE_COUNTRY_CODE;
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    supa = makeSupabase({ student_lists: lists, students });
+    jest.doMock('../../bot/shared/config/supabase', () => supa);
+    ep = require('../../bot/shared/routes/edit-class-endpoint');
+  }
+
+  it('INIT builds the ROSTER_VIEW', async () => {
+    load([{ id: 's1', list_id: 'L1', student_name: 'A One', father_name: 'One', roll_number: 1, is_active: true }]);
+    const res = await ep.handleEditClassInit('u1', 'u1:L1');
+    expect(res.screen).toBe('ROSTER_VIEW');
+    expect(res.data.class_info).toContain('5 - A');
+    expect(res.data.has_students).toBe(true);
+  });
+
+  it('ROSTER_VIEW actions route to the right screens', async () => {
+    load([{ id: 's1', list_id: 'L1', student_name: 'A', roll_number: 1, is_active: true }]);
+    const ft = 'u1:L1';
+    expect((await ep.handleEditClassDataExchange('u1', 'ROSTER_VIEW', { _action: 'add', _list_id: 'L1' }, ft)).screen).toBe('ADD_STUDENT');
+    expect((await ep.handleEditClassDataExchange('u1', 'ROSTER_VIEW', { _action: 'edit', _list_id: 'L1' }, ft)).screen).toBe('SELECT_STUDENT_TO_EDIT');
+    expect((await ep.handleEditClassDataExchange('u1', 'ROSTER_VIEW', { _action: 'remove', _list_id: 'L1' }, ft)).screen).toBe('REMOVE_STUDENTS');
+    expect((await ep.handleEditClassDataExchange('u1', 'ROSTER_VIEW', { _action: 'done', _list_id: 'L1' }, ft)).screen).toBe('SUCCESS');
+  });
+
+  it('ADD_STUDENT inserts a student and self-loops', async () => {
+    load([]);
+    const res = await ep.handleEditClassDataExchange('u1', 'ADD_STUDENT', { _action: 'add', _list_id: 'L1', _class_display: '5 - A', first_name: 'Zara', last_name: 'Abdul', parent_phone: '+14155550123' }, 'u1:L1');
+    expect(res.screen).toBe('ADD_STUDENT');
+    expect(supa.__store.students.length).toBe(1);
+    expect(supa.__store.students[0].student_name).toBe('Zara Abdul');
+    expect(supa.__store.students[0].parent_phone).toBe('+14155550123');
+  });
+
+  it('ADD_STUDENT surfaces an invalid-phone error without inserting', async () => {
+    load([]);
+    const res = await ep.handleEditClassDataExchange('u1', 'ADD_STUDENT', { _action: 'add', _list_id: 'L1', first_name: 'Zara', parent_phone: 'abc' }, 'u1:L1');
+    expect(res.screen).toBe('ADD_STUDENT');
+    expect(res.data.error).toBeDefined();
+    expect(supa.__store.students.length).toBe(0);
+  });
+
+  it('ADD_STUDENT requires a name', async () => {
+    load([]);
+    const res = await ep.handleEditClassDataExchange('u1', 'ADD_STUDENT', { _action: 'add', _list_id: 'L1', first_name: '' }, 'u1:L1');
+    expect(res.data.error.message).toMatch(/name/i);
+  });
+
+  it('REMOVE_STUDENTS soft-deletes selected and forwards to SUCCESS', async () => {
+    load([{ id: 's1', list_id: 'L1', student_name: 'A', roll_number: 1, is_active: true }]);
+    const res = await ep.handleEditClassDataExchange('u1', 'REMOVE_STUDENTS', { _list_id: 'L1', students_to_remove: ['s1'] }, 'u1:L1');
+    expect(res.screen).toBe('SUCCESS');
+    expect(supa.__store.students[0].is_active).toBe(false);
+  });
+
+  it('EDIT_STUDENT pre-fills then updates', async () => {
+    load([{ id: 's1', list_id: 'L1', student_name: 'Zara Abdul', father_name: 'Abdul', parent_phone: '+14155550123', roll_number: 1, is_active: true }]);
+    const pre = await ep.handleEditClassDataExchange('u1', 'SELECT_STUDENT_TO_EDIT', { _list_id: 'L1', _student_id: 's1' }, 'u1:L1');
+    expect(pre.screen).toBe('EDIT_STUDENT');
+    expect(pre.data.form_init_values.first_name).toBe('Zara'); // derived
+    const upd = await ep.handleEditClassDataExchange('u1', 'EDIT_STUDENT', { _list_id: 'L1', _student_id: 's1', first_name: 'Zahra', last_name: 'Abdul', parent_phone: '' }, 'u1:L1');
+    expect(upd.screen).toBe('SUCCESS');
+    expect(supa.__store.students[0].student_name).toBe('Zahra Abdul');
+    expect(supa.__store.students[0].parent_phone).toBeNull(); // cleared
+  });
+});
+
+// ── trigger helper ──────────────────────────────────────────────────────────
+describe('detectEditClassIntent', () => {
+  const { detectEditClassIntent } = require('../../bot/shared/handlers/edit-class-trigger');
+
+  it('detects the keywords', () => {
+    for (const m of ['edit class', 'I want to edit class now', 'remove student', '/editclass', 'manage class']) {
+      expect(detectEditClassIntent(m).detected).toBe(true);
+    }
+  });
+
+  it('does not fire on unrelated text or empty input', () => {
+    expect(detectEditClassIntent('what is the weather').detected).toBe(false);
+    expect(detectEditClassIntent('').detected).toBe(false);
+    expect(detectEditClassIntent(null).detected).toBe(false);
+  });
+});
+
+// ── flow JSON + leak gate ─────────────────────────────────────────────────────
+describe('edit-class-flow.json', () => {
+  const flowPath = path.join(__dirname, '../../docs/flows/edit-class-flow.json');
+
+  it('is valid JSON with the expected forward-only routing', () => {
+    const flow = JSON.parse(fs.readFileSync(flowPath, 'utf8'));
+    expect(flow.routing_model.ROSTER_VIEW).toContain('ADD_STUDENT');
+    expect(flow.routing_model.SELECT_STUDENT_TO_EDIT).toEqual(['EDIT_STUDENT']);
+    expect(flow.routing_model.EDIT_STUDENT).toEqual(['SUCCESS']);
+  });
+
+  it('is leak-free (no internal phone/name/path/bead tokens)', () => {
+    const files = [
+      flowPath,
+      path.join(__dirname, '../../bot/shared/routes/edit-class-endpoint.js'),
+      path.join(__dirname, '../../bot/shared/utils/phone-validation.js'),
+      path.join(__dirname, '../../bot/shared/handlers/edit-class-trigger.js'),
+    ];
+    for (const f of files) {
+      const raw = fs.readFileSync(f, 'utf8');
+      for (const banned of ['+92', '+255', '0329', '5012345', 'Taleemabad', 'Rawalpindi', 'TaleemHub', 'bd-', 'PROJ-', 'Silverleaf']) {
+        expect(raw).not.toContain(banned);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Phase 4E — edit-class flow (5 of 5, completes Phase 4E)

Ports the edit-class roster flow: view roster, add / edit / remove students.

### What's added
- **edit-class-endpoint.js** — `ROSTER_VIEW → ADD_STUDENT | REMOVE_STUDENTS | SELECT_STUDENT_TO_EDIT | SUCCESS` (forward-only); add/edit/remove with cross-class injection guards; surfaces phone-validation errors instead of silently dropping.
- **phone-validation.js** (NEW, generic) — E.164 validation + Meta-blocked country codes; optional local-format expansion via `DEFAULT_PHONE_COUNTRY_CODE`. Drops prod's hardcoded `+92` special-casing — region-agnostic.
- **`students.parent_phone` column** → `00_complete-schema.sql`. This also **closes a latent gap**: the already-merged quiz subsystem reads `students.parent_phone` but the column was never actually defined (a schema NOTE assumed it lived on the students table).
- **edit-class-trigger.js** (NEW, pure) — `"edit class"`/`"edit roster"`/`"remove student"` keyword detector, unit-testable.
- text-message.handler.js — edit-class detection (0 / 1 / many classes → flow or interactive class picker), checked before attendance.
- whatsapp-bot.js — `edit_class_<id>` multi-class picker button handler.
- `POST /edit-class` mount; `EDIT_CLASS_FLOW_ID` constant + `.env.template`; `DEFAULT_PHONE_COUNTRY_CODE` documented.
- **docs/flows/edit-class-flow.json** (sanitized; generic phone examples).

### Tests
15 new tests (phone validation, endpoint roster CRUD, trigger helper, flow JSON, leak gate). Full suite: **74 suites / 1002 passing**. Bot-only deps mocked.

**This completes Phase 4E — all 5 flow-features (settings, status, student-videos, homework, edit-class) are ported.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)