### PR TITLE
Phase 6: conformance CI + stale-write fix (dead-code assessed)

### DIFF
--- a/bot/shared/handlers/flow-response.handler.js
+++ b/bot/shared/handlers/flow-response.handler.js
@@ -299,17 +299,14 @@ async function handleReadingAssessmentFlow(message, phoneNumber, userId) {
       assessmentId: assessment.id
     });
 
-    // Update conversation state
+    // Update conversation state. Comprehension/assessment context lives in Redis
+    // (see redis-comprehension.service), not a conversations column — writing a
+    // non-existent context_data column here previously failed the whole update,
+    // so current_state never persisted.
     const { error: updateError } = await supabase
       .from('conversations')
       .update({
-        current_state: 'AWAITING_READING_AUDIO',
-        context_data: {
-          assessment_id: assessment.id,
-          student_name: studentName,
-          is_auto_mode: isAutoMode,
-          test_comprehension: comprehensionRequired
-        }
+        current_state: 'AWAITING_READING_AUDIO'
       })
       .eq('user_id', userId)
       .order('created_at', { ascending: false })

--- a/tests/setup/column-completeness.test.js
+++ b/tests/setup/column-completeness.test.js
@@ -33,10 +33,10 @@ const ALLOWLIST = {
   // _saveGrade writes a per-STUDENT summary shape — this mismatch exists in prod too
   // and is out of scope for OSS schema parity (the schema correctly mirrors prod).
   exam_grades: ['grade', 'graded_at', 'marks_obtained', 'percentage', 'question_breakdown', 'roll_number', 'session_id', 'student_name', 'total_marks'],
-  // BUG#33: context_data was moved to Redis (see voice-message.handler); flow-response.handler
-  // still writes it — a CODE inconsistency to fix, not a column to add. conversation_state is a
-  // coaching_sessions column mis-attributed here by chain proximity.
-  conversations: ['context_data', 'conversation_state'],
+  // conversation_state is a coaching_sessions column mis-attributed to conversations
+  // by chain proximity (parser artifact). (The stale context_data write was removed —
+  // comprehension state lives in Redis, see redis-comprehension.service.)
+  conversations: ['conversation_state'],
   // camelCase key from a nested non-DB object (parser artifact).
   coaching_sessions: ['excerptlength'],
   // Mis-attributed by chain proximity; no quiz_sessions write references updated_at.

--- a/tests/setup/table-usage-conformance.test.js
+++ b/tests/setup/table-usage-conformance.test.js
@@ -1,0 +1,86 @@
+/**
+ * Table-Usage Conformance (Phase 6)
+ *
+ * The inverse of schema-completeness: every CREATE TABLE in the consolidated
+ * schema must be referenced somewhere in the codebase (bot / dashboard /
+ * infrastructure — by name, in .js or .sql), otherwise it is an orphan table
+ * that bloats the schema and confuses cloners.
+ *
+ * This is the "dead-table" guard. Tables that are intentionally defined but not
+ * yet wired (reserved for a feature whose ingestion/code isn't in the OSS tree)
+ * go in ALLOWLIST with a reason — a deliberate, reviewed decision.
+ *
+ * Note: 36 of the 37 tables not referenced via bot/ `.from()` ARE referenced
+ * elsewhere (dashboard code, SQL, RPC bodies, seed) — so this guard scans the
+ * whole repo, not just bot/.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCHEMA_PATH = path.join(ROOT, 'infrastructure/supabase/00_complete-schema.sql');
+
+// Tables intentionally defined but not yet referenced by code — each justified.
+const ALLOWLIST = new Set([
+  // Curriculum page-level capture table; part of the textbooks / textbook_toc /
+  // pre_generated_lps set. Populated by a curriculum-ingestion path not yet in
+  // the OSS tree (the OSS curriculum-LP path serves pre_generated_lps + toc).
+  'textbook_pages',
+]);
+
+function collectFiles(dir, exts) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (['node_modules', '.git', 'dist', 'build', 'coverage'].includes(e.name)) continue;
+      out.push(...collectFiles(p, exts));
+    } else if (exts.some((x) => e.name.endsWith(x))) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function extractCreateTables(sql) {
+  const set = new Set();
+  const re = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)/gi;
+  let m;
+  while ((m = re.exec(sql)) !== null) set.add(m[1].toLowerCase());
+  return set;
+}
+
+describe('Table-Usage Conformance', () => {
+  it('every schema table is referenced somewhere in the codebase (or allowlisted)', () => {
+    const schemaSQL = fs.readFileSync(SCHEMA_PATH, 'utf-8');
+    const tables = extractCreateTables(schemaSQL);
+
+    // All non-schema source across the repo (exclude the schema file itself + tests).
+    const files = [
+      ...collectFiles(path.join(ROOT, 'bot'), ['.js']),
+      ...collectFiles(path.join(ROOT, 'dashboard'), ['.js', '.ts', '.tsx']),
+      ...collectFiles(path.join(ROOT, 'infrastructure'), ['.js', '.sql']),
+    ].filter((f) => f !== SCHEMA_PATH && !/(^|\/)(tests?|__tests__)\//.test(f) && !/\.test\.js$/.test(f));
+
+    const haystack = files.map((f) => fs.readFileSync(f, 'utf-8')).join('\n');
+
+    const orphans = [];
+    for (const t of tables) {
+      if (ALLOWLIST.has(t)) continue;
+      const re = new RegExp(`\\b${t}\\b`);
+      if (!re.test(haystack)) orphans.push(t);
+    }
+    orphans.sort();
+
+    expect(orphans).toEqual([]);
+  });
+
+  it('allowlisted tables are still defined in the schema (no stale allowlist entries)', () => {
+    const tables = extractCreateTables(fs.readFileSync(SCHEMA_PATH, 'utf-8'));
+    for (const t of ALLOWLIST) {
+      expect(tables.has(t)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What
Phase 6 = **dead-code purge + conformance CI**. After assessment, aggressive deletion proved unsafe/low-value (see below), so this ships the one *real* dead-code fix + conformance guards that prevent rot.

### Dead-code fix
`flow-response.handler` updated `conversations.context_data` — a column that exists in **neither the OSS schema nor prod** (comprehension state moved to Redis). The non-existent column made the whole `.update()` fail, so `current_state` never persisted either. Dropped it; `current_state` now persists. Column-completeness guard allowlist tightened (`context_data` removed → now enforced).

### Conformance CI
New `tests/setup/table-usage-conformance.test.js`: the inverse of schema-completeness — every `CREATE TABLE` must be referenced somewhere in the repo. 72/73 are; `textbook_pages` (reserved curriculum page-capture) is the lone allowlisted orphan. Catches future dead tables.

### Deliberately NOT done (assessed)
- **Table deletion**: 36 of 37 tables not referenced via `bot/.from()` are live elsewhere (dashboard / SQL / RPC bodies / seed). Only `textbook_pages` is truly unreferenced, and it's part of a coherent curriculum set — documented as reserved, not deleted.
- **Module deletion**: several services are ported-but-unwired (e.g. bandit, coaching-card). "Dead" vs "reserved" is ambiguous, and deleting in a cloned repo is risky for little value.

## Tests
Full suite **81 suites / 1060 tests green** (+1 suite, +2 tests).

## Follow-up flagged (not in this PR)
448 internal ticket refs (`bd-NNN`/`BUG-NNN`/`Bug #NN`/`PROJ-NNN`) across 99 files in OSS comments + some `logToFile`/`throw` strings — a low-severity leak inherited from the prod sync. A full sanitize + guard is a sizable careful sweep; pending a go/no-go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)