### PR TITLE
chore: strip internal ticket refs + fix unparseable entry file + hygiene guards

### DIFF
--- a/bot/scripts/deployment/register-commands-meta.js
+++ b/bot/scripts/deployment/register-commands-meta.js
@@ -48,7 +48,7 @@ const COMMANDS = [
   }
 ];
 
-// BUG-001 FIX: Ice breakers for Android users (slash menu doesn't work on all Android devices)
+// Ice breakers for Android users (slash menu doesn't work on all Android devices)
 // Max 4 ice breakers, max 80 chars each, NO emojis
 const ICE_BREAKERS = [
   "Show Menu - See all features I can help with",
@@ -117,7 +117,7 @@ async function registerCommands() {
       {
         enable_welcome_message: true,
         commands: COMMANDS,
-        prompts: ICE_BREAKERS  // BUG-001: Add ice breakers for Android
+        prompts: ICE_BREAKERS // Add ice breakers for Android
       },
       {
         headers: {

--- a/bot/scripts/register-attendance-flows.js
+++ b/bot/scripts/register-attendance-flows.js
@@ -7,7 +7,6 @@
  *   node scripts/register-attendance-flows.js [--production]
  *
  * Created: January 24, 2026
- * Bead: bd-056
  *
  * API Reference:
  * - Create Flow: POST https://graph.facebook.com/{VERSION}/{WABA_ID}/flows
@@ -35,7 +34,7 @@ const STAGING_TOKEN = process.env.WHATSAPP_TOKEN;
 const WABA_ID = isProduction ? process.env.WABA_ID : STAGING_WABA_ID;
 const ACCESS_TOKEN = isProduction ? process.env.WHATSAPP_TOKEN : STAGING_TOKEN;
 
-// Base URL for flow endpoints (bd-215)
+// Base URL for flow endpoints
 // Railway domains follow pattern: {service-name}-production.up.railway.app
 const ENDPOINT_BASE_URL = process.env.APP_URL || (isProduction
   ? 'https://your-app-production.up.railway.app'
@@ -257,7 +256,7 @@ async function main() {
       file: 'attendance-setup-flow.json',
       categories: ['OTHER'],
       envVar: 'ATTENDANCE_SETUP_FLOW_ID',
-      endpointPath: '/api/flows/attendance-setup'  // bd-215
+      endpointPath: '/api/flows/attendance-setup'
     },
     {
       name: 'Attendance Marking',

--- a/bot/scripts/setup-flow-encryption.js
+++ b/bot/scripts/setup-flow-encryption.js
@@ -10,7 +10,6 @@
  * Usage:
  *   node scripts/setup-flow-encryption.js [--production]
  *
- * Bead: bd-186
  * Created: January 25, 2026
  */
 

--- a/bot/shared/config/gamma-languages.config.js
+++ b/bot/shared/config/gamma-languages.config.js
@@ -1,6 +1,6 @@
 /**
  * Gamma API Language Configuration
- * Bug #10: Language Parameter Passthrough
+ * Language Parameter Passthrough
  *
  * Supports:
  * - English (default)

--- a/bot/shared/config/registration-data.js
+++ b/bot/shared/config/registration-data.js
@@ -8,7 +8,6 @@
  *   PERSONAL_INFO: ${data.countries}, ${data.regions}
  *   PROFESSIONAL_INFO: ${data.organizations}, ${data.grades}, ${data.subjects}
  *
- * Bead: bd-384, bd-391
  * Updated: February 13, 2026
  */
 

--- a/bot/shared/handlers/attendance-flow.handler.js
+++ b/bot/shared/handlers/attendance-flow.handler.js
@@ -3,8 +3,7 @@
  * Handles WhatsApp Flow responses for attendance setup and marking
  *
  * Created: January 24, 2026
- * Bead: bd-057
- * Updated: January 26, 2026 (bd-214: Auto-compute academic year)
+ * Updated: January 26, 2026 (Auto-compute academic year)
  */
 
 const supabase = require('../config/supabase');
@@ -13,7 +12,7 @@ const AttendanceGeneratorService = require('../services/attendance-generator.ser
 const { logToFile } = require('../utils/logger');
 
 /**
- * Get current academic year based on Pakistan school calendar (bd-214)
+ * Get current academic year based on Pakistan school calendar
  * Academic year runs April to March:
  * - January-March 2026 → 2025-2026
  * - April-December 2026 → 2026-2027
@@ -52,7 +51,7 @@ class AttendanceFlowHandler {
     try {
       const className = responseJson.class_name?.trim();
       const section = responseJson.section?.trim() || null;
-      // bd-214: Auto-compute academic year instead of expecting from flow
+      // Auto-compute academic year instead of expecting from flow
       const academicYear = getCurrentAcademicYear();
       const attendanceFrequency = responseJson.attendance_frequency;
       const studentList = responseJson.student_list?.trim();
@@ -63,7 +62,7 @@ class AttendanceFlowHandler {
         return null;
       }
 
-      logToFile('📅 Academic year auto-computed (bd-214)', { academicYear });
+      logToFile('📅 Academic year auto-computed', { academicYear });
 
       return {
         className,
@@ -220,7 +219,7 @@ class AttendanceFlowHandler {
       // Parse and add students
       const parsedStudents = StudentListService.parseStudentText(data.studentList);
 
-      // bd-212: Check if parsing returned any students
+      // Check if parsing returned any students
       if (!parsedStudents || parsedStudents.length === 0) {
         logToFile('❌ No students parsed from input', {
           studentListInput: data.studentList,

--- a/bot/shared/handlers/exam-checker.handler.js
+++ b/bot/shared/handlers/exam-checker.handler.js
@@ -5,7 +5,6 @@
  * Handles text commands, image uploads, button responses, and WhatsApp Flows.
  *
  * Created: 2026-01-24
- * Beads: bd-086, bd-087
  */
 
 const { ExamCheckerOrchestrator, ExamSessionService } = require('../services/exam-checker');

--- a/bot/shared/handlers/flow-response.handler.js
+++ b/bot/shared/handlers/flow-response.handler.js
@@ -33,11 +33,11 @@ const { logToFile } = require('../utils/logger');
 // Flow IDs - configure via environment variables
 const READING_ASSESSMENT_FLOW_ID = process.env.READING_ASSESSMENT_FLOW_ID || '';
 
-// Attendance Flow IDs (bd-058)
+// Attendance Flow IDs
 const ATTENDANCE_SETUP_FLOW_ID = process.env.ATTENDANCE_SETUP_FLOW_ID || '';
 const ATTENDANCE_MARKING_FLOW_ID = process.env.ATTENDANCE_MARKING_FLOW_ID || '';
 
-// Registration Flow ID (bd-384: PROJ-010)
+// Registration Flow ID
 const REGISTRATION_FLOW_ID = process.env.REGISTRATION_FLOW_ID || '';
 
 /**
@@ -65,7 +65,7 @@ async function handleFlowResponse(message, phoneNumber, userId) {
       return await handleReadingAssessmentFlow(message, phoneNumber, userId);
     }
 
-    // Attendance flows (bd-058)
+    // Attendance flows
     if (flowId === ATTENDANCE_SETUP_FLOW_ID && ATTENDANCE_SETUP_FLOW_ID) {
       return await handleAttendanceSetupFlow(message, phoneNumber, userId);
     }
@@ -409,7 +409,7 @@ function mapLevelToPassageType(level) {
 }
 
 /**
- * Handle Attendance Setup Flow submission (bd-058)
+ * Handle Attendance Setup Flow submission
  * Creates a new class with students
  *
  * @param {object} message - Flow response message
@@ -467,7 +467,7 @@ async function handleAttendanceSetupFlow(message, phoneNumber, userId) {
 }
 
 /**
- * Handle Attendance Marking Flow submission (bd-058)
+ * Handle Attendance Marking Flow submission
  * Records attendance for a class
  *
  * @param {object} message - Flow response message
@@ -479,7 +479,7 @@ async function handleAttendanceMarkingFlow(message, phoneNumber, userId) {
   try {
     logToFile('📋 Processing attendance marking flow', { phoneNumber, userId });
 
-    // Parse flow response to get flow_token and absent_students (bd-193)
+    // Parse flow response to get flow_token and absent_students
     // Flow token format: "userId:classId:date:sessionType:encodedClassName"
     let responseJson = {};
     try {
@@ -538,22 +538,22 @@ async function handleAttendanceMarkingFlow(message, phoneNumber, userId) {
 
     await WhatsAppService.sendMessage(phoneNumber, confirmMessage);
 
-    // Generate and send Excel file (bd-195)
-    // Note: "Your Excel file is being generated..." is already in confirmMessage (bd-198)
+    // Generate and send Excel file
+    // Note: "Your Excel file is being generated..." is already in confirmMessage
     try {
-      // Transform stats to match generateCaption expected format (bd-197)
+      // Transform stats to match generateCaption expected format
       const summary = {
         present: result.stats.present,
         absent: result.stats.absent,
         attendancePercentage: parseFloat(result.stats.attendanceRate) || 0
       };
 
-      // Fetch class info from DB to get proper section (bd-206)
-      // Also validates that listId exists in database (bd-209)
+      // Fetch class info from DB to get proper section
+      // Also validates that listId exists in database
       const StudentListService = require('../services/student-list.service');
       const { data: classInfo, error: classError } = await StudentListService.getStudentListById(listId);
 
-      // Validate listId exists before proceeding (bd-209)
+      // Validate listId exists before proceeding
       if (classError || !classInfo) {
         logToFile('❌ Invalid listId - class not found in database', {
           userId,
@@ -578,14 +578,14 @@ async function handleAttendanceMarkingFlow(message, phoneNumber, userId) {
           },
           selectedListId: listId,
           records: result.records,
-          markingMethod: 'tap',  // bd-210: DB constraint only allows 'voice', 'tap', 'everyone_present'
+          markingMethod: 'tap', // DB constraint only allows 'voice', 'tap', 'everyone_present'
           summary: summary,
-          sessionDate: sessionDate  // Pass the actual date (bd-207)
+          sessionDate: sessionDate // Pass the actual date
         }
       );
 
       if (!deliveryResult.success) {
-        // bd-216: Handle duplicate attendance gracefully
+        // Handle duplicate attendance gracefully
         if (deliveryResult.isDuplicate) {
           logToFile('⚠️ Duplicate attendance detected - showing friendly message', {
             userId,
@@ -646,7 +646,7 @@ async function handleAttendanceMarkingFlow(message, phoneNumber, userId) {
 }
 
 /**
- * Handle Registration Flow submission (bd-381: PROJ-010)
+ * Handle Registration Flow submission
  * Extracts form data and updates user record with full registration info
  *
  * @param {object} message - Flow response message

--- a/bot/shared/handlers/image-message.handler.js
+++ b/bot/shared/handlers/image-message.handler.js
@@ -52,7 +52,7 @@ async function handleImageMessage(message, from, user = null) {
 
     // Start typing indicator
     const typingController = WhatsAppService.startContinuousTypingIndicator(from, message.id);
-    let idempotencyAcquired = false; // Track if we own the lock (bd-691)
+    let idempotencyAcquired = false; // Track if we own the lock
 
     try {
       // Extract image info
@@ -85,7 +85,7 @@ async function handleImageMessage(message, from, user = null) {
       }
 
       // ============================================================
-      // Phase 3 (bd-630): Classroom photo collection for coaching
+      // Phase 3: Classroom photo collection for coaching
       // ============================================================
       try {
         const coachingSupabase = require('../config/supabase');
@@ -191,7 +191,7 @@ async function handleImageMessage(message, from, user = null) {
       }
 
       // ============================================================
-      // EXAM CHECKER DETECTION (bd-086): Check for active exam session
+      // EXAM CHECKER DETECTION: Check for active exam session
       // ============================================================
       try {
         const ExamCheckerHandler = require('./exam-checker.handler');
@@ -264,7 +264,7 @@ async function handleImageMessage(message, from, user = null) {
 
       typingController.stop();
 
-      // Only send error message if we acquired the idempotency lock (bd-691)
+      // Only send error message if we acquired the idempotency lock
       // Without this guard, every concurrent failed handler sends an error message
       if (idempotencyAcquired) {
         const userLanguage = user?.preferred_language || 'en';
@@ -300,7 +300,7 @@ async function runImageAnalysis({ user, from, imageId, mimeType, caption, typing
   // Get or create session for conversation history
   const sessionId = await getOrCreateSession(user.id);
 
-  // Atomic idempotency check — SET NX ensures only one handler proceeds (bd-690)
+  // Atomic idempotency check — SET NX ensures only one handler proceeds
   const idempotencyKey = `image:${user.id}:${imageId}`;
   const idempotencyAcquired = await redisService.setNX(
     idempotencyKey,

--- a/bot/shared/handlers/lesson-plan-v2.handler.js
+++ b/bot/shared/handlers/lesson-plan-v2.handler.js
@@ -49,7 +49,7 @@ async function handleCurriculumLessonPlan({ userId, topic, grade, subject, curri
     }
 
     // OSS sendDocument reads a file path (createReadStream), so write the R2
-    // buffer to a temp file first, then clean it up (guards the bd-1349 trap
+    // buffer to a temp file first, then clean it up (guards the trap
     // where passing a Buffer to a path-expecting sender silently fails).
     let tmpPath;
     try {

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -30,7 +30,7 @@ const openai = getClient();
 // Import REAL language detection utilities for command detection
 const { detectLanguageOverride } = require('../utils/language-detector');
 const { getUserLanguage, setUserLanguage } = require('../utils/language-cache');
-// Bug #10: Import language detection for content generation
+// Import language detection for content generation
 const { detectRequestedLanguage, parseSubjectAndGrade } = require('../utils/language-detection');
 const path = require('path');
 const {
@@ -249,7 +249,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
   }
 
   // ============================================================
-  // ICE BREAKER DETECTION: Handle tapped ice breakers (BUG-001 fix)
+  // ICE BREAKER DETECTION: Handle tapped ice breakers (fix)
   // ============================================================
   const trimmedMessage = messageBody.trim().toLowerCase();
 
@@ -317,7 +317,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
   }
 
   // ============================================================
-  // EXAM CHECKER DETECTION (bd-086): Check for exam check trigger
+  // EXAM CHECKER DETECTION: Check for exam check trigger
   // ============================================================
   if (user) {
     try {
@@ -662,7 +662,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
   }
 
   // ============================================================
-  // BUG #18: COMPREHENSION TEXT ANSWER HANDLING
+  // COMPREHENSION TEXT ANSWER HANDLING
   // CRITICAL: Must check BEFORE normal conversation to route comprehension answers
   // ============================================================
   if (user) {
@@ -679,7 +679,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
       });
 
       if (activeFlow) {
-        logToFile('📝 Comprehension TEXT answer detected (Bug #18)', {
+        logToFile('📝 Comprehension TEXT answer detected', {
           assessmentId: activeFlow.assessment_id,
           currentQuestion: activeFlow.current_question_index,
           answerText: messageBody.substring(0, 50) + '...'
@@ -705,7 +705,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
           .single();
         const language = assessment?.language || 'en';
 
-        // Bug #18: Evaluate TEXT answer directly (no transcription needed)
+        // Evaluate TEXT answer directly (no transcription needed)
         const answerEvaluation = await ComprehensionService.evaluateTextAnswer(
           questionData,
           messageBody,
@@ -746,7 +746,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
             hasImage: !!nextQuestion.imageUrl
           });
 
-          // Bug #7: Handle image questions (word-level comprehension)
+          // Handle image questions (word-level comprehension)
           if (nextQuestion.imageUrl && nextQuestion.buttons) {
             await WhatsAppService.sendImageWithButtons(
               from,
@@ -1126,11 +1126,11 @@ async function handleTextMessage(message, from, messageBody, user = null) {
       return;
     }
 
-    // BUG-002 FIX: Check if user has features but missed registration (recovery path)
+    // Check if user has features but missed registration (recovery path)
     // This handles users who used features but never got asked for name
     if (user?.id) {
       const featureCount = await FeatureRegistrationService.countUserFeatures(user.id);
-      logToFile('📝 BUG-002: Checking feature count for recovery registration', {
+      logToFile('📝 Checking feature count for recovery registration', {
         userId: user.id,
         featureCount,
         phoneNumber: from
@@ -1138,7 +1138,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
 
       if (featureCount > 0) {
         // User has features but never got registered - trigger recovery registration
-        logToFile('📝 BUG-002: Triggering recovery registration for user with features', {
+        logToFile('📝 Triggering recovery registration for user with features', {
           userId: user.id,
           featureCount,
           phoneNumber: from
@@ -1361,7 +1361,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
   }
 
   // ============================================================
-  // ATTENDANCE SYSTEM INTEGRATION (bd-060)
+  // ATTENDANCE SYSTEM INTEGRATION
   // ============================================================
   // Check if user is in an active attendance session
   if (user?.id) {
@@ -1418,12 +1418,12 @@ async function handleTextMessage(message, from, messageBody, user = null) {
             break;
 
           case AttendanceConversationService.STATES.AWAITING_DATE_SELECTION:
-            // User selecting date for attendance (bd-065)
+            // User selecting date for attendance
             result = await AttendanceConversationService.handleDateSelection(user.id, messageBody);
             break;
 
           case AttendanceConversationService.STATES.AWAITING_SESSION_TYPE:
-            // User selecting AM/PM session type (bd-066)
+            // User selecting AM/PM session type
             result = await AttendanceConversationService.handleSessionTypeSelection(user.id, messageBody);
             break;
 
@@ -1436,7 +1436,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
             break;
 
           case AttendanceConversationService.STATES.PROCESSING:
-            // Check if processing has timed out (bd-190)
+            // Check if processing has timed out
             if (AttendanceConversationService.isProcessingTimedOut(sessionState)) {
               logToFile('⚠️ Processing timeout detected, clearing stuck state', { userId: user.id, processingStartedAt: sessionState.processingStartedAt });
               await AttendanceConversationService.clearSessionState(user.id);
@@ -1471,16 +1471,16 @@ async function handleTextMessage(message, from, messageBody, user = null) {
         } else if (result.action === 'AWAIT_VOICE_INPUT' || result.action === 'PROMPT_VOICE') {
           await WhatsAppService.sendMessage(from, result.message);
         } else if (result.action === 'SEND_MARKING_FLOW') {
-          // Send the WhatsApp Flow for marking attendance (bd-186: encryption endpoint implemented)
+          // Send the WhatsApp Flow for marking attendance (encryption endpoint implemented)
           if (ATTENDANCE_MARKING_FLOW_ID) {
             const sessionState = await AttendanceConversationService.getSessionState(user.id);
             const today = new Date().toISOString().split('T')[0];
-            // Flow token format: userId:classId:date:sessionType:className - all data for response handling (bd-193)
+            // Flow token format: userId:classId:date:sessionType:className - all data for response handling
             const sessionType = sessionState?.selectedSession || 'morning';
             const className = result.selectedClass?.class_name || 'Class';
             const section = result.selectedClass?.section || '';
             const flowToken = `${user.id}:${sessionState?.selectedListId}:${today}:${sessionType}:${encodeURIComponent(className)}`;
-            // bd-198: Dynamic header with class + section (e.g., "5A Attendance")
+            // Dynamic header with class + section (e.g., "5A Attendance")
             const displayName = section ? `${className}${section}` : className;
 
             await WhatsAppService.sendFlow(from, {
@@ -1489,7 +1489,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
               body: result.message,
               buttonText: 'Mark Attendance',
               // Note: Don't specify screen for data_api_version 3.0+ flows with endpoint
-              // The endpoint determines first screen via INIT response (bd-191)
+              // The endpoint determines first screen via INIT response
               flowToken: flowToken
             });
             logToFile('📋 Sent attendance marking flow', {
@@ -1508,7 +1508,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
           // Send initial "generating" message
           await WhatsAppService.sendMessage(from, result.message);
 
-          // Generate, upload, and deliver Excel (bd-063)
+          // Generate, upload, and deliver Excel
           try {
             const sessionState = await AttendanceConversationService.getSessionState(user.id);
             const deliveryResult = await AttendanceDeliveryService.processAndDeliver(
@@ -1525,17 +1525,17 @@ async function handleTextMessage(message, from, messageBody, user = null) {
             );
 
             if (!deliveryResult.success) {
-              // bd-190: Clear state on delivery failure to prevent stuck PROCESSING
+              // Clear state on delivery failure to prevent stuck PROCESSING
               await AttendanceConversationService.clearSessionState(user.id);
               logToFile('📋 Cleared session state after delivery failure', { userId: user.id, error: deliveryResult.error });
               await WhatsAppService.sendMessage(from, `Sorry, there was an error generating your attendance file: ${deliveryResult.error}\n\nSay "attendance" to try again.`);
             } else {
-              // bd-190: Clear state on successful completion
+              // Clear state on successful completion
               await AttendanceConversationService.clearSessionState(user.id);
               logToFile('📋 Cleared session state after successful delivery', { userId: user.id });
             }
           } catch (deliveryError) {
-            // bd-190: Clear state on exception to prevent stuck PROCESSING
+            // Clear state on exception to prevent stuck PROCESSING
             await AttendanceConversationService.clearSessionState(user.id);
             logToFile('Attendance delivery error - state cleared', { error: deliveryError.message, userId: user.id });
             await WhatsAppService.sendMessage(from, 'Sorry, something went wrong delivering your attendance file. Say "attendance" to try again.');
@@ -1564,7 +1564,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
   }
 
   // ============================================================
-  // ADD CLASS DETECTION (bd-205)
+  // ADD CLASS DETECTION
   // Check BEFORE attendance - triggers setup flow even with existing classes
   // ============================================================
   const addClassDetection = AttendanceDetectorService.detectAddClassIntent(messageBody);
@@ -1648,13 +1648,13 @@ async function handleTextMessage(message, from, messageBody, user = null) {
       return;
     }
 
-    // BUG-002 FIX: Check if user has features but missed registration (recovery path)
+    // Check if user has features but missed registration (recovery path)
     if (user?.id) {
       const featureCount = await FeatureRegistrationService.countUserFeatures(user.id);
 
       if (featureCount > 0) {
         // User has features but never got registered - trigger recovery registration
-        logToFile('📝 BUG-002: Recovery registration for user with features', {
+        logToFile('📝 Recovery registration for user with features', {
           userId: user.id,
           featureCount,
           phoneNumber: from
@@ -2023,7 +2023,7 @@ async function handleLessonPlanRequest(from, messageBody, user, sessionId, respo
     const topic = await OpenAIService.extractTopic(messageBody);
     logToFile('Topic extracted', { topic });
 
-    // Bug #10: Detect explicitly requested language (defaults to 'en')
+    // Detect explicitly requested language (defaults to 'en')
     const contentLanguage = detectRequestedLanguage(messageBody);
     logToFile('Content language detected', { contentLanguage, messageBody: messageBody.substring(0, 100) });
 
@@ -2141,7 +2141,7 @@ async function handlePresentationRequest(from, messageBody, user, sessionId, res
     const topic = await OpenAIService.extractTopic(messageBody);
     logToFile('Topic extracted', { topic });
 
-    // Bug #10: Detect explicitly requested language (defaults to 'en')
+    // Detect explicitly requested language (defaults to 'en')
     const contentLanguage = detectRequestedLanguage(messageBody);
     logToFile('Content language detected for presentation', { contentLanguage });
 

--- a/bot/shared/handlers/voice-message.handler.js
+++ b/bot/shared/handlers/voice-message.handler.js
@@ -22,7 +22,7 @@ const {
 } = require('../database/bot-helpers');
 const { uploadAudio } = require('../storage/r2');
 const supabase = require('../config/supabase');
-// Bug #10: Import language detection for content generation
+// Import language detection for content generation
 const { detectRequestedLanguage } = require('../utils/language-detection');
 // Language cache for ASR routing based on user preference
 const { getUserLanguage, setUserLanguage } = require('../utils/language-cache');
@@ -115,7 +115,7 @@ async function handleVoiceMessage(message, from, user = null) {
     }
 
     // ============================================================
-    // ATTENDANCE VOICE INPUT CHECK (bd-060, bd-062)
+    // ATTENDANCE VOICE INPUT CHECK
     // Check if user is awaiting voice input for attendance roll call
     // ============================================================
     if (user) {
@@ -179,7 +179,7 @@ async function handleVoiceMessage(message, from, user = null) {
 
     // PRIORITY 1: CHECK FOR COMPREHENSION QUESTION ANSWER (Sprint 1.8)
     // CRITICAL: Must check BEFORE reading assessment to avoid routing comprehension answers as new readings
-    // BUG #33 FIX: Query Redis instead of conversations table (context_data column doesn't exist)
+    // Query Redis instead of conversations table (context_data column doesn't exist)
     if (user) {
       try {
         const RedisComprehensionService = require('../services/redis-comprehension.service');
@@ -214,7 +214,7 @@ async function handleVoiceMessage(message, from, user = null) {
           // Import ComprehensionService
           const ComprehensionService = require('../services/reading/comprehension.service');
 
-          // BUG #33 FIX: Get question data from Redis flow state
+          // Get question data from Redis flow state
           const questions = activeFlow.questions;
           const currentQuestionIndex = activeFlow.current_question_index;
           const questionData = questions[currentQuestionIndex];
@@ -244,7 +244,7 @@ async function handleVoiceMessage(message, from, user = null) {
             confidence: answerEvaluation.confidence
           });
 
-          // BUG #33 FIX: Record answer in Redis and get updated state
+          // Record answer in Redis and get updated state
           const updatedFlow = await RedisComprehensionService.recordAnswer(
             assessmentId,
             answerEvaluation
@@ -273,7 +273,7 @@ async function handleVoiceMessage(message, from, user = null) {
               questionText: nextQuestion.question.substring(0, 50) + '...'
             });
 
-            // Bug #7: Handle image questions (word-level comprehension)
+            // Handle image questions (word-level comprehension)
             if (nextQuestion.imageUrl && nextQuestion.buttons) {
               await WhatsAppService.sendImageWithButtons(
                 from,
@@ -288,7 +288,7 @@ async function handleVoiceMessage(message, from, user = null) {
               );
             }
 
-            // BUG #33 FIX: State already updated in Redis by recordAnswer()
+            // State already updated in Redis by recordAnswer
             logToFile('✅ Next comprehension question sent, state updated in Redis', {
               questionIndex: nextQuestionIndex,
               totalQuestions: questions.length,
@@ -319,7 +319,7 @@ async function handleVoiceMessage(message, from, user = null) {
               language
             );
 
-            // BUG #33 FIX: Save to reading_assessments table (proper persistence)
+            // Save to reading_assessments table (proper persistence)
             await supabase
               .from('reading_assessments')
               .update({
@@ -331,7 +331,7 @@ async function handleVoiceMessage(message, from, user = null) {
               })
               .eq('id', assessmentId);
 
-            // BUG #33 FIX: Clear Redis state (no conversations table cleanup needed)
+            // Clear Redis state (no conversations table cleanup needed)
             await RedisComprehensionService.clearFlow(assessmentId);
 
             // Import AnalysisService to generate combined report
@@ -401,7 +401,7 @@ async function handleVoiceMessage(message, from, user = null) {
     // Comes after comprehension check to avoid interference
     if (user) {
       try {
-        // BUG #33 FIX: Abandon any stale comprehension flows before processing new reading
+        // Abandon any stale comprehension flows before processing new reading
         const RedisComprehensionService = require('../services/redis-comprehension.service');
         await RedisComprehensionService.abandonUserFlows(user.id);
 
@@ -419,7 +419,7 @@ async function handleVoiceMessage(message, from, user = null) {
           .single();
 
         if (activeAssessment) {
-          // FIX 2 (Bug #34): Validate assessment state to detect stale reads and invalid states
+          // FIX 2: Validate assessment state to detect stale reads and invalid states
           const validationErrors = [];
 
           // Validation 1: Check assessment age (reject if >30 minutes old)
@@ -479,7 +479,7 @@ async function handleVoiceMessage(message, from, user = null) {
             assessmentAge: Math.round(assessmentAge / 60000) + ' minutes'
           });
 
-          // FIX 5 (Bug #34): Enhanced error logging for reading assessment processing
+          // FIX 5: Enhanced error logging for reading assessment processing
           logToFile('📥 Starting reading assessment audio processing', {
             assessmentId: activeAssessment.id,
             userId: user.id,
@@ -1148,7 +1148,7 @@ async function handleVoiceLessonPlanRequest(from, transcription, user, sessionId
     const topic = await OpenAIService.extractTopic(transcription);
     logToFile('Topic extracted', { topic });
 
-    // Bug #10: Detect explicitly requested language from transcription (defaults to 'en')
+    // Detect explicitly requested language from transcription (defaults to 'en')
     const contentLanguage = detectRequestedLanguage(transcription);
     logToFile('Content language detected for voice lesson plan', { contentLanguage });
 
@@ -1208,7 +1208,7 @@ async function handleVoicePresentationRequest(from, transcription, user, session
     const topic = await OpenAIService.extractTopic(transcription);
     logToFile('Topic extracted', { topic });
 
-    // Bug #10: Detect explicitly requested language from transcription (defaults to 'en')
+    // Detect explicitly requested language from transcription (defaults to 'en')
     const contentLanguage = detectRequestedLanguage(transcription);
     logToFile('Content language detected for voice presentation', { contentLanguage });
 

--- a/bot/shared/routes/attendance-setup-endpoint.js
+++ b/bot/shared/routes/attendance-setup-endpoint.js
@@ -1,7 +1,7 @@
 /**
  * Attendance Setup Endpoint Handler
  *
- * Handles endpoint-based navigation for student entry with loops (bd-215)
+ * Handles endpoint-based navigation for student entry with loops
  *
  * Flow:
  * 1. INIT → CLASS_INFO screen (grade, section, frequency)
@@ -10,14 +10,13 @@
  * 4. ADD_STUDENT "Done" → Validate 1+ students → SUCCESS screen
  *
  * Created: January 26, 2026
- * Bead: bd-215, bd-389
  */
 
 const supabase = require('../config/supabase');
 const StudentListService = require('../services/student-list.service');
 const { logToFile } = require('../utils/logger');
 
-// Import academic year helper from attendance-flow.handler (bd-214)
+// Import academic year helper from attendance-flow.handler
 function getCurrentAcademicYear() {
   const now = new Date();
   const month = now.getMonth() + 1;
@@ -100,12 +99,12 @@ async function handleClassInfoSubmit(userId, screenData) {
   }
 
   try {
-    // Create student list in database (bd-214: academic year auto-computed)
+    // Create student list in database (academic year auto-computed)
     const academicYear = getCurrentAcademicYear();
     const trimmedClassName = class_name.trim();
     const trimmedSection = section?.trim() || null;
 
-    // Check if class already exists for this user - check ALL classes including soft-deleted (bd-215)
+    // Check if class already exists for this user - check ALL classes including soft-deleted
     const { data: existingLists } = await supabase
       .from('student_lists')
       .select('id, class_name, section, is_active')
@@ -161,7 +160,7 @@ async function handleClassInfoSubmit(userId, screenData) {
       ? `${trimmedClassName} - ${trimmedSection}`
       : trimmedClassName;
 
-    // Get existing students if reusing a class (bd-215)
+    // Get existing students if reusing a class
     let studentCount = 0;
     let studentsSummary = [];
 
@@ -179,7 +178,7 @@ async function handleClassInfoSubmit(userId, screenData) {
       }
     }
 
-    // bd-388: Use pre-composed strings for pure dynamic references
+    // Use pre-composed strings for pure dynamic references
     // WhatsApp Flows mixed static+dynamic text interpolation is unreliable
     const classInfo = `Class: ${classDisplay} | Students: ${studentCount}`;
     const heading = `Add Student #${studentCount + 1}`;
@@ -193,11 +192,11 @@ async function handleClassInfoSubmit(userId, screenData) {
         student_count: studentCount,
         students_added: studentsSummary,
         student_number: studentCount + 1,
-        // bd-388: Pre-composed strings for pure dynamic references
+        // Pre-composed strings for pure dynamic references
         class_info: classInfo,
         heading: heading,
         students_list: studentsList,
-        // bd-389: Form-level init-values to clear TextInput fields on loop
+        // Form-level init-values to clear TextInput fields on loop
         form_init_values: { first_name: '', last_name: '' }
       }
     };
@@ -237,7 +236,7 @@ async function handleAddStudentAction(listId, studentData, classDisplay) {
         class_info: `Class: ${classDisplay}`,
         heading: 'Add Student',
         students_list: '',
-        // bd-389: Form-level init-values to clear TextInput fields on loop
+        // Form-level init-values to clear TextInput fields on loop
         form_init_values: { first_name: '', last_name: '' },
         error: { message: 'Student name is required' }
       }
@@ -300,7 +299,7 @@ async function handleAddStudentAction(listId, studentData, classDisplay) {
     const studentsSummary = getStudentListSummary(allStudents || []);
     const totalStudents = allStudents?.length || 0;
 
-    // bd-388: Pre-composed strings for pure dynamic references
+    // Pre-composed strings for pure dynamic references
     const classInfo = `Class: ${classDisplay} | Students: ${totalStudents}`;
     const heading = `Add Student #${totalStudents + 1}`;
     const studentsList = formatStudentsListString(studentsSummary);
@@ -313,11 +312,11 @@ async function handleAddStudentAction(listId, studentData, classDisplay) {
         student_count: totalStudents,
         students_added: studentsSummary,
         student_number: totalStudents + 1,
-        // bd-388: Pre-composed strings for pure dynamic references
+        // Pre-composed strings for pure dynamic references
         class_info: classInfo,
         heading: heading,
         students_list: studentsList,
-        // bd-389: Form-level init-values to clear TextInput fields on loop
+        // Form-level init-values to clear TextInput fields on loop
         form_init_values: { first_name: '', last_name: '' }
       }
     };
@@ -334,7 +333,7 @@ async function handleAddStudentAction(listId, studentData, classDisplay) {
 
   } catch (error) {
     logToFile('❌ Exception adding student', { error: error.message });
-    // bd-388: No version field in response (Meta expects {screen, data} only)
+    // No version field in response (Meta expects {screen, data} only)
     return {
       screen: 'ADD_STUDENT',
       data: {
@@ -343,7 +342,7 @@ async function handleAddStudentAction(listId, studentData, classDisplay) {
         class_info: `Class: ${classDisplay}`,
         heading: 'Add Student',
         students_list: '',
-        // bd-389: Form-level init-values to clear TextInput fields on loop
+        // Form-level init-values to clear TextInput fields on loop
         form_init_values: { first_name: '', last_name: '' },
         error: { message: 'Failed to add student. Please try again.' }
       }
@@ -385,14 +384,14 @@ async function handleDoneAction(listId, classDisplay) {
           class_info: `Class: ${classDisplay} | Students: 0`,
           heading: 'Add Student #1',
           students_list: '',
-          // bd-389: Form-level init-values to clear TextInput fields on loop
+          // Form-level init-values to clear TextInput fields on loop
           form_init_values: { first_name: '', last_name: '' },
           error: { message: 'Please add at least one student before finishing.' }
         }
       };
     }
 
-    // bd-388: Pre-composed success_message for pure dynamic reference
+    // Pre-composed success_message for pure dynamic reference
     const successMessage = `Your class ${classDisplay} has been created with ${students.length} student${students.length === 1 ? '' : 's'}.`;
 
     const responseData = {
@@ -441,7 +440,7 @@ function getStudentListSummary(students) {
 }
 
 /**
- * Format students list as a display string for pure dynamic reference (bd-388)
+ * Format students list as a display string for pure dynamic reference
  * @param {Array} studentsSummary - Array of {name: "1. Zara Abdul"} objects
  * @returns {string} - Formatted string or empty if no students
  */

--- a/bot/shared/routes/flow-endpoint.routes.js
+++ b/bot/shared/routes/flow-endpoint.routes.js
@@ -5,12 +5,11 @@
  *
  * Endpoints:
  * - POST /api/flows/attendance-marking - Handle attendance marking flow data requests
- * - POST /api/flows/attendance-setup - Handle attendance setup flow with student entry loops (bd-215)
- * - POST /api/flows/registration - Handle registration flow data requests (bd-384: PROJ-010)
+ * - POST /api/flows/attendance-setup - Handle attendance setup flow with student entry loops
+ * - POST /api/flows/registration - Handle registration flow data requests
  *
- * Bead: bd-186, bd-384
  * Created: January 25, 2026
- * Updated: February 17, 2026 (bd-396: Registration Flow v3 added)
+ * Updated: February 17, 2026 (Registration Flow v3 added)
  */
 
 const express = require('express');
@@ -154,7 +153,7 @@ async function handleAttendanceMarkingRequest(data) {
  */
 async function handleInit(flowToken, screenData) {
   try {
-    // Parse flow token to get user ID and class info (bd-193)
+    // Parse flow token to get user ID and class info
     // Flow token format: "userId:classId:date:sessionType:encodedClassName"
     const tokenParts = (flowToken || '').split(':');
     const [userId, classId, dateStr, sessionType, encodedClassName] = tokenParts;
@@ -164,7 +163,7 @@ async function handleInit(flowToken, screenData) {
       return FlowEncryptionService.createErrorResponse('Invalid flow token');
     }
 
-    // Get student list for the class (bd-192: fixed method name)
+    // Get student list for the class (fixed method name)
     const { data: students, error: studentsError } = await StudentListService.getStudentsByList(classId);
 
     if (studentsError || !students || students.length === 0) {
@@ -176,7 +175,7 @@ async function handleInit(flowToken, screenData) {
     const classInfo = await StudentListService.getStudentListById(classId);
     const className = encodedClassName ? decodeURIComponent(encodedClassName) : (classInfo?.class_name || 'Class');
 
-    // Format session type for display - include "Session:" prefix (bd-194)
+    // Format session type for display - include "Session:" prefix
     // The Flow's "Session: ${data.session_type}" concatenation has binding issues
     // So we include the prefix in the value and update Flow to use just ${data.session_type}
     const sessionTypeDisplay = sessionType === 'morning' ? 'Session: Morning' :
@@ -193,7 +192,7 @@ async function handleInit(flowToken, screenData) {
     });
 
     // Format students for CheckboxGroup (id, title format)
-    // Note: field is student_name not name (bd-192)
+    // Note: field is student_name not name
     const formattedStudents = students.map((student, index) => ({
       id: student.id,
       title: `${index + 1}. ${student.student_name}`,
@@ -256,7 +255,7 @@ async function handleDataExchange(flowToken, screen, screenData) {
 }
 
 /**
- * Handle attendance setup flow data requests (bd-215)
+ * Handle attendance setup flow data requests
  *
  * Actions:
  * - ping: Health check
@@ -346,7 +345,7 @@ async function handleAttendanceSetupRequest(data) {
   if (action === 'BACK') {
     if (screen === 'ADD_STUDENT') {
       // Can't go back from ADD_STUDENT (class already created)
-      // Fetch current class data to populate screen (bd-215 fix)
+      // Fetch current class data to populate screen (fix)
       try {
         // Get the most recent active class for this user
         const { data: recentClass } = await supabase
@@ -374,7 +373,7 @@ async function handleAttendanceSetupRequest(data) {
           const studentCount = students?.length || 0;
           const studentsSummary = getStudentListSummary(students || []);
 
-          // bd-388: Include pre-composed strings for pure dynamic references
+          // Include pre-composed strings for pure dynamic references
           const classInfo = `Class: ${classDisplay} | Students: ${studentCount}`;
           const heading = `Add Student #${studentCount + 1}`;
           const studentsList = formatStudentsListString(studentsSummary);
@@ -390,7 +389,7 @@ async function handleAttendanceSetupRequest(data) {
               class_info: classInfo,
               heading: heading,
               students_list: studentsList,
-              // bd-389: Form-level init-values to clear TextInput fields
+              // Form-level init-values to clear TextInput fields
               form_init_values: { first_name: '', last_name: '' }
             }
           };
@@ -413,7 +412,7 @@ async function handleAttendanceSetupRequest(data) {
           class_info: 'Class: Unknown | Students: 0',
           heading: 'Add Student #1',
           students_list: '',
-          // bd-389: Form-level init-values to clear TextInput fields
+          // Form-level init-values to clear TextInput fields
           form_init_values: { first_name: '', last_name: '' }
         }
       };
@@ -434,7 +433,7 @@ async function handleAttendanceSetupRequest(data) {
 }
 
 /**
- * Handle registration flow data requests (bd-384: PROJ-010)
+ * Handle registration flow data requests
  *
  * Actions:
  * - ping: Health check

--- a/bot/shared/routes/registration-endpoint.js
+++ b/bot/shared/routes/registration-endpoint.js
@@ -1,10 +1,10 @@
 /**
  * Registration Flow Endpoint Handler
  *
- * Handles endpoint-based WhatsApp Flow for user registration (PROJ-010).
+ * Handles endpoint-based WhatsApp Flow for user registration.
  * Uses data_api_version 3.0 with encrypted data exchange.
  *
- * Flow screens (bd-391, bd-395: split-screen + conditional org):
+ * Flow screens (split-screen + conditional org):
  *   PERSONAL_INFO → REGION_INFO (if PK) → PROFESSIONAL_INFO → SUCCESS (if org != "other")
  *   PERSONAL_INFO → REGION_INFO (if PK) → PROFESSIONAL_INFO → ORG_DETAILS → SUCCESS (if org == "other")
  *   PERSONAL_INFO → PROFESSIONAL_INFO (if not PK) → SUCCESS
@@ -29,7 +29,6 @@
  * - handlePing returns {data: {status: 'active'}}
  * - Log full JSON responses for debugging
  *
- * Bead: bd-384, bd-391, bd-395
  * Updated: February 16, 2026
  */
 
@@ -48,7 +47,7 @@ const REDIS_TTL = 3600; // 1 hour
 
 /**
  * Handle INIT action - return PERSONAL_INFO screen with country dropdown only
- * bd-391: Region is now on a separate screen, not included in INIT
+ * Region is now on a separate screen, not included in INIT
  */
 async function handleRegistrationInit(userId) {
   logToFile('📝 Registration flow INIT', { userId });
@@ -94,7 +93,7 @@ async function handleRegistrationDataExchange(userId, screen, screenData, flowTo
 
 /**
  * Handle PERSONAL_INFO screen submission
- * bd-391: Split-screen routing - PK goes to REGION_INFO, others skip to PROFESSIONAL_INFO
+ * Split-screen routing - PK goes to REGION_INFO, others skip to PROFESSIONAL_INFO
  */
 async function handlePersonalInfoSubmit(userId, screenData, flowToken) {
   const fullName = (screenData.full_name || '').trim();
@@ -116,7 +115,7 @@ async function handlePersonalInfoSubmit(userId, screenData, flowToken) {
   };
   await storeRegData(flowToken, regData);
 
-  // bd-391: Route based on country
+  // Route based on country
   if (country === 'PK') {
     // Pakistan users → REGION_INFO screen
     const response = {
@@ -151,7 +150,7 @@ async function handlePersonalInfoSubmit(userId, screenData, flowToken) {
 }
 
 /**
- * Handle REGION_INFO screen submission (bd-391: new screen for PK users)
+ * Handle REGION_INFO screen submission (new screen for PK users)
  * Updates Redis with selected region, navigates to PROFESSIONAL_INFO
  */
 async function handleRegionInfoSubmit(userId, screenData, flowToken) {
@@ -180,13 +179,13 @@ async function handleRegionInfoSubmit(userId, screenData, flowToken) {
 
 /**
  * Handle PROFESSIONAL_INFO screen submission
- * bd-395: Organization is mandatory. If org is "other", navigate to ORG_DETAILS.
+ * Organization is mandatory. If org is "other", navigate to ORG_DETAILS.
  * Otherwise, go directly to SUCCESS.
  */
 async function handleProfessionalInfoSubmit(userId, screenData, flowToken) {
   const organization = screenData.organization || '';
 
-  // bd-395: Organization is mandatory
+  // Organization is mandatory
   if (!organization) {
     return createErrorResponse('Organization is required');
   }
@@ -201,7 +200,7 @@ async function handleProfessionalInfoSubmit(userId, screenData, flowToken) {
     subjects: screenData.subjects || []
   };
 
-  // bd-395: If org is "other", navigate to ORG_DETAILS for custom org name
+  // If org is "other", navigate to ORG_DETAILS for custom org name
   if (organization === 'other') {
     await storeRegData(flowToken, allData);
 
@@ -249,14 +248,14 @@ async function handleProfessionalInfoSubmit(userId, screenData, flowToken) {
 }
 
 /**
- * Handle ORG_DETAILS screen submission (bd-395)
+ * Handle ORG_DETAILS screen submission
  * Collects custom organization name when user selected "Other".
  * Combines with stored data from Redis and returns SUCCESS.
  */
 async function handleOrgDetailsSubmit(userId, screenData, flowToken) {
   const organizationOther = (screenData.organization_other || '').trim();
 
-  // bd-395: Custom org name is mandatory when "Other" is selected
+  // Custom org name is mandatory when "Other" is selected
   if (!organizationOther) {
     return createErrorResponse('Please enter your organization name');
   }
@@ -294,13 +293,13 @@ async function handleOrgDetailsSubmit(userId, screenData, flowToken) {
 
 /**
  * Handle BACK navigation between screens
- * bd-391: Updated for split-screen routing
- * bd-395: Added ORG_DETAILS → PROFESSIONAL_INFO
+ * Updated for split-screen routing
+ * Added ORG_DETAILS → PROFESSIONAL_INFO
  */
 async function handleRegistrationBack(userId, screen, flowToken) {
   logToFile('📝 Registration flow BACK', { userId, screen });
 
-  // bd-395: BACK from ORG_DETAILS → PROFESSIONAL_INFO
+  // BACK from ORG_DETAILS → PROFESSIONAL_INFO
   if (screen === 'ORG_DETAILS') {
     return {
       screen: 'PROFESSIONAL_INFO',

--- a/bot/shared/services/__mocks__/feature-registration.service.js
+++ b/bot/shared/services/__mocks__/feature-registration.service.js
@@ -11,7 +11,7 @@ const FeatureRegistrationService = {
   isRegistrationComplete: jest.fn().mockResolvedValue(true),
   getRegistrationStatus: jest.fn().mockResolvedValue({ status: 'complete' }),
 
-  // Feature count for recovery registration (BUG-002)
+  // Feature count for recovery registration
   countUserFeatures: jest.fn().mockResolvedValue(0),
 
   // Start feature-based registration flow

--- a/bot/shared/services/attendance-conversation.service.js
+++ b/bot/shared/services/attendance-conversation.service.js
@@ -3,7 +3,6 @@
  * State machine for managing attendance marking workflow
  *
  * Created: January 24, 2026
- * Bead: bd-059
  *
  * States:
  * - IDLE: Not in an attendance session
@@ -23,8 +22,8 @@ const { logToFile } = require('../utils/logger');
 const STATES = {
   IDLE: 'IDLE',
   AWAITING_CLASS_SELECTION: 'AWAITING_CLASS_SELECTION',
-  AWAITING_DATE_SELECTION: 'AWAITING_DATE_SELECTION',      // bd-065
-  AWAITING_SESSION_TYPE: 'AWAITING_SESSION_TYPE',          // bd-066 (AM/PM)
+  AWAITING_DATE_SELECTION: 'AWAITING_DATE_SELECTION',
+  AWAITING_SESSION_TYPE: 'AWAITING_SESSION_TYPE', // (AM/PM)
   AWAITING_MARKING_METHOD: 'AWAITING_MARKING_METHOD',
   AWAITING_VOICE_INPUT: 'AWAITING_VOICE_INPUT',
   AWAITING_VERIFICATION: 'AWAITING_VERIFICATION',
@@ -35,10 +34,10 @@ const STATES = {
 // Session TTL in seconds (1 hour)
 const SESSION_TTL = 3600;
 
-// Processing timeout in seconds (2 minutes) - bd-190
+// Processing timeout in seconds (2 minutes) -
 const PROCESSING_TIMEOUT = 120;
 
-// Rate limiting constants (bd-069)
+// Rate limiting constants
 const RATE_LIMIT_WINDOW = 300; // 5 minutes
 const RATE_LIMIT_MAX_SESSIONS = 5; // Max 5 sessions per 5 minutes
 
@@ -46,7 +45,7 @@ const RATE_LIMIT_MAX_SESSIONS = 5; // Max 5 sessions per 5 minutes
 const VOICE_KEYWORDS = ['voice', 'آواز', 'awaz', 'bolo', 'بولو', '1', 'roll call'];
 const TAP_KEYWORDS = ['tap', 'type', 'ٹیپ', '2', 'mark', 'select'];
 
-// Session type keywords (bd-066)
+// Session type keywords
 const MORNING_KEYWORDS = ['morning', 'am', 'صبح', 'subah', '1'];
 const AFTERNOON_KEYWORDS = ['afternoon', 'pm', 'دوپہر', 'dopahar', '2'];
 
@@ -112,7 +111,7 @@ class AttendanceConversationService {
   }
 
   /**
-   * Check if PROCESSING state has timed out (bd-190)
+   * Check if PROCESSING state has timed out
    * @param {Object} sessionState - Current session state
    * @returns {boolean} True if processing has timed out
    */
@@ -135,7 +134,7 @@ class AttendanceConversationService {
   }
 
   /**
-   * Check rate limit for user (bd-069)
+   * Check rate limit for user
    * @returns {Object} { allowed: boolean, remainingTime?: number }
    */
   static async checkRateLimit(userId) {
@@ -169,7 +168,7 @@ class AttendanceConversationService {
   }
 
   /**
-   * Increment rate limit counter (bd-069)
+   * Increment rate limit counter
    */
   static async incrementRateLimit(userId) {
     try {
@@ -198,7 +197,7 @@ class AttendanceConversationService {
   }
 
   /**
-   * Handle existing session recovery (bd-068)
+   * Handle existing session recovery
    * @returns {Object} { hasExisting: boolean, sessionState?: Object, action?: string }
    */
   static async handleSessionRecovery(userId) {
@@ -237,7 +236,7 @@ class AttendanceConversationService {
   }
 
   /**
-   * Generate date selection message (bd-065)
+   * Generate date selection message
    */
   static generateDateSelectionMessage() {
     const today = new Date();
@@ -270,7 +269,7 @@ class AttendanceConversationService {
   }
 
   /**
-   * Generate session type message (bd-066 - AM/PM)
+   * Generate session type message (- AM/PM)
    */
   static generateSessionTypeMessage() {
     return [
@@ -334,7 +333,7 @@ class AttendanceConversationService {
 
   /**
    * Start a new attendance session
-   * Now includes rate limiting (bd-069), concurrent prevention (bd-067), and session recovery (bd-068)
+   * Now includes rate limiting, concurrent prevention, and session recovery
    *
    * @param {string} userId - User ID
    * @param {Object} options - Optional settings
@@ -344,7 +343,7 @@ class AttendanceConversationService {
    */
   static async startAttendanceSession(userId, options = {}) {
     try {
-      // bd-069: Check rate limit
+      // Check rate limit
       const rateLimitCheck = await this.checkRateLimit(userId);
       if (!rateLimitCheck.allowed) {
         return {
@@ -359,7 +358,7 @@ class AttendanceConversationService {
         };
       }
 
-      // bd-067 & bd-068: Check for existing session (concurrent prevention + recovery)
+      // & Check for existing session (concurrent prevention + recovery)
       if (!options.forceNew) {
         const recoveryResult = await this.handleSessionRecovery(userId);
         if (recoveryResult.hasExisting) {
@@ -498,7 +497,7 @@ class AttendanceConversationService {
   }
 
   /**
-   * Handle date selection response (bd-065)
+   * Handle date selection response
    */
   static async handleDateSelection(userId, input) {
     try {
@@ -564,7 +563,7 @@ class AttendanceConversationService {
   }
 
   /**
-   * Handle session type selection (bd-066 - AM/PM)
+   * Handle session type selection (- AM/PM)
    */
   static async handleSessionTypeSelection(userId, input) {
     try {
@@ -794,7 +793,7 @@ class AttendanceConversationService {
         confidence: 1.0
       }));
 
-      // Update state to processing with timestamp (bd-190)
+      // Update state to processing with timestamp
       await this.saveSessionState(userId, {
         ...sessionState,
         state: STATES.PROCESSING,
@@ -818,7 +817,7 @@ class AttendanceConversationService {
   }
 
   /**
-   * Handle voice input for attendance roll call (bd-062)
+   * Handle voice input for attendance roll call
    * Called when teacher sends a voice message with roll call
    *
    * @param {string} userId - User ID
@@ -976,7 +975,7 @@ class AttendanceConversationService {
 
       // Check for confirmation
       if (['yes', 'confirm', 'correct', 'ok', 'ہاں', 'جی', 'ٹھیک'].some(kw => normalizedResponse.includes(kw))) {
-        // Update state to processing with timestamp (bd-190)
+        // Update state to processing with timestamp
         await this.saveSessionState(userId, {
           ...sessionState,
           state: STATES.PROCESSING,
@@ -1044,7 +1043,7 @@ class AttendanceConversationService {
       return false;
     }
 
-    // Include processing timestamp (bd-190)
+    // Include processing timestamp
     await this.saveSessionState(userId, {
       ...sessionState,
       state: STATES.PROCESSING,

--- a/bot/shared/services/attendance-delivery.service.js
+++ b/bot/shared/services/attendance-delivery.service.js
@@ -3,8 +3,7 @@
  * Orchestrates Excel generation, R2 upload, database save, and WhatsApp delivery
  *
  * Created: January 24, 2026
- * Bead: bd-063
- * Updated: January 25, 2026 (bd-199: Monthly cumulative register)
+ * Updated: January 25, 2026 (Monthly cumulative register)
  *
  * Flow:
  * 1. Save attendance session and records to database FIRST
@@ -28,7 +27,7 @@ const { TEMP_DIR } = require('../utils/constants');
 class AttendanceDeliveryService {
   /**
    * Process and deliver attendance for a completed session
-   * Generates a MONTHLY CUMULATIVE register (bd-199)
+   * Generates a MONTHLY CUMULATIVE register
    *
    * @param {string} userId - User UUID
    * @param {string} phoneNumber - User's WhatsApp phone number
@@ -51,7 +50,7 @@ class AttendanceDeliveryService {
         recordCount: sessionData.records?.length
       });
 
-      // Extract metadata - use sessionDate if provided, otherwise current date (bd-207)
+      // Extract metadata - use sessionDate if provided, otherwise current date
       const sessionDate = sessionData.sessionDate ? new Date(sessionData.sessionDate) : new Date();
       const metadata = {
         userId,
@@ -69,7 +68,7 @@ class AttendanceDeliveryService {
         metadata
       );
 
-      // bd-216: Handle duplicate session gracefully
+      // Handle duplicate session gracefully
       if (dbResult.isDuplicate) {
         logToFile('⚠️ Returning duplicate session info to user', {
           existingSessionId: dbResult.existingSession.id,
@@ -87,7 +86,7 @@ class AttendanceDeliveryService {
         };
       }
 
-      // Step 2: Fetch all attendance data for the month (bd-199)
+      // Step 2: Fetch all attendance data for the month
       const month = sessionDate.getMonth() + 1; // 1-12
       const year = sessionDate.getFullYear();
 
@@ -100,7 +99,7 @@ class AttendanceDeliveryService {
         sessionCount: sessions.length
       });
 
-      // Step 3: Generate MONTHLY register Excel buffer (bd-199)
+      // Step 3: Generate MONTHLY register Excel buffer
       logToFile('Generating monthly register Excel...', { className, month, year });
 
       const excelBuffer = await AttendanceGeneratorService.createMonthlyRegisterBufferFromData(
@@ -196,7 +195,7 @@ class AttendanceDeliveryService {
   }
 
   /**
-   * Get all attendance data for a class in a given month (bd-199)
+   * Get all attendance data for a class in a given month
    *
    * @param {string} listId - Student list ID
    * @param {number} month - Month (1-12)
@@ -274,7 +273,7 @@ class AttendanceDeliveryService {
    * @param {number} month - Month (1-12)
    * @param {number} year - Year
    * @param {Object} todaySummary - Today's attendance summary
-   * @param {Date} sessionDate - The specific date attendance was marked (bd-207)
+   * @param {Date} sessionDate - The specific date attendance was marked
    */
   static generateMonthlyCaptionSimple(className, section, month, year, todaySummary, sessionDate) {
     const monthNames = [
@@ -284,7 +283,7 @@ class AttendanceDeliveryService {
 
     const displayName = section ? `${className} - ${section}` : className;
 
-    // Format the specific date (bd-207)
+    // Format the specific date
     const date = sessionDate || new Date();
     const day = date.getDate();
     const dateDisplay = `${monthNames[date.getMonth()]} ${day}, ${date.getFullYear()}`;
@@ -305,7 +304,7 @@ class AttendanceDeliveryService {
   }
 
   /**
-   * Check if attendance already exists for this class/date/session (bd-216)
+   * Check if attendance already exists for this class/date/session
    */
   static async checkExistingSession(listId, sessionDate, sessionType) {
     try {
@@ -347,12 +346,12 @@ class AttendanceDeliveryService {
       const absentCount = records.filter(r => r.status === 'absent').length;
 
       // Create attendance session
-      // Use metadata.date for session_date (bd-207)
+      // Use metadata.date for session_date
       const sessionDateStr = metadata.date instanceof Date
         ? metadata.date.toISOString().split('T')[0]
         : new Date().toISOString().split('T')[0];
 
-      // bd-216: Check for duplicate session BEFORE insert
+      // Check for duplicate session BEFORE insert
       const existingSession = await this.checkExistingSession(
         listId,
         sessionDateStr,
@@ -407,7 +406,7 @@ class AttendanceDeliveryService {
         .single();
 
       if (sessionError) {
-        // bd-209: Fail loudly instead of silently continuing with empty Excel
+        // Fail loudly instead of silently continuing with empty Excel
         logToFile('❌ Database session insert failed - aborting', {
           error: sessionError.message,
           listId,
@@ -432,7 +431,7 @@ class AttendanceDeliveryService {
       logToFile('📊 Inserting attendance records', {
         sessionId,
         recordCount: recordInserts.length,
-        sampleRecords: recordInserts.slice(0, 3) // Log first 3 for debugging (bd-208)
+        sampleRecords: recordInserts.slice(0, 3) // Log first 3 for debugging
       });
 
       const { data: insertedRecords, error: recordsError } = await supabase
@@ -461,7 +460,7 @@ class AttendanceDeliveryService {
       return { sessionId };
 
     } catch (error) {
-      // bd-209: Re-throw to fail loudly instead of continuing with empty Excel
+      // Re-throw to fail loudly instead of continuing with empty Excel
       logToFile('❌ Database save error - aborting', { error: error.message });
       throw error;
     }

--- a/bot/shared/services/attendance-detector.service.js
+++ b/bot/shared/services/attendance-detector.service.js
@@ -3,7 +3,6 @@
  * Detects attendance-related keywords in user messages
  *
  * Created: January 24, 2026
- * Bead: bd-050
  *
  * Keywords:
  * - High confidence: Direct triggers that should immediately start attendance flow
@@ -48,7 +47,7 @@ const ATTENDANCE_KEYWORDS = {
 };
 
 /**
- * Keywords for adding a new class (bd-205)
+ * Keywords for adding a new class
  * These trigger the setup flow even if user already has classes
  */
 const ADD_CLASS_KEYWORDS = [
@@ -161,7 +160,7 @@ class AttendanceDetectorService {
   }
 
   /**
-   * Detect "add class" intent in a user message (bd-205)
+   * Detect "add class" intent in a user message
    * This triggers the setup flow even if user already has classes
    *
    * @param {string} message - User's message

--- a/bot/shared/services/attendance-generator.service.js
+++ b/bot/shared/services/attendance-generator.service.js
@@ -3,7 +3,6 @@
  * Excel generation for attendance records matching Pakistani register format
  *
  * Created: January 24, 2026
- * Bead: bd-053
  */
 
 const ExcelJS = require('exceljs');
@@ -366,7 +365,7 @@ class AttendanceGeneratorService {
   }
 
   // =========================================================================
-  // MONTHLY CUMULATIVE REGISTER METHODS (bd-199)
+  // MONTHLY CUMULATIVE REGISTER METHODS
   // =========================================================================
 
   /**

--- a/bot/shared/services/audio.service.js
+++ b/bot/shared/services/audio.service.js
@@ -97,7 +97,7 @@ class AudioService {
       });
 
       // Build request body based on model version
-      // Bug #29 Fix: Use specific language hint if provided (reading assessment)
+      // Use specific language hint if provided (reading assessment)
       // Otherwise use all supported languages (coaching multi-language audio)
       // Note: Only include languages Soniox supports (pa, ta are supported; sd, bal, ps are NOT)
       // IMPORTANT: Soniox expects ISO 639-1 codes (e.g., 'pa'), NOT locale codes (e.g., 'pa-PK')

--- a/bot/shared/services/coaching.service.js
+++ b/bot/shared/services/coaching.service.js
@@ -479,7 +479,7 @@ class CoachingService {
 
       logToFile('Analysis metadata', metadata);
 
-      // Resolve pedagogical framework for this user (bd-609)
+      // Resolve pedagogical framework for this user
       const framework = await selectFramework(session.user_id);
       logToFile('Framework resolved', { userId: session.user_id, framework: framework.name });
 
@@ -768,7 +768,7 @@ class CoachingService {
     try {
       logToFile('🔄 Starting report generation', { coachingSessionId });
 
-      // Get complete session data (Bug #10: Include response_language for report generation)
+      // Get complete session data (Include response_language for report generation)
       const { data: session, error: sessionError } = await supabase
         .from('coaching_sessions')
         .select('*, users!inner(phone_number, first_name, last_name, response_language)')
@@ -811,7 +811,7 @@ class CoachingService {
       logToFile('Analysis enhanced and saved', { coachingSessionId, hasDomain4: !!enhancedAnalysis.domain4_professional_responsibilities });
 
       // Generate report using Gamma API (replaces PDFKit and chart generation)
-      // Bug #10: Pass user's response_language for RTL support
+      // Pass user's response_language for RTL support
       const reportLanguage = session.users.response_language || 'en';
       logToFile('Generating report with Gamma API', { coachingSessionId, reportLanguage });
       const { gammaUrl, pdfUrl } = await ContentService.generateClassroomObservationReport({
@@ -823,7 +823,7 @@ class CoachingService {
         analysis: enhancedAnalysis,  // Use enhanced analysis with Q&A
         scores: enhancedAnalysis.scores,
         conversationState: session.conversation_state,  // Include reflective Q&A
-        language: reportLanguage  // Bug #10: Pass language for RTL support
+        language: reportLanguage // Pass language for RTL support
       });
 
       logToFile('Gamma report generated', { coachingSessionId, gammaUrl, pdfUrl });

--- a/bot/shared/services/coaching/analysis-processor.service.js
+++ b/bot/shared/services/coaching/analysis-processor.service.js
@@ -96,7 +96,7 @@ class AnalysisProcessorService {
 
       logToFile('Analysis metadata', metadata);
 
-      // Resolve pedagogical framework for this user (bd-609)
+      // Resolve pedagogical framework for this user
       const framework = await selectFramework(session.user_id);
       logToFile('Framework resolved', { userId: session.user_id, framework: framework.name });
 

--- a/bot/shared/services/coaching/classroom-photo/photo-analysis.service.js
+++ b/bot/shared/services/coaching/classroom-photo/photo-analysis.service.js
@@ -4,7 +4,7 @@
  * Analyzes classroom photos using the existing vision.service.js
  * (GPT-4.1-mini) with framework-specific prompts.
  *
- * Bead: bd-613 (Phase 1C-B)
+ * Bead: (Phase 1C-B)
  */
 
 const { logToFile } = require('../../../utils/logger');

--- a/bot/shared/services/coaching/classroom-photo/photo-prompt.service.js
+++ b/bot/shared/services/coaching/classroom-photo/photo-prompt.service.js
@@ -4,7 +4,7 @@
  * Builds the WhatsApp interactive buttons config for asking
  * the teacher if they want to share a classroom photo.
  *
- * Bead: bd-612 (Phase 1C-B)
+ * Bead: (Phase 1C-B)
  */
 
 /**

--- a/bot/shared/services/coaching/coaching-card/card-image.service.js
+++ b/bot/shared/services/coaching/coaching-card/card-image.service.js
@@ -4,7 +4,7 @@
  * Generates a 600×400 PNG coaching card using the Canvas library
  * (same library used by passage-generation.service.js and annotation.service.js).
  *
- * Bead: bd-616 (Phase 1C-C)
+ * Bead: (Phase 1C-C)
  */
 
 const { createCanvas } = require('canvas');

--- a/bot/shared/services/coaching/coaching-card/card-response.service.js
+++ b/bot/shared/services/coaching/coaching-card/card-response.service.js
@@ -4,7 +4,7 @@
  * Handles teacher button responses to the coaching card.
  * Stores response in coaching_sessions.prioritized_action.
  *
- * Bead: bd-617 (Phase 1C-C)
+ * Bead: (Phase 1C-C)
  */
 
 const supabase = require('../../../config/supabase');

--- a/bot/shared/services/coaching/coaching-card/prioritized-action.service.js
+++ b/bot/shared/services/coaching/coaching-card/prioritized-action.service.js
@@ -4,7 +4,7 @@
  * Generates a single, actionable teaching improvement tip based on
  * the coaching analysis and framework context.
  *
- * Bead: bd-615 (Phase 1C-C)
+ * Bead: (Phase 1C-C)
  */
 
 const { logToFile } = require('../../../utils/logger');

--- a/bot/shared/services/coaching/coaching-flow-helpers.service.js
+++ b/bot/shared/services/coaching/coaching-flow-helpers.service.js
@@ -4,7 +4,7 @@
  * Shared helper functions used by whatsapp-bot.js button handlers
  * to orchestrate the Phase 3 coaching flow transitions.
  *
- * Phase 3: bd-631 (LP selection), bd-630 (photo handlers)
+ * Phase 3: (LP selection), (photo handlers)
  */
 
 const supabase = require('../../config/supabase');

--- a/bot/shared/services/coaching/coaching-session.service.js
+++ b/bot/shared/services/coaching/coaching-session.service.js
@@ -34,7 +34,7 @@ class CoachingSessionService {
         audioDuration
       });
 
-      // Get user details (registration no longer required upfront - BUG-017 fix)
+      // Get user details (registration no longer required upfront - fix)
       // Feature-based registration happens after first feature completion
       const { data: user, error: userError} = await supabase
         .from('users')

--- a/bot/shared/services/coaching/frameworks/fico-framework.js
+++ b/bot/shared/services/coaching/frameworks/fico-framework.js
@@ -8,7 +8,7 @@
  * Scale: 1=Not Observed / 2=Emerging / 3=Effective / 4=Highly Effective
  * Photo-aware indicators: 3.2 (Routines & Transitions), 4.4 (Use of Materials)
  *
- * Bead: bd-595 (Phase 1C-A4)
+ * Bead: (Phase 1C-A4)
  */
 
 // ─── Domain definitions ──────────────────────────────────────────────

--- a/bot/shared/services/coaching/frameworks/framework-registry.js
+++ b/bot/shared/services/coaching/frameworks/framework-registry.js
@@ -4,7 +4,7 @@
  * Single source of truth for all observation framework modules.
  * Lazy-loads framework modules on first access and caches them.
  *
- * Bead: bd-596 (Phase 1C)
+ * Bead: (Phase 1C)
  */
 
 const { logToFile } = require('../../../utils/logger');

--- a/bot/shared/services/coaching/frameworks/framework-selector.js
+++ b/bot/shared/services/coaching/frameworks/framework-selector.js
@@ -9,7 +9,7 @@
  *   2. Region default (Punjab/Sindh → HOTS, others → OECD)
  *   3. Global default → OECD
  *
- * Bead: bd-596 (Phase 1C)
+ * Bead: (Phase 1C)
  */
 
 const supabase = require('../../../config/supabase');

--- a/bot/shared/services/coaching/frameworks/hots-framework.js
+++ b/bot/shared/services/coaching/frameworks/hots-framework.js
@@ -7,7 +7,7 @@
  * 5 Areas, 16 Indicators, Scale 1-3 (Emerging/Developing/Proficient)
  * Max: 48 marks (16 × 3)
  *
- * Bead: bd-593 (Phase 1C-A2)
+ * Bead: (Phase 1C-A2)
  * Fix: NOTION-327d-a9 — aligned to official PESRP/PECTAA spec (Google Sheet from Muqadas Saleem)
  */
 

--- a/bot/shared/services/coaching/frameworks/oecd-framework.js
+++ b/bot/shared/services/coaching/frameworks/oecd-framework.js
@@ -7,7 +7,7 @@
  * 5 Goals, 19 classroom criteria + 4 debrief criteria = 23 total
  * Max: 103 classroom + 14 LP bonus + 15 debrief = 132 max
  *
- * Bead: bd-592 (Phase 1C-A1)
+ * Bead: (Phase 1C-A1)
  */
 
 const {

--- a/bot/shared/services/coaching/frameworks/teach-framework.js
+++ b/bot/shared/services/coaching/frameworks/teach-framework.js
@@ -6,7 +6,7 @@
  * Element scoring: holistic 1-5 (not mathematical average)
  * Max: 50 (9 elements + 1 time_on_task × 5)
  *
- * Bead: bd-594 (Phase 1C-A3)
+ * Bead: (Phase 1C-A3)
  */
 
 // ─── Area definitions ────────────────────────────────────────────────

--- a/bot/shared/services/coaching/lp-coaching/lp-coaching-linker.service.js
+++ b/bot/shared/services/coaching/lp-coaching/lp-coaching-linker.service.js
@@ -5,7 +5,7 @@
  * Links selected LP to coaching session, fetches LP content
  * for analysis, or triggers upload flow.
  *
- * Bead: bd-620 (Phase 1C-D)
+ * Bead: (Phase 1C-D)
  */
 
 const supabase = require('../../../config/supabase');

--- a/bot/shared/services/coaching/lp-coaching/lp-framework-prompt.service.js
+++ b/bot/shared/services/coaching/lp-coaching/lp-framework-prompt.service.js
@@ -5,7 +5,7 @@
  * prompts. When a teacher generates a new lesson plan, the framework
  * they use for coaching informs the LP structure.
  *
- * Bead: bd-621 (Phase 1C-D)
+ * Bead: (Phase 1C-D)
  */
 
 const FRAMEWORK_LP_INSTRUCTIONS = {

--- a/bot/shared/services/coaching/lp-coaching/lp-selection-list.service.js
+++ b/bot/shared/services/coaching/lp-coaching/lp-selection-list.service.js
@@ -5,7 +5,7 @@
  * to link to a coaching session. Falls back to Yes/No buttons
  * when the teacher has no recent LPs.
  *
- * Bead: bd-619 (Phase 1C-D)
+ * Bead: (Phase 1C-D)
  */
 
 const { logToFile } = require('../../../utils/logger');

--- a/bot/shared/services/coaching/report-generator.service.js
+++ b/bot/shared/services/coaching/report-generator.service.js
@@ -44,7 +44,7 @@ class ReportGeneratorService {
    */
   static async generateReport(coachingSessionId, payload = {}) {
     try {
-      // Bug #9: Check for partial report flags
+      // Check for partial report flags
       const isPartialReport = payload.partial || false;
       const isAutoCompleted = payload.autoCompleted || false;
       const isUserRequestedEarly = payload.userRequestedEarly || false;
@@ -179,7 +179,7 @@ class ReportGeneratorService {
         await this.generateAndSendVoiceDebrief(session, from, coachingSessionId, enhancedAnalysis);
       }
 
-      // Phase 3 (bd-634): Coaching Card — prioritized action + image + response buttons
+      // Phase 3: Coaching Card — prioritized action + image + response buttons
       try {
         const { generatePrioritizedAction } = require('./coaching-card/prioritized-action.service');
         const { generateCardImage } = require('./coaching-card/card-image.service');
@@ -255,7 +255,7 @@ class ReportGeneratorService {
 
       logToFile('✅ Report generation complete', { coachingSessionId });
 
-      // bd-551 Trigger 3: Offer quiz to teacher's students after coaching report
+      // Trigger 3: Offer quiz to teacher's students after coaching report
       try {
         const language = session.users?.preferred_language || session.transcript_language || 'en';
         const quizTopic = enhancedAnalysis?.topic;
@@ -527,7 +527,7 @@ class ReportGeneratorService {
   static async generatePDFReport(session, teacherName, enhancedAnalysis) {
     logToFile('Generating PDF report', { coachingSessionId: session.id });
 
-    // Resolve framework and dispatch to correct transformer (bd-611)
+    // Resolve framework and dispatch to correct transformer
     // Prefer framework from enhanced payload, then persisted analysis_data, then OECD fallback.
     const frameworkKey = enhancedAnalysis.framework || session.analysis_data?.framework || 'oecd';
     const transformer = getReportTransformer(frameworkKey);
@@ -546,7 +546,7 @@ class ReportGeneratorService {
       logToFile('⚠️  Error checking prior sessions for report', { error: e.message });
     }
 
-    // bd-723/BUG-053: For HOTS, enhanceAnalysisWithReflections reshapes analysis
+    // /For HOTS, enhanceAnalysisWithReflections reshapes analysis
     // into OECD-style goal keys (goal1_..., goal2_...) which destroys the HOTS
     // "areas" structure. Use the raw analysis_data (which has areas) for the
     // HOTS transformer, merging in subject/topic from enhanced analysis.
@@ -915,7 +915,7 @@ class ReportGeneratorService {
 
     this._applyLessonPlanEvidenceToCriteria(goals, session.lesson_plan_structured, teacherName);
 
-    // Bug #9: Build partial report note if applicable
+    // Build partial report note if applicable
     let partialReportNote = null;
     if (session._isPartialReport) {
       const questionsCompleted = session._questionsAtCompletion || 0;
@@ -952,7 +952,7 @@ class ReportGeneratorService {
       debriefReflection,
       fidelitySection,
       feedback: enhancedAnalysis.executive_summary || enhancedAnalysis.summary || 'Analysis complete.',
-      // Bug #9: Partial report metadata
+      // Partial report metadata
       isPartialReport: session._isPartialReport || false,
       partialReportNote
     };
@@ -1342,7 +1342,7 @@ class ReportGeneratorService {
   }
 
   /**
-   * bd-551 Trigger 3: Offer quiz after coaching report PDF is sent.
+   * Trigger 3: Offer quiz after coaching report PDF is sent.
    * Sends interactive buttons if teacher has a class with student phone numbers.
    * Called from generateReport after PDF delivery.
    *

--- a/bot/shared/services/coaching/report-transformers/_shared.js
+++ b/bot/shared/services/coaching/report-transformers/_shared.js
@@ -1,7 +1,7 @@
 /**
  * Shared utilities for report data transformers.
  *
- * Bead: bd-604 (Phase 1C-A2)
+ * Bead: (Phase 1C-A2)
  */
 
 const { logToFile } = require('../../../utils/logger');

--- a/bot/shared/services/coaching/report-transformers/fico-report-transformer.js
+++ b/bot/shared/services/coaching/report-transformers/fico-report-transformer.js
@@ -8,7 +8,7 @@
  * Photo-aware indicators (3.2 Routines & Transitions, 4.4 Use of Materials)
  * include photo evidence in the evidence text when available.
  *
- * Bead: bd-607 (Phase 1C-A2)
+ * Bead: (Phase 1C-A2)
  */
 
 const { formatDate, extractFidelity, buildPartialNote } = require('./_shared');

--- a/bot/shared/services/coaching/report-transformers/hots-report-transformer.js
+++ b/bot/shared/services/coaching/report-transformers/hots-report-transformer.js
@@ -6,7 +6,7 @@
  *
  * 5 areas → 5 goals, indicators → criteria, scale 1-3, no debrief, no LP bonus.
  *
- * Bead: bd-605 (Phase 1C-A2)
+ * Bead: (Phase 1C-A2)
  */
 
 const { formatDate, extractFidelity, buildPartialNote } = require('./_shared');

--- a/bot/shared/services/coaching/report-transformers/mewaka-report-transformer.js
+++ b/bot/shared/services/coaching/report-transformers/mewaka-report-transformer.js
@@ -9,7 +9,7 @@
  * 1. focusArea — the ONE focus indicator + try-this + lever question.
  * Operator-locked 2026-05-20 as the lead element of every coaching report.
  * 2. strengths — 3 entries surfaced at the TOP LEVEL, not buried in goal
- * criteria. Fix for the PROJ-025 finding that the analyser emits these
+ * criteria. Fix for the finding that the analyser emits these
  * and the transformer was dropping them before they hit the PDF.
  * 3. growthOpportunities — 2 entries, also previously dropped.
  *

--- a/bot/shared/services/coaching/report-transformers/oecd-report-transformer.js
+++ b/bot/shared/services/coaching/report-transformers/oecd-report-transformer.js
@@ -5,7 +5,7 @@
  * Transforms OECD framework analysis into the generic reportData shape
  * consumed by pdf-report.service.js.
  *
- * Bead: bd-604 (Phase 1C-A2)
+ * Bead: (Phase 1C-A2)
  */
 
 const { logToFile } = require('../../../utils/logger');
@@ -327,7 +327,7 @@ function transformOECDToReportData(session, teacherName, enhancedAnalysis, hasPr
   // LP evidence injection (OECD-specific)
   _applyLessonPlanEvidenceToCriteria(goals, session.lesson_plan_structured, teacherName);
 
-  // Bug #9: Build partial report note if applicable
+  // Build partial report note if applicable
   let partialReportNote = null;
   if (session._isPartialReport) {
     const questionsCompleted = session._questionsAtCompletion || 0;

--- a/bot/shared/services/coaching/report-transformers/report-transformer-dispatch.js
+++ b/bot/shared/services/coaching/report-transformers/report-transformer-dispatch.js
@@ -4,7 +4,7 @@
  * Routes framework key → appropriate report data transformer function.
  * Unknown frameworks fall back to OECD.
  *
- * Bead: bd-604 (Phase 1C-A2)
+ * Bead: (Phase 1C-A2)
  */
 
 const { logToFile } = require('../../../utils/logger');

--- a/bot/shared/services/coaching/report-transformers/teach-report-transformer.js
+++ b/bot/shared/services/coaching/report-transformers/teach-report-transformer.js
@@ -7,7 +7,7 @@
  * 3 areas + Time on Task → 4 goals, elements → criteria, holistic 1-5,
  * behavior L/M/H ratings in evidence text. No debrief, no LP bonus.
  *
- * Bead: bd-606 (Phase 1C-A2)
+ * Bead: (Phase 1C-A2)
  */
 
 const { formatDate, extractFidelity, buildPartialNote } = require('./_shared');

--- a/bot/shared/services/coaching/transcription-processor.service.js
+++ b/bot/shared/services/coaching/transcription-processor.service.js
@@ -199,7 +199,7 @@ class TranscriptionProcessorService {
       );
       await WhatsAppService.sendMessage(from, encouragingMessage);
 
-      // Phase 3 (bd-636): Agency follow-up — remind teacher of prior commitment
+      // Phase 3: Agency follow-up — remind teacher of prior commitment
       try {
         const { data: priorSessions } = await supabase
           .from('coaching_sessions')
@@ -219,7 +219,7 @@ class TranscriptionProcessorService {
         logToFile('⚠️ Agency follow-up check failed (non-critical)', { error: agencyError.message });
       }
 
-      // Phase 3 (bd-629): Ask about classroom photo FIRST, before LP question
+      // Phase 3: Ask about classroom photo FIRST, before LP question
       const { buildPhotoPrompt } = require('./classroom-photo/photo-prompt.service');
       const userLanguage = await getUserLanguage(session.user_id) || 'en';
       const photoPrompt = buildPhotoPrompt(coachingSessionId, userLanguage);

--- a/bot/shared/services/content.service.js
+++ b/bot/shared/services/content.service.js
@@ -10,7 +10,7 @@ const { getLanguageConfig } = require('../config/gamma-languages.config');
 class ContentService {
   /**
    * Generate content using Gamma API (presentations and lesson plans)
-   * Bug #10: Added language parameter for RTL support
+   * Added language parameter for RTL support
    * @param {string} topic - Content topic
    * @param {string} fullUserMessage - Full user message for context
    * @param {string} format - 'presentation' or 'document'
@@ -21,12 +21,12 @@ class ContentService {
    */
   static async _generateGammaContent(topic, fullUserMessage, format, contentType, language = 'en') {
     try {
-      // Bug #10: Get language configuration for RTL support
+      // Get language configuration for RTL support
       const langConfig = getLanguageConfig(language);
       logToFile(`Generating ${contentType} with Gamma API`, { topic, format, language: langConfig.code });
 
       // Use the full user message to preserve all details
-      // Bug #10: Use language-specific intro and prompt suffix
+      // Use language-specific intro and prompt suffix
       const inputText = format === 'presentation'
         ? `${langConfig.presentationIntro} based on this request: "${fullUserMessage}"
 
@@ -121,7 +121,7 @@ Make this practical, detailed, and immediately usable by teachers with varying e
           ? undefined
           : 'Maintain the exact structure and formatting provided in the prompt. Include all 9 sections with clear headings. Preserve all bullet points, time allocations, and instructional details. Do not summarize or condense the content.',
         textOptions: {
-          language: langConfig.code,  // Bug #10: Use detected language instead of hardcoded 'en'
+          language: langConfig.code, // Use detected language instead of hardcoded 'en'
           audience: format === 'presentation' ? 'teachers and students' : 'teachers',
           tone: 'educational and engaging',
           amount: format === 'presentation' ? undefined : 'extensive' // Keep all details for lesson plans
@@ -198,7 +198,7 @@ Make this practical, detailed, and immediately usable by teachers with varying e
 
   /**
    * Generate a lesson plan using Gamma API
-   * Bug #10: Added language parameter for RTL support
+   * Added language parameter for RTL support
    * @param {string} topic - Lesson topic
    * @param {string} fullUserMessage - Full user message for context
    * @param {string} language - Language code ('en', 'ur', 'ar', 'es') - defaults to 'en'
@@ -219,7 +219,7 @@ Make this practical, detailed, and immediately usable by teachers with varying e
 
   /**
    * Generate a presentation using Gamma API
-   * Bug #10: Added language parameter for RTL support
+   * Added language parameter for RTL support
    * @param {string} topic - Presentation topic
    * @param {string} fullUserMessage - Full user message for context
    * @param {string} language - Language code ('en', 'ur', 'ar', 'es') - defaults to 'en'

--- a/bot/shared/services/exam-checker/annotation.service.js
+++ b/bot/shared/services/exam-checker/annotation.service.js
@@ -3,10 +3,10 @@
  * Generates annotated exam images with grades and feedback
  *
  * REWRITTEN: 2026-01-25
- * Original Bead: bd-085
- * Fix Beads: bd-165 (larger marks), bd-167 (Caveat font), bd-168 (margin feedback),
- *            bd-169 (score circle), bd-170 (tick/cross), bd-174 (Canvas migration),
- *            bd-175 (Noto Nastaliq for Urdu)
+ * Original Bead:
+ * Fix Beads: (larger marks), (Caveat font), (margin feedback),
+ * (score circle), (tick/cross), (Canvas migration),
+ * (Noto Nastaliq for Urdu)
  *
  * CHANGES FROM ORIGINAL:
  * - Migrated from Sharp+SVG to Canvas+registerFont
@@ -166,7 +166,7 @@ class AnnotationService {
     const { width, height } = image;
     const { studentName, grade, percentage, questionResults, isFirstPage, language, totalMarks, marksAwarded } = annotations;
 
-    // Draw score circle on first page (top-right corner) - bd-169
+    // Draw score circle on first page (top-right corner) -
     if (isFirstPage) {
       this._drawScoreCircle(ctx, marksAwarded || 0, totalMarks || 0, width - 90, 90);
 
@@ -178,7 +178,7 @@ class AnnotationService {
       }
     }
 
-    // Draw question marks and feedback - bd-165, bd-170
+    // Draw question marks and feedback -
     for (let i = 0; i < (questionResults || []).length; i++) {
       const qr = questionResults[i];
       const { marksAwarded: qMarks, maxMarks, feedback, bbox } = qr;
@@ -212,7 +212,7 @@ class AnnotationService {
       ctx.textAlign = 'left';
       ctx.fillText(`${qMarks}/${maxMarks}`, x - 70, y + 50);
 
-      // Draw margin feedback - bd-168
+      // Draw margin feedback -
       if (feedback) {
         this._drawMarginFeedback(ctx, feedback, x - 200, y + 20, language);
       }
@@ -235,7 +235,7 @@ class AnnotationService {
   }
 
   /**
-   * Draw a hand-drawn style tick mark (bd-170)
+   * Draw a hand-drawn style tick mark
    */
   static _drawTick(ctx, x, y, size = 50) {
     ctx.strokeStyle = COLORS.correct;
@@ -250,7 +250,7 @@ class AnnotationService {
   }
 
   /**
-   * Draw a hand-drawn style cross mark (bd-170)
+   * Draw a hand-drawn style cross mark
    */
   static _drawCross(ctx, x, y, size = 40) {
     ctx.strokeStyle = COLORS.incorrect;
@@ -267,7 +267,7 @@ class AnnotationService {
   }
 
   /**
-   * Draw a partial credit wavy mark (bd-170)
+   * Draw a partial credit wavy mark
    */
   static _drawPartialMark(ctx, x, y, size = 50) {
     ctx.strokeStyle = COLORS.partial;
@@ -281,7 +281,7 @@ class AnnotationService {
   }
 
   /**
-   * Draw hand-drawn score circle (bd-169)
+   * Draw hand-drawn score circle
    */
   static _drawScoreCircle(ctx, score, max, x, y, radius = 65) {
     // Draw circle
@@ -309,7 +309,7 @@ class AnnotationService {
   }
 
   /**
-   * Draw margin feedback text (bd-168)
+   * Draw margin feedback text
    */
   static _drawMarginFeedback(ctx, feedback, x, y, language = 'en') {
     if (!feedback) return;
@@ -366,7 +366,7 @@ class AnnotationService {
   }
 
   /**
-   * Generate a summary PDF with all grades (bd-171)
+   * Generate a summary PDF with all grades
    * @param {object} session - Exam session
    * @param {Array} gradingResults - All grading results
    * @returns {string} PDF URL

--- a/bot/shared/services/exam-checker/delivery.service.js
+++ b/bot/shared/services/exam-checker/delivery.service.js
@@ -3,7 +3,7 @@
  * Sends graded results to users via WhatsApp
  *
  * Created: 2026-01-24
- * Bead: bd-085 (annotation dependency)
+ * Bead: (annotation dependency)
  */
 
 const whatsappService = require('../whatsapp.service');

--- a/bot/shared/services/exam-checker/exam-checker.orchestrator.js
+++ b/bot/shared/services/exam-checker/exam-checker.orchestrator.js
@@ -8,7 +8,6 @@
  * - Each method is <20 lines (mostly delegation)
  *
  * Created: 2026-01-24
- * Bead: bd-081
  */
 
 const { runWithCorrelation, getCurrentCorrelationId } = require('../../utils/structured-logger');

--- a/bot/shared/services/exam-checker/exam-session.service.js
+++ b/bot/shared/services/exam-checker/exam-session.service.js
@@ -3,7 +3,7 @@
  * Manages exam checking sessions in Supabase + Redis
  *
  * Created: 2026-01-24
- * Bead: bd-081 (orchestrator dependency)
+ * Bead: (orchestrator dependency)
  */
 
 const supabase = require('../../config/supabase');

--- a/bot/shared/services/exam-checker/feedback.service.js
+++ b/bot/shared/services/exam-checker/feedback.service.js
@@ -3,7 +3,6 @@
  * Generates structured pedagogical feedback using Hattie's Feed Up/Back/Forward framework
  *
  * Created: 2026-01-25
- * Bead: bd-176
  *
  * Framework:
  * - Feed Up: What was the learning goal?

--- a/bot/shared/services/exam-checker/grading-scale.service.js
+++ b/bot/shared/services/exam-checker/grading-scale.service.js
@@ -3,7 +3,6 @@
  * Board-specific grade conversion (FBISE, Cambridge, Punjab Matric)
  *
  * Created: 2026-01-25
- * Bead: bd-177
  *
  * Supports:
  * - FBISE (Federal Board of Intermediate and Secondary Education)

--- a/bot/shared/services/exam-checker/grading.service.js
+++ b/bot/shared/services/exam-checker/grading.service.js
@@ -1,11 +1,10 @@
 /**
  * Grading Service for Exam Checker
  * Uses GPT-4o to grade student answers against marking scheme
- * Enhanced with board-specific scales (bd-177) and structured feedback (bd-176)
+ * Enhanced with board-specific scales and structured feedback
  *
  * Created: 2026-01-24
  * Updated: 2026-01-25 (Board scales + Feed Up/Back/Forward)
- * Beads: bd-084, bd-176, bd-177
  */
 
 const { getClient } = require('../llm-client');
@@ -134,7 +133,7 @@ class GradingService {
 
       const result = await this.gradeQuestion(question, studentAnswer);
 
-      // Generate structured feedback for this question (bd-176)
+      // Generate structured feedback for this question
       const feedback = FeedbackService.generate({
         question: question.text || question.id,
         learningObjective: question.learningObjective,
@@ -157,7 +156,7 @@ class GradingService {
 
     const percentage = totalMarks > 0 ? Math.round((marksAwarded / totalMarks) * 100) : 0;
 
-    // Get board-specific grade (bd-177)
+    // Get board-specific grade
     const gradeReport = GradingScaleService.getFullReport(percentage, board);
 
     // Generate overall structured feedback
@@ -327,7 +326,7 @@ Maximum Marks: ${question.marks || 1}`
 
   /**
    * Calculate letter grade from marks
-   * Now uses GradingScaleService for board-specific grades (bd-177)
+   * Now uses GradingScaleService for board-specific grades
    * @param {number} marks - Marks awarded
    * @param {number} total - Total marks
    * @param {string} board - Board name (optional)

--- a/bot/shared/services/exam-checker/index.js
+++ b/bot/shared/services/exam-checker/index.js
@@ -3,7 +3,6 @@
  *
  * Created: 2026-01-24
  * Updated: 2026-01-25 (Added Surya, GradingScale, Feedback services)
- * Beads: bd-081, bd-166, bd-173, bd-176, bd-177
  */
 
 const { ExamCheckerOrchestrator, SESSION_STATES } = require('./exam-checker.orchestrator');

--- a/bot/shared/services/exam-checker/ocr.service.js
+++ b/bot/shared/services/exam-checker/ocr.service.js
@@ -1,11 +1,11 @@
 /**
  * OCR Service for Exam Checker
  * Extracts text from exam images using Mistral (primary) → Chandra (fallback)
- * Enhanced with Surya bounding boxes for annotation positioning (bd-173)
+ * Enhanced with Surya bounding boxes for annotation positioning
  *
  * Created: 2026-01-24
  * Updated: 2026-01-25 (Surya integration)
- * Beads: bd-083 (OCR), bd-173 (Surya integration)
+ * Beads: (OCR), (Surya integration)
  */
 
 const axios = require('axios');
@@ -102,7 +102,7 @@ class OCRService {
 
   /**
    * Extract text from a single image
-   * Enhanced with Surya bounding boxes for annotation positioning (bd-173)
+   * Enhanced with Surya bounding boxes for annotation positioning
    * @param {string} imageUrl - URL of the image
    * @param {boolean} includeBoundingBoxes - Whether to fetch Surya bounding boxes
    * @returns {object} OCR result with optional bounding boxes

--- a/bot/shared/services/exam-checker/question-detector.service.js
+++ b/bot/shared/services/exam-checker/question-detector.service.js
@@ -3,7 +3,7 @@
  * Analyzes OCR results to detect students and question types
  *
  * Created: 2026-01-24
- * Bead: bd-083 (OCR dependency)
+ * Bead: (OCR dependency)
  */
 
 const { logToFile } = require('../../utils/logger');

--- a/bot/shared/services/exam-checker/surya.service.js
+++ b/bot/shared/services/exam-checker/surya.service.js
@@ -3,7 +3,7 @@
  * Detects text line positions using Datalab's Surya API
  *
  * Created: 2026-01-25
- * Beads: bd-166 (position detection), bd-173 (OCR integration)
+ * Beads: (position detection), (OCR integration)
  *
  * API: https://api.datalab.to/v1/detection
  * Docs: https://github.com/datalab-to/surya

--- a/bot/shared/services/flow-encryption.service.js
+++ b/bot/shared/services/flow-encryption.service.js
@@ -11,7 +11,6 @@
  * 5. Encrypt response using flipped IV + AES key
  * 6. Return Base64 encoded response
  *
- * Bead: bd-186
  * Created: January 25, 2026
  *
  * References:

--- a/bot/shared/services/menu.service.js
+++ b/bot/shared/services/menu.service.js
@@ -104,7 +104,7 @@ class MenuService {
           break;
 
         case 'menu_reading':
-          // BUG-008/009 FIX: Use WhatsApp Flow (same as /reading test command)
+          // /009 FIX: Use WhatsApp Flow (same as /reading test command)
           // Old ReadingAssessmentService.initiateAssessment() didn't ask for student name
           // WhatsApp Flow collects all info in proper multi-screen form
           const FeatureIntroService = require('./feature-intro.service');

--- a/bot/shared/services/name-extractor.service.js
+++ b/bot/shared/services/name-extractor.service.js
@@ -3,7 +3,6 @@
  * GPT-4o-mini powered extraction of student names and attendance status from transcripts
  *
  * Created: January 24, 2026
- * Bead: bd-052
  */
 
 const { logToFile } = require('../utils/logger');

--- a/bot/shared/services/openai.service.js
+++ b/bot/shared/services/openai.service.js
@@ -619,7 +619,7 @@ Keep your responses relatively short as they will be sent via WhatsApp messages.
       ];
 
       // Get response from OpenAI
-      // Bug #11: Reduce max_tokens for voice to enforce 60-second limit
+      // Reduce max_tokens for voice to enforce 60-second limit
       // RTL languages (Arabic script) use more tokens per word, so allow 400 tokens
       const RTL_LANGUAGES = ['ur', 'ar', 'bal-PK', 'sd-PK', 'ps-PK', 'pa-PK'];
       const isRTL = RTL_LANGUAGES.includes(language);

--- a/bot/shared/services/pdf-report.service.js
+++ b/bot/shared/services/pdf-report.service.js
@@ -88,7 +88,7 @@ class PDFReportService {
       yPos = this._drawHeader(doc, reportData, percentage, performance, yPos);
       yPos = this._drawTeacherInfo(doc, reportData, yPos);
 
-      // Bug #9: Partial report note (if applicable)
+      // Partial report note (if applicable)
       if (reportData.isPartialReport && reportData.partialReportNote) {
         yPos = this._drawPartialReportNote(doc, reportData.partialReportNote, yPos);
       }
@@ -368,7 +368,7 @@ class PDFReportService {
   }
 
   /**
-   * Bug #9: Draw partial report note banner
+   * Draw partial report note banner
    * @param {PDFDocument} doc - PDF document
    * @param {string} noteText - Partial report note text
    * @param {number} yPos - Current Y position

--- a/bot/shared/services/reading-assessment.service.js
+++ b/bot/shared/services/reading-assessment.service.js
@@ -392,8 +392,8 @@ If this is a concurrent session (student number > 1), mention this is for "${stu
       const studentIdentifier = state.studentIdentifier;
 
       // Map grade level to passage type
-      // Bug #21 Fix: Changed words from 30 to 14 for 2-column layout
-      // Bug #24 Fix: Changed letters from 20 to 14 for 3x4+2 grid layout
+      // Changed words from 30 to 14 for 2-column layout
+      // Changed letters from 20 to 14 for 3x4+2 grid layout
       const gradeMap = {
         0: { type: 'letters', wordCount: 14, grade: 0 },
         1: { type: 'words', wordCount: 14, grade: 1 },
@@ -522,7 +522,7 @@ If this is a concurrent session (student number > 1), mention this is for "${stu
     try {
       logToFile('🎤 Audio received for reading assessment', { userId });
 
-      // FIX 3 (Bug #34): Find active assessment with row-level locking
+      // FIX 3: Find active assessment with row-level locking
       // First, get the assessment ID without locking (only assessments from last 30 minutes)
       const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000).toISOString();
 

--- a/bot/shared/services/reading/analysis.service.js
+++ b/bot/shared/services/reading/analysis.service.js
@@ -112,7 +112,7 @@ class AnalysisService {
           word_timestamps: transcriptionResult.wordTimestamps,
           num_speakers_detected: transcriptionResult.numSpeakers,
           detected_language: transcriptionResult.language,
-          audio_duration_seconds: transcriptionResult.audioDurationSeconds, // Bug #29 fix: Store calculated duration
+          audio_duration_seconds: transcriptionResult.audioDurationSeconds, // Store calculated duration
           last_successful_step: 'transcription'
         })
         .eq('id', assessmentId);
@@ -162,8 +162,8 @@ class AnalysisService {
           words_read: fluencyMetrics.wordsRead,
           words_correct: fluencyMetrics.wordsCorrect,
           wcpm: fluencyMetrics.wcpm,
-          accuracy_percentage: fluencyMetrics.wordAccuracy, // Bug #15 fix: word alignment accuracy
-          pronunciation_accuracy: fluencyMetrics.pronunciationAccuracy, // Bug #15 fix: Azure pronunciation accuracy
+          accuracy_percentage: fluencyMetrics.wordAccuracy, // word alignment accuracy
+          pronunciation_accuracy: fluencyMetrics.pronunciationAccuracy, // Azure pronunciation accuracy
           time_elapsed_seconds: fluencyMetrics.timeElapsed,
           errors: fluencyMetrics.errors,
           self_corrections_count: fluencyMetrics.selfCorrectionsCount, // Fixed: use count (integer), not array
@@ -204,7 +204,7 @@ class AnalysisService {
       });
 
       // STEP 4: Compare to benchmarks
-      // Bug #3e Fix: Pass passage_type to use correct benchmark function (LCPM for letters, WCPM for others)
+      // e Fix: Pass passage_type to use correct benchmark function (LCPM for letters, WCPM for others)
       logToFile('Step 4/7: Comparing to grade-level benchmarks...');
       const benchmarkResult = await this.compareToBenchmarks(
         fluencyMetrics.wcpm,
@@ -278,7 +278,7 @@ class AnalysisService {
 
       // Sprint 1.8: Check if comprehension testing is requested
       // CRITICAL FIX: Check BEFORE generating report to avoid duplicate reports
-      // Bug #3 Fix: Block comprehension for 'letters' type (pedagogically invalid - random letters have no meaning)
+      // Block comprehension for 'letters' type (pedagogically invalid - random letters have no meaning)
       const comprehensionAllowed = assessment.comprehension_requested && assessment.passage_type !== 'letters';
 
       if (assessment.comprehension_requested && assessment.passage_type === 'letters') {
@@ -403,7 +403,7 @@ class AnalysisService {
       try {
         const voiceFeedbackUrl = await this.generateVoiceFeedback(assessment, userLanguage);
 
-        // Bug #1 Fix: Add defensive logging to understand voice feedback delivery failures
+        // Add defensive logging to understand voice feedback delivery failures
         logToFile('🔍 Voice feedback generation result', {
           assessmentId: assessment.id,
           voiceFeedbackUrl: voiceFeedbackUrl || 'NULL/UNDEFINED',
@@ -430,7 +430,7 @@ class AnalysisService {
           await WhatsAppService.sendAudioFromUrl(phoneNumber, voiceFeedbackUrl);
           logToFile('✅ Voice feedback sent to teacher', { assessmentId: assessment.id });
         } else {
-          // Bug #1 Fix: Log when voiceFeedbackUrl is null/falsy
+          // Log when voiceFeedbackUrl is null/falsy
           logToFile('⚠️ Voice feedback URL is null/falsy - skipping delivery', {
             assessmentId: assessment.id,
             voiceFeedbackUrl
@@ -516,7 +516,7 @@ class AnalysisService {
         speakerStats: transcriptionResult.speakerStats,
         languageMismatch: transcriptionResult.languageMismatch,
         fullText: transcriptionResult.fullText,
-        audioDurationSeconds: transcriptionResult.audioDurationSeconds // Bug #29 fix
+        audioDurationSeconds: transcriptionResult.audioDurationSeconds // fix
       };
 
     } catch (error) {
@@ -624,7 +624,7 @@ class AnalysisService {
   static async compareToBenchmarks(wcpm, gradeLevel, language, isSecondLanguage, passageType = 'sentences') {
     let data, error;
 
-    // Bug #3e Fix: Use LCPM benchmarks for letters, WCPM benchmarks for everything else
+    // e Fix: Use LCPM benchmarks for letters, WCPM benchmarks for everything else
     if (passageType === 'letters') {
       // Letters use LCPM (Letters Correct Per Minute) benchmarks
       const result = await supabase.rpc('check_lcpm_benchmark_status', {
@@ -758,7 +758,7 @@ Generate a 3-4 sentence summary that:
         diagnosticSummary: assessment.diagnostic_summary || 'Analysis in progress...'
       };
 
-      // BUG #34 FIX: Add comprehension data if available
+      // Add comprehension data if available
       if (assessment.comprehension_answers && assessment.comprehension_score !== null) {
         const answers = assessment.comprehension_answers;
         const correctAnswers = answers.filter(a => a.correct).length;
@@ -912,7 +912,7 @@ Output the complete enhanced summary (not just the new parts).`;
 
       const BUCKET_NAME = process.env.R2_BUCKET_NAME;
 
-      // BUG #33 FIX: Use format "Reading Assessment_Student Name_DDMMYYYY.pdf"
+      // Use format "Reading Assessment_Student Name_DDMMYYYY.pdf"
       const date = new Date();
       const day = String(date.getDate()).padStart(2, '0');
       const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -989,7 +989,7 @@ Output the complete enhanced summary (not just the new parts).`;
 
       const teacherName = teacher.first_name || 'Teacher';
 
-      // BUG #1 FIX: Use assessment's language field for voice feedback
+      // Use assessment's language field for voice feedback
       // assessment.language is the actual language of the passage (e.g., 'ur' for Urdu)
       // userLanguage is the user's preferred language (could be 'en' even for Urdu tests)
       const feedbackLanguage = freshAssessment.language || userLanguage;
@@ -1000,7 +1000,7 @@ Output the complete enhanced summary (not just the new parts).`;
         assessmentLanguage: freshAssessment.language,
         userPreferredLanguage: userLanguage,
         feedbackLanguage: feedbackLanguage,
-        bugFix: 'Bug #1 - Using assessment language instead of user preference'
+        bugFix: '- Using assessment language instead of user preference'
       });
 
       // Generate voice feedback audio using assessment language
@@ -1046,7 +1046,7 @@ Output the complete enhanced summary (not just the new parts).`;
    */
   static async sendResults(assessment, reportUrl, phoneNumber, userLanguage) {
     try {
-      // Bug #2 Fix: Fetch teacher's name to address them properly (prevents [Recipient's Name] placeholder)
+      // Fetch teacher's name to address them properly (prevents [Recipient's Name] placeholder)
       const { data: teacher } = await supabase
         .from('users')
         .select('first_name')
@@ -1056,7 +1056,7 @@ Output the complete enhanced summary (not just the new parts).`;
       const teacherName = teacher?.first_name || 'Teacher';
 
       // Send completion message
-      // Bug #2 Fix: Include teacher name in prompt so GPT addresses them properly
+      // Include teacher name in prompt so GPT addresses them properly
       const completionPrompt = `Generate a brief message in language code "${userLanguage}" addressing ${teacherName} and saying:
 1. The reading assessment for ${assessment.student_identifier} is complete
 2. Results show WCPM: ${assessment.wcpm}, Accuracy: ${assessment.accuracy_percentage}%
@@ -1119,15 +1119,15 @@ Output the complete enhanced summary (not just the new parts).`;
       // Import ComprehensionService
       const ComprehensionService = require('./comprehension.service');
 
-      // Bug #7: Generate questions based on passage type
+      // Generate questions based on passage type
       const questionData = await ComprehensionService.generateQuestions(
         assessment.passage_text,
         assessment.language,
         assessment.grade_level,
-        assessment.passage_type || 'sentences'  // Bug #7: Pass passage type for dispatch
+        assessment.passage_type || 'sentences' // Pass passage type for dispatch
       );
 
-      // Bug #7: Handle null return (letters passages have no comprehension)
+      // Handle null return (letters passages have no comprehension)
       if (!questionData) {
         logToFile('⏭️ No comprehension for this passage type', {
           assessmentId: assessment.id,
@@ -1176,7 +1176,7 @@ Output the complete enhanced summary (not just the new parts).`;
       const introMessage = introResponse.choices[0].message.content.trim();
       await WhatsAppService.sendMessage(phoneNumber, introMessage);
 
-      // BUG #38 FIX: Set comprehension status BEFORE sending first question
+      // Set comprehension status BEFORE sending first question
       // Race condition: User could respond with voice before status was set, causing
       // findActiveFlowByUser() to return null and routing answer to general conversation
       // Confirmed case: Waqas (923005233742) had 3 failed assessments on Jan 20, 2026
@@ -1187,7 +1187,7 @@ Output the complete enhanced summary (not just the new parts).`;
         assessment.user_id
       );
 
-      logToFile('Comprehension flow started in DATABASE (Bug #38 fix - status set before question)', {
+      logToFile('Comprehension flow started in DATABASE (fix - status set before question)', {
         assessmentId: assessment.id,
         questionCount: questions.length
       });
@@ -1201,7 +1201,7 @@ Output the complete enhanced summary (not just the new parts).`;
         questions.length
       );
 
-      logToFile('First comprehension question sent (Bug #38 fix - safe for immediate response)', {
+      logToFile('First comprehension question sent (fix - safe for immediate response)', {
         assessmentId: assessment.id,
         questionType: firstQuestion.type
       });
@@ -1217,7 +1217,7 @@ Output the complete enhanced summary (not just the new parts).`;
   }
 
   /**
-   * Bug #7: Send comprehension question with appropriate format
+   * Send comprehension question with appropriate format
    * Handles both text-only questions and image+button questions (word-level)
    * @param {string} phoneNumber - WhatsApp phone number
    * @param {object} question - Question object with type, question text, optional imageUrl/buttons
@@ -1326,11 +1326,11 @@ Output the complete enhanced summary (not just the new parts).`;
         benchmark: {
           benchmarkMin: assessment.grade_benchmark_min,
           benchmarkMax: assessment.grade_benchmark_max,
-          onTrack: assessment.on_track,  // Bug #21 Fix: Use correct column name
+          onTrack: assessment.on_track, // Use correct column name
           percentileRank: assessment.percentile_rank
         },
         errors: assessment.error_breakdown || assessment.errors || [],
-        // Bug #23 Fix: Use pronunciation_data (which exists) instead of pronunciation_score (which doesn't exist)
+        // Use pronunciation_data (which exists) instead of pronunciation_score (which doesn't exist)
         pronunciation: assessment.pronunciation_data ? {
           pronunciationData: assessment.pronunciation_data,
           // Include words array for mispronunciation extraction
@@ -1426,7 +1426,7 @@ Output the complete enhanced summary (not just the new parts).`;
       const reportBuffer = await ReportService.generateReadingAssessmentReport(reportData);
 
       // Upload to R2
-      // BUG #33 FIX: Use format "Reading Assessment_Student Name_DDMMYYYY.pdf"
+      // Use format "Reading Assessment_Student Name_DDMMYYYY.pdf"
       const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
 
       const r2Client = new S3Client({
@@ -1485,7 +1485,7 @@ Output the complete enhanced summary (not just the new parts).`;
       try {
         const voiceFeedbackUrl = await this.generateVoiceFeedback(assessment, userLanguage);
 
-        // Bug #1 Fix: Add defensive logging for comprehension flow voice feedback
+        // Add defensive logging for comprehension flow voice feedback
         logToFile('🔍 Combined voice feedback generation result', {
           assessmentId,
           voiceFeedbackUrl: voiceFeedbackUrl || 'NULL/UNDEFINED',

--- a/bot/shared/services/reading/comprehension.service.js
+++ b/bot/shared/services/reading/comprehension.service.js
@@ -8,7 +8,7 @@
  * - EGRA-based benchmarking (3/5 = adequate comprehension)
  * - Teacher guidance generation
  *
- * Bug #7: Word-Level Comprehension Redesign
+ * Word-Level Comprehension Redesign
  * - Letters: No comprehension (blocked)
  * - Words: 3-question vocabulary assessment (semantic, receptive with images, productive)
  * - Sentences/Paragraphs: 5-question standard comprehension
@@ -25,7 +25,7 @@ const openai = getClient();
 class ComprehensionService {
   /**
    * Generate comprehension questions for a passage
-   * Bug #7: Passage-type-specific question generation
+   * Passage-type-specific question generation
    * @param {string} passageText - The passage students read
    * @param {string} language - 'en' or 'ur'
    * @param {number} gradeLevel - Grade level (0-5)
@@ -41,7 +41,7 @@ class ComprehensionService {
         passageLength: passageText.length
       });
 
-      // Bug #7: Dispatch based on passage type
+      // Dispatch based on passage type
       // Letters: No comprehension (no semantic content)
       if (passageType === 'letters') {
         logToFile('⏭️ Skipping comprehension for letters passage (no semantic content)');
@@ -134,7 +134,7 @@ ${passageText}
       const prompt = prompts[language] || prompts.en;
 
       const response = await openai.chat.completions.create({
-        model: 'gpt-4o', // Bug #31 Fix: gpt-4 deprecated, use gpt-4o for JSON mode support
+        model: 'gpt-4o', // gpt-4 deprecated, use gpt-4o for JSON mode support
         messages: [{ role: 'user', content: prompt }],
         temperature: 0.3,
         response_format: { type: 'json_object' }
@@ -158,7 +158,7 @@ ${passageText}
   }
 
   /**
-   * Bug #18: Evaluate student's TEXT answer to a comprehension question
+   * Evaluate student's TEXT answer to a comprehension question
    * @param {object} questionData - Question object with expected answer
    * @param {string} textAnswer - Student's text answer directly
    * @param {string} language - 'en' or 'ur'
@@ -166,7 +166,7 @@ ${passageText}
    */
   static async evaluateTextAnswer(questionData, textAnswer, language) {
     try {
-      logToFile('📝 Evaluating comprehension TEXT answer (Bug #18)', {
+      logToFile('📝 Evaluating comprehension TEXT answer', {
         questionId: questionData.id,
         questionType: questionData.type,
         language,
@@ -296,7 +296,7 @@ Respond in JSON:
 }`;
 
       const response = await openai.chat.completions.create({
-        model: 'gpt-4o', // Bug #31 Fix: gpt-4 deprecated, use gpt-4o for JSON mode support
+        model: 'gpt-4o', // gpt-4 deprecated, use gpt-4o for JSON mode support
         messages: [{ role: 'user', content: evaluationPrompt }],
         temperature: 0.1,  // Low temp for consistent evaluation
         response_format: { type: 'json_object' }
@@ -463,7 +463,7 @@ ${comprehensionAnalysis.answers.map(a =>
       const prompt = prompts[language] || prompts.en;
 
       const response = await openai.chat.completions.create({
-        model: 'gpt-4o', // Bug #31 Fix: gpt-4 deprecated, use gpt-4o for consistency
+        model: 'gpt-4o', // gpt-4 deprecated, use gpt-4o for consistency
         messages: [{ role: 'user', content: prompt }],
         temperature: 0.5,
         max_tokens: 300
@@ -544,7 +544,7 @@ ${comprehensionAnalysis.answers.map(a =>
   }
 
   /**
-   * Generate word-level comprehension questions (Bug #7)
+   * Generate word-level comprehension questions
    * 3-question vocabulary assessment for word-level passages
    *
    * Question Types:

--- a/bot/shared/services/reading/fluency.service.js
+++ b/bot/shared/services/reading/fluency.service.js
@@ -53,7 +53,7 @@ class FluencyService {
       const transcribedText = transcriptionResult.text || '';
       const wordTimestamps = transcriptionResult.wordTimestamps || [];
 
-      // CRITICAL FIX (Bug #6): Clean transcript artifacts before word alignment
+      // CRITICAL FIX: Clean transcript artifacts before word alignment
       // Soniox diarization adds timestamps [00:01], speaker labels "Teacher (EN):", etc.
       // These artifacts cause false errors like "Inserted: 0001", "Inserted: teacher"
       const cleanedTranscript = this.cleanTranscriptForAlignment(transcribedText);
@@ -67,7 +67,7 @@ class FluencyService {
         transcribedWords: transcribedWords.length
       });
 
-      // Bug #1 Fix: For letter-type assessments, use letter name mapping instead of word alignment
+      // For letter-type assessments, use letter name mapping instead of word alignment
       // Children say "alif" but passage stores "ا" - standard Levenshtein fails
       const passageType = assessment.passage_type || 'sentences';
       let alignment;
@@ -111,7 +111,7 @@ class FluencyService {
       });
 
       // Step 5: Calculate fluency metric (WCPM or LCPM based on passage type)
-      // Bug #6 Fix: Use LCPM for letters, WCPM for connected text
+      // Use LCPM for letters, WCPM for connected text
       // Note: passageType already defined above for letter matching
       const timeMinutes = timeElapsed / 60;
       const rawScore = timeMinutes > 0 ? alignment.correctWords / timeMinutes : 0;
@@ -168,7 +168,7 @@ class FluencyService {
         pronunciationAccuracy: pronunciationAccuracy ? Math.round(pronunciationAccuracy * 10) / 10 : null, // Azure pronunciation (English only)
         timeElapsed: Math.round(timeElapsed),
 
-        // Bug #6 Fix: Passage-type-specific metric info
+        // Passage-type-specific metric info
         metricType: metricType, // 'LCPM' for letters, 'WCPM' for connected text
         metricDisplayName: metricDisplayName, // Human-readable metric name
         fluencyScore: Math.round(rawScore * 10) / 10, // The actual score (same as wcpm but with generic name)
@@ -209,7 +209,7 @@ class FluencyService {
   }
 
   /**
-   * Clean transcript artifacts before word alignment (FIX for Bug #6)
+   * Clean transcript artifacts before word alignment (FIX for )
    * Removes Soniox diarization markers that cause false errors
    * @param {string} transcript - Raw transcript with diarization
    * @returns {string} Cleaned transcript without artifacts
@@ -455,7 +455,7 @@ class FluencyService {
   }
 
   // ============================================================================
-  // Bug #1 Fix: Letter Name Mapping with GPT-4o Fallback
+  // Letter Name Mapping with GPT-4o Fallback
   // Option A: Fast letter name lookup + Option C: GPT-4o for ambiguous cases
   // ============================================================================
 

--- a/bot/shared/services/reading/passage-generation.service.js
+++ b/bot/shared/services/reading/passage-generation.service.js
@@ -58,7 +58,7 @@ if (CANVAS_AVAILABLE) {
   } catch (fontError) {
     console.warn('[passage-generation] Font registration failed:', fontError.message);
   }
-  // Bug #20 Fix: Register Lexend font for English passages (improves reading proficiency)
+  // Register Lexend font for English passages (improves reading proficiency)
   try {
     const { registerFont } = getCanvas();
     registerFont(path.join(__dirname, '../../fonts/Lexend-Regular.ttf'), {
@@ -102,24 +102,24 @@ const BACKGROUND_COLOR = '#FFFFFF';
 const TEXT_COLOR = '#1A1A1A';
 
 // Font sizes based on passage type
-// Bug #21 Fix: Increased word font size from 56 to 80 for better readability
+// Increased word font size from 56 to 80 for better readability
 const FONT_SIZES = {
   letters: 72,    // Very large for letter recognition
-  words: 80,      // Very large for word reading (Bug #21: increased from 56)
+  words: 80, // Very large for word reading (increased from 56)
   sentences: 48,  // Medium-large for sentence reading
   paragraph: 42,  // Standard for paragraph reading
   story: 38       // Slightly smaller for longer stories
 };
 
 // Line height multipliers
-// Bug #22 Fix: Urdu needs 2.0x spacing for proper script readability
+// Urdu needs 2.0x spacing for proper script readability
 const LINE_HEIGHT_MULTIPLIER = {
   en: 1.6,  // English: Standard spacing
   ur: 2.0   // Urdu: Double spacing for Nastaliq script
 };
 
 // ============================================================================
-// Bug #8 Fix: Sentence Diversity System
+// Sentence Diversity System
 // Prevents thematic repetition (Sara/Ali, dogs, parks, mangoes)
 // ============================================================================
 
@@ -294,17 +294,17 @@ class PassageGenerationService {
       });
 
       // Step 1: Generate passage text
-      // Bug #27 Fix: For word-type passages, use manual word generation (bypass GPT-4)
+      // For word-type passages, use manual word generation (bypass GPT-4)
       // For other types, use GPT-4 generation
       let passageText;
       let passageTitle = null;
 
       if (passageConfig.type === 'words') {
-        // Bug #27 Fix: GPT-4 hybrid approach (age-appropriate words + guaranteed count)
+        // GPT-4 hybrid approach (age-appropriate words + guaranteed count)
         // ALWAYS generate exactly 14 words for 2-column grid (7 per column), ignore passageConfig.wordCount
         const words = await generateRandomWords(14, passageConfig.grade, language);
 
-        // Bug #2a Fix: Store words in HORIZONTAL reading order for fluency comparison
+        // a Fix: Store words in HORIZONTAL reading order for fluency comparison
         // Grid displays in 2 columns (7 rows):
         //   words[0]   words[7]   (row 0)
         //   words[1]   words[8]   (row 1)
@@ -361,7 +361,7 @@ class PassageGenerationService {
       // Step 3: Create passage image using Canvas (only passage text, no title)
       let imageBuffer;
       if (passageConfig.type === 'words' && passageConfig._columnOrderWords) {
-        // Bug #2a Fix: For words, use column-order array for grid image
+        // a Fix: For words, use column-order array for grid image
         // (passageText is already in horizontal order for fluency scoring)
         const fontFamily = language === 'ur' ? 'Noto Nastaliq Urdu' : 'Lexend';
         imageBuffer = await generateWordGrid(passageConfig._columnOrderWords, language, fontFamily);
@@ -386,12 +386,12 @@ class PassageGenerationService {
         assessmentId
       );
 
-      // Step 5: Update assessment record (Bug #16 fix: store title separately)
+      // Step 5: Update assessment record (store title separately)
       await supabase
         .from('reading_assessments')
         .update({
           passage_text: passageText,
-          passage_title: passageTitle, // Bug #16: Store title separately (null for letters/words/sentences)
+          passage_title: passageTitle, // Store title separately (null for letters/words/sentences)
           passage_image_url: imageUrl,
           passage_generated_at: new Date().toISOString(),
           passage_word_count: passageConfig.wordCount,
@@ -421,7 +421,7 @@ class PassageGenerationService {
       }
 
       // Step 7: Send instructions in user's language
-      // Bug #5 Fix: Add language-specific reading direction for letters type
+      // Add language-specific reading direction for letters type
       const isRTL = ['ur', 'ar'].includes(language);
       const readingDirection = isRTL ? 'RIGHT TO LEFT' : 'LEFT TO RIGHT';
       const readingDirectionUrdu = 'دائیں سے بائیں';  // Right to left in Urdu
@@ -430,7 +430,7 @@ class PassageGenerationService {
       let instructionsPrompt;
 
       if (passageConfig.type === 'letters') {
-        // Bug #5 Fix: Special instructions for alphabet reading with explicit direction
+        // Special instructions for alphabet reading with explicit direction
         const directionText = userLanguage === 'ur' ? readingDirectionUrdu :
                               userLanguage === 'ar' ? readingDirectionArabic :
                               readingDirection;
@@ -535,7 +535,7 @@ Generate EXACTLY ${wordCount} random letters for letter recognition practice. NO
 - NO sentences or words, just individual letters
 - Example format (for 14 letters): "A b C d E f G h I j K l M n"
 
-Bug #24 Fix: MUST generate exactly ${wordCount} letters for 3x4+2 grid layout (3 rows of 4 + 1 row of 2)
+MUST generate exactly ${wordCount} letters for 3x4+2 grid layout (3 rows of 4 + 1 row of 2)
 
 IMPORTANT: Start your response DIRECTLY with the first letter. Do NOT include phrases like "Here's a sequence" or "Certainly!" or any other text. JUST THE LETTERS.`,
 
@@ -550,7 +550,7 @@ Generate EXACTLY ${wordCount} random Urdu letters for letter recognition practic
 - NO words or sentences, just individual letters
 - Example format (for 14 letters): ا ب پ ت ٹ ث ج چ ح خ د ڈ ذ ر
 
-Bug #24 Fix: MUST generate exactly ${wordCount} letters for 3x4+2 grid layout (3 rows of 4 + 1 row of 2)
+MUST generate exactly ${wordCount} letters for 3x4+2 grid layout (3 rows of 4 + 1 row of 2)
 
 IMPORTANT: Start your response DIRECTLY with the first Urdu letter. Do NOT include phrases like "یہاں ہے" or "Certainly!" or "Here's a sequence" or any other text in any language. JUST THE URDU LETTERS.`
       },
@@ -579,7 +579,7 @@ bed
 cup
 pen
 
-Bug #21 Fix: MUST generate exactly ${wordCount} words for 2-column layout (7 words per column)`,
+MUST generate exactly ${wordCount} words for 2-column layout (7 words per column)`,
 
         ur: `CRITICAL: Generate EXACTLY ${wordCount} simple, grade ${grade}-appropriate Urdu words for reading practice. NO MORE, NO LESS.
 - Use common, everyday Urdu vocabulary
@@ -606,7 +606,7 @@ Bug #21 Fix: MUST generate exactly ${wordCount} words for 2-column layout (7 wor
 شیر
 ہاتھی
 
-Bug #21 Fix: MUST generate exactly ${wordCount} words for 2-column layout (7 words per column)`
+MUST generate exactly ${wordCount} words for 2-column layout (7 words per column)`
       },
 
       sentences: {
@@ -618,7 +618,7 @@ REQUIREMENTS:
 - 8-12 words per sentence
 - Clear punctuation
 
-🚨 CRITICAL - DIVERSITY RULES (Bug #8 Fix):
+🚨 CRITICAL - DIVERSITY RULES (Fix):
 - Use DIFFERENT names in each sentence (NOT just Sara/Ali!)
 - Names to use: ${getRandomNames(5, 'en').join(', ')}
 - Each sentence must have a DIFFERENT topic/theme
@@ -645,7 +645,7 @@ REQUIREMENTS:
 - CRITICAL: PURE URDU ONLY - NO English words or transliterated English (e.g., use مدرسہ NOT سکول, use گاڑی NOT بس/کار)
 - Use Pakistani Urdu (not literary Urdu)
 
-🚨 CRITICAL - DIVERSITY RULES (Bug #8 Fix):
+🚨 CRITICAL - DIVERSITY RULES (Fix):
 - Use DIFFERENT names in each sentence (NOT just سارہ/علی!)
 - Names to use: ${getRandomNames(5, 'ur').join('، ')}
 - Each sentence must have a DIFFERENT topic/theme
@@ -758,7 +758,7 @@ IMPORTANT: Return ONLY valid JSON in this exact format (no markdown, no code blo
     let passageText = response.choices[0].message.content.trim();
     let passageTitle = null;
 
-    // CRITICAL FIX (Bug #16): For paragraph and story types, extract title separately
+    // CRITICAL FIX: For paragraph and story types, extract title separately
     // JSON format: { "title": "...", "passage": "..." }
     // Title stored in passage_title column, only passage text used for word alignment
     if (type === 'paragraph' || type === 'story') {
@@ -793,7 +793,7 @@ IMPORTANT: Return ONLY valid JSON in this exact format (no markdown, no code blo
       }
     }
 
-    // CRITICAL FIX (Bug #3): Remove ordinal numbers added by GPT
+    // CRITICAL FIX: Remove ordinal numbers added by GPT
     // GPT-4o often adds "1. 2. 3." before sentences even though not requested
     // This causes word alignment to fail catastrophically (90+ false errors)
     // Regex removes patterns like "1. ", "2. ", "99. " at start of lines
@@ -801,9 +801,9 @@ IMPORTANT: Return ONLY valid JSON in this exact format (no markdown, no code blo
       .replace(/^\d+\.\s+/gm, '')  // Remove "1. ", "2. ", etc. at start of lines (multiline mode)
       .trim();
 
-    // CRITICAL FIX (Bug #25): Enforce exact word count for word-type passages
+    // CRITICAL FIX: Enforce exact word count for word-type passages
     // GPT-4 often ignores "EXACTLY X words" constraints and generates more
-    // Similar to Bug #24 (letter count validation), truncate to exact count
+    // Similar to (letter count validation), truncate to exact count
     if (type === 'words') {
       const words = cleanedPassageText
         .split('\n')
@@ -861,7 +861,7 @@ IMPORTANT: Return ONLY valid JSON in this exact format (no markdown, no code blo
 
   /**
    * Create passage image using Canvas
-   * Bug #21 Fix: 2-column layout for word type passages
+   * 2-column layout for word type passages
    * @param {string} text - Passage text
    * @param {string} language - 'en' or 'ur'
    * @param {string} type - Passage type for font size selection
@@ -872,15 +872,15 @@ IMPORTANT: Return ONLY valid JSON in this exact format (no markdown, no code blo
       logToFile('Creating passage image', { language, type });
 
       const fontSize = FONT_SIZES[type] || 42;
-      // Bug #22 Fix: Use language-specific line height (Urdu 2.0x, English 1.6x)
+      // Use language-specific line height (Urdu 2.0x, English 1.6x)
       const lineHeight = fontSize * (LINE_HEIGHT_MULTIPLIER[language] || LINE_HEIGHT_MULTIPLIER.en);
 
       // Set font based on language
-      // Bug #20 Fix: Use Lexend for English (improves reading proficiency)
+      // Use Lexend for English (improves reading proficiency)
       // CRITICAL: Use Noto Nastaliq Urdu for proper contextual letter shaping in Urdu
       const fontFamily = language === 'ur' ? 'Noto Nastaliq Urdu' : 'Lexend';
 
-      // Bug #24 Fix: Use alphabet grid generator for letter type passages
+      // Use alphabet grid generator for letter type passages
       if (type === 'letters') {
         // Split letters by spaces and take first 14
         const letters = text.split(/\s+/).filter(l => l.length > 0).slice(0, 14);
@@ -893,7 +893,7 @@ IMPORTANT: Return ONLY valid JSON in this exact format (no markdown, no code blo
         });
       }
 
-      // Bug #21 Fix: 2-column layout for word type passages
+      // 2-column layout for word type passages
       if (type === 'words') {
         return this.createTwoColumnWordImage(text, language, fontSize, fontFamily);
       }
@@ -982,7 +982,7 @@ IMPORTANT: Return ONLY valid JSON in this exact format (no markdown, no code blo
   }
 
   /**
-   * Bug #21: Create 2-column layout image for word type passages
+   * Create 2-column layout image for word type passages
    * @param {string} text - Word list (one word per line)
    * @param {string} language - 'en' or 'ur'
    * @param {number} fontSize - Font size

--- a/bot/shared/services/reading/report.service.js
+++ b/bot/shared/services/reading/report.service.js
@@ -42,7 +42,7 @@ class ReadingReportService {
   };
 
   /**
-   * Bug #22 Fix: Check if text contains non-Latin characters (Arabic/Urdu/etc.)
+   * Check if text contains non-Latin characters (Arabic/Urdu/etc.)
    * PDFKit cannot render these with standard Helvetica font
    * @param {string} text - Text to check
    * @returns {boolean} True if contains non-Latin characters
@@ -55,7 +55,7 @@ class ReadingReportService {
   }
 
   /**
-   * Bug #22 Fix: Translate non-Latin text to English for PDF display
+   * Translate non-Latin text to English for PDF display
    * @param {string} text - Non-Latin text to translate
    * @returns {Promise<string>} Translated English text
    */
@@ -175,7 +175,7 @@ class ReadingReportService {
         yPos = this._drawErrorAnalysis(doc, reportData, yPos);
       }
 
-      // Bug #19 Fix: Add mispronunciation details section (English only)
+      // Add mispronunciation details section (English only)
       if (reportData.pronunciation && reportData.language === 'en') {
         yPos = this._drawMispronunciationDetails(doc, reportData, yPos);
         yPos = this._drawPronunciationAssessment(doc, reportData, yPos);
@@ -286,7 +286,7 @@ class ReadingReportService {
        .font('Helvetica')
        .text('Student Reading Fluency Evaluation powered by Rumi', 145, yPos + 35);
 
-    // Bug #6 Fix: Dynamic metric name based on passage type
+    // Dynamic metric name based on passage type
     const metricInfo = this._getMetricInfo(reportData.passageType);
 
     // Fluency score badge (top right) - uses dynamic metric name
@@ -395,12 +395,12 @@ class ReadingReportService {
 
     const passageText = data.passageText || 'N/A';
 
-    // Bug #28 Fix: Detect words-type passages and render in 2-column layout
+    // Detect words-type passages and render in 2-column layout
     if (data.passageType === 'words') {
       // Words type: 2-column layout (matches WhatsApp image)
       let words = passageText.split('\n').filter(w => w.trim().length > 0);
 
-      // Bug #2a Fix: passageText is now stored in HORIZONTAL reading order
+      // a Fix: passageText is now stored in HORIZONTAL reading order
       // (w0, w7, w1, w8, w2, w9, ...) but PDF needs COLUMN order for visual display
       // Convert back: horizontal → column order
       if (words.length === 14) {
@@ -419,7 +419,7 @@ class ReadingReportService {
 
       const boxHeight = 200; // Fixed height for 7 words per column
 
-      // Bug #19 Fix: Removed incorrect "words can be read in any order" note
+      // Removed incorrect "words can be read in any order" note
       // Words should be read left-to-right, row by row
 
       doc.roundedRect(50, yPos, 495, boxHeight, 8)
@@ -461,7 +461,7 @@ class ReadingReportService {
 
     } else {
       // Non-words type: Single-column layout (original behavior)
-      // BUG #3 FIX: Calculate height with CORRECT font (Urdu font is taller than Helvetica)
+      // Calculate height with CORRECT font (Urdu font is taller than Helvetica)
       const isUrdu = data.language === 'ur' && fs.existsSync(path.join(__dirname, '../../../fonts/NotoSansArabic.ttf'));
       const fontName = isUrdu ? 'UrduFont' : 'Helvetica';
 
@@ -523,7 +523,7 @@ class ReadingReportService {
     doc.roundedRect(50, yPos, 495, 110, 8)
        .fillAndStroke(this.COLORS.background, this.COLORS.border);
 
-    // Bug #6 Fix: Dynamic metric name (LCPM for letters, WCPM for connected text)
+    // Dynamic metric name (LCPM for letters, WCPM for connected text)
     const metricInfo = this._getMetricInfo(data.passageType);
 
     // Fluency metric (WCPM or LCPM)
@@ -563,7 +563,7 @@ class ReadingReportService {
     this._drawRoundedProgressBar(doc, 60, yPos + 60, 435, 12, data.accuracy, accuracyColor);
 
     // Words/Letters breakdown
-    // Bug #3b/3c Fix: Use dynamic label based on passage type
+    // b/3c Fix: Use dynamic label based on passage type
     const unit = data.passageType === 'letters' ? 'letters' : 'words';
     doc.fontSize(8)
        .fillColor(this.COLORS.secondary)
@@ -594,7 +594,7 @@ class ReadingReportService {
     doc.roundedRect(50, yPos, 495, 90, 8)
        .fillAndStroke(this.COLORS.background, this.COLORS.border);
 
-    // Bug #6 Fix: Dynamic metric name in benchmark
+    // Dynamic metric name in benchmark
     const metricInfo = this._getMetricInfo(data.passageType);
 
     // Benchmark range
@@ -712,7 +712,7 @@ class ReadingReportService {
          .font('Helvetica')
          .text('ERROR EXAMPLES', 60, yPos + 55);
 
-      // BUG #2 FIX: Use UrduFont for Urdu assessments to render Urdu characters correctly
+      // Use UrduFont for Urdu assessments to render Urdu characters correctly
       // Previously used Helvetica which cannot render Arabic/Urdu script
       const isUrdu = data.language === 'ur';
       const errorFont = isUrdu && fs.existsSync(path.join(__dirname, '../../../fonts/NotoSansArabic.ttf'))
@@ -735,7 +735,7 @@ class ReadingReportService {
   }
 
   /**
-   * Draw mispronunciation details section (Bug #19 fix)
+   * Draw mispronunciation details section (fix)
    * Shows which specific words were mispronounced with accuracy scores
    * @private
    */
@@ -761,7 +761,7 @@ class ReadingReportService {
 
     yPos += 25;
 
-    // Bug #30: Show top 5 errors with phonetic guidance (was 8 without details)
+    // Show top 5 errors with phonetic guidance (was 8 without details)
     const topErrors = mispronunciations.slice(0, 5);
 
     // Calculate dynamic box height based on errors (more space for phoneme breakdowns)
@@ -786,7 +786,7 @@ class ReadingReportService {
        .font('Helvetica')
        .text('TOP PRONUNCIATION ERRORS (with phoneme breakdowns)', 60, yPos + 55);
 
-    // Bug #30 Fix: Show detailed phoneme breakdowns for each error
+    // Show detailed phoneme breakdowns for each error
     let exampleY = yPos + 70;
     for (const error of topErrors) {
       // Word and accuracy score
@@ -1006,7 +1006,7 @@ class ReadingReportService {
          .text(`${Math.round(pron.prosodyScore)}%`, 60, yPos + 70);
     }
 
-    // REMOVED (Bug #7): Source indicator is debug text, not needed in teacher-facing reports
+    // REMOVED: Source indicator is debug text, not needed in teacher-facing reports
     // doc.fontSize(7)
     //    .fillColor(this.COLORS.secondary)
     //    .font('Helvetica-Oblique')
@@ -1017,7 +1017,7 @@ class ReadingReportService {
 
   /**
    * Sprint 1.8: Draw comprehension assessment section
-   * Bug #22 Fix: Made async to support non-Latin text translation
+   * Made async to support non-Latin text translation
    * @private
    */
   static async _drawComprehensionAssessment(doc, data, yPos) {
@@ -1087,7 +1087,7 @@ class ReadingReportService {
 
     let questionY = yPos + 110;
     if (comp.answers && comp.answers.length > 0) {
-      // Bug #22 Fix: Use for...of loop to support async translation of non-Latin text
+      // Use for...of loop to support async translation of non-Latin text
       for (let index = 0; index < Math.min(comp.answers.length, 5); index++) {
         const answer = comp.answers[index];
         const icon = answer.correct ? '✅' : '❌';
@@ -1102,7 +1102,7 @@ class ReadingReportService {
         questionY += 12;
 
         // Student's answer with visual indicators for wrong answers
-        // Bug #22 Fix: Translate non-Latin text (Urdu/Arabic) to English for PDF display
+        // Translate non-Latin text (Urdu/Arabic) to English for PDF display
         let studentAnswer = answer.studentAnswer || 'No answer';
         let translationNote = '';
 
@@ -1222,7 +1222,7 @@ class ReadingReportService {
   }
 
   /**
-   * Bug #6 Fix: Get metric info based on passage type
+   * Get metric info based on passage type
    * @param {string} passageType - Passage type (letters, words, sentences, etc.)
    * @returns {Object} Metric info with shortName and displayName
    * @private
@@ -1266,7 +1266,7 @@ class ReadingReportService {
     // Handle null/undefined
     if (!percentileRank) return 'Unknown';
 
-    // Bug #18 Fix: Parse to number if string (database stores as VARCHAR)
+    // Parse to number if string (database stores as VARCHAR)
     // percentileRank can be: '75' (string), 75 (number), or 'above'/'at'/'below' (legacy)
     const rank = typeof percentileRank === 'string'
       ? parseInt(percentileRank, 10)

--- a/bot/shared/services/reading/transcription.service.js
+++ b/bot/shared/services/reading/transcription.service.js
@@ -45,7 +45,7 @@ class TranscriptionService {
       tempAudioPath = await this.downloadAudio(audioUrl, assessmentId);
 
       // Step 2: Transcribe with Soniox (speaker diarization enabled)
-      // Bug #29 Fix: Pass expected language to force correct transcription language
+      // Pass expected language to force correct transcription language
       logToFile('Calling Soniox with speaker diarization and language hint enabled...', {
         expectedLanguage
       });
@@ -219,7 +219,7 @@ class TranscriptionService {
       // Calculate word-level timestamps for fluency analysis
       const wordTimestamps = this.extractWordTimestamps(primarySpeakerTokens);
 
-      // Bug #29 Fix: Calculate audio duration from tokens (more reliable than WhatsApp metadata)
+      // Calculate audio duration from tokens (more reliable than WhatsApp metadata)
       // Use the last token's end_ms from primary speaker tokens, or fall back to all tokens
       let audioDurationSeconds = 0;
       const tokensForDuration = primarySpeakerTokens.length > 0 ? primarySpeakerTokens : tokens;
@@ -264,7 +264,7 @@ class TranscriptionService {
         confidence: confidence,
         qualityScore: qualityScore,
 
-        // Audio duration (Bug #29 fix)
+        // Audio duration (fix)
         audioDurationSeconds: audioDurationSeconds,
 
         // Raw data for debugging

--- a/bot/shared/services/reading/vocabulary-image.service.js
+++ b/bot/shared/services/reading/vocabulary-image.service.js
@@ -1,6 +1,6 @@
 /**
  * Vocabulary Image Service
- * Bug #7: Generates 3-picture composite images for word-level comprehension using Gemini 2.5 Flash
+ * Generates 3-picture composite images for word-level comprehension using Gemini 2.5 Flash
  *
  * Purpose: Create visual vocabulary assessments for L2/L3 learners
  * - Receptive vocabulary testing (picture-word matching)
@@ -54,7 +54,7 @@ class VocabularyImageService {
       });
 
       // Generate image via Gemini
-      // Bug #16 Fix: More explicit prompt to prevent wrong labels like "SKIP"
+      // More explicit prompt to prevent wrong labels like "SKIP"
       const prompt = `Create an educational image showing exactly 3 objects side by side:
 
 LEFT POSITION: A ${orderedWords[0].toUpperCase()} (cartoon style, colorful)

--- a/bot/shared/services/reading/voice-feedback.service.js
+++ b/bot/shared/services/reading/voice-feedback.service.js
@@ -40,7 +40,7 @@ class VoiceFeedbackService {
    */
   static async generateVoiceFeedback(assessment, teacherName, userLanguage = 'en') {
     try {
-      // Bug #17 Fix: Extract student name from assessment
+      // Extract student name from assessment
       const studentName = assessment.student_identifier || 'the student';
 
       logToFile('📢 Starting voice feedback generation', {
@@ -141,8 +141,8 @@ class VoiceFeedbackService {
       let totalErrorCount;
 
       if (assessment.pronunciation_data?.source === 'azure' && assessment.pronunciation_data.words) {
-        // Bug #17 Fix: Expand to top 3-4 errors (from 2)
-        // Bug #32 Fix: Pass transcript and passage text for word-level comparison
+        // Expand to top 3-4 errors (from 2)
+        // Pass transcript and passage text for word-level comparison
         const azureErrors = this._extractAzureErrors(
           assessment.pronunciation_data.words,
           assessment.transcript_text,
@@ -451,8 +451,8 @@ ${hasComprehension ? '- ¡Equilibra errores de pronunciación y orientación de 
 
   /**
    * Extract and prioritize pronunciation errors from Azure data
-   * Bug #17 Enhancement: Extract actual vs expected pronunciation
-   * Bug #32 Fix: Use transcript/passage word-level comparison for actual pronunciation
+   * Enhancement: Extract actual vs expected pronunciation
+   * Use transcript/passage word-level comparison for actual pronunciation
    * @param {Array} words - Words array from Azure pronunciation assessment
    * @param {string} transcriptText - Actual transcribed text from Soniox (optional, for context)
    * @param {string} passageText - Reference passage text (optional, for context)
@@ -477,8 +477,8 @@ ${hasComprehension ? '- ¡Equilibra errores de pronunciación y orientación de 
     let passageWords = [];
     if (transcriptText && passageText) {
       // CRITICAL FIX: Clean transcript to remove timestamps and speaker labels
-      // This fixes Bug #35 where "[00:09] Teacher (EN):" was breaking word alignment
-      // Bug #24 Fix: Use correct method name - cleanTranscriptForAlignment, not cleanTranscript
+      // This fixes where "[00:09] Teacher (EN):" was breaking word alignment
+      // Use correct method name - cleanTranscriptForAlignment, not cleanTranscript
       const cleanedTranscript = FluencyService.cleanTranscriptForAlignment(transcriptText);
       transcriptWords = cleanedTranscript.toLowerCase().split(/\s+/).filter(w => w.length > 0);
       passageWords = passageText.toLowerCase().split(/\s+/).filter(w => w.length > 0);
@@ -488,7 +488,7 @@ ${hasComprehension ? '- ¡Equilibra errores de pronunciación y orientación de 
     const errors = words
       .filter(w => w.errorType && w.errorType !== 'None')
       .map((w, index) => {
-        // Bug #32 Fix: Find actual vs expected using word position
+        // Find actual vs expected using word position
         let actualPronunciation = null;
         let expectedPronunciation = w.word; // Expected is always the reference word
 
@@ -517,7 +517,7 @@ ${hasComprehension ? '- ¡Equilibra errores de pronunciación y orientación de 
           accuracyScore: Math.round(w.accuracyScore || 0),
           phonemes: w.phonemes || [],
           syllables: w.syllables || [],
-          // Bug #32: Use word-level comparison instead of phoneme extraction
+          // Use word-level comparison instead of phoneme extraction
           actualPronunciation: actualPronunciation,
           expectedPronunciation: expectedPronunciation
         };
@@ -711,7 +711,7 @@ ${hasComprehension ? '- ¡Equilibra errores de pronunciación y orientación de 
 
   /**
    * Format error for GPT-4 prompt
-   * Bug #17 Enhancement: Include actual vs expected pronunciation
+   * Enhancement: Include actual vs expected pronunciation
    * @param {object} error - Error object
    * @param {string} errorSource - Source of error data ('azure' or 'word_alignment')
    * @returns {string} Formatted error description
@@ -721,7 +721,7 @@ ${hasComprehension ? '- ¡Equilibra errores de pronunciación y orientación de 
     // Azure pronunciation errors have different structure
     if (errorSource === 'azure') {
       if (error.errorType === 'Mispronunciation') {
-        // Bug #17: Include actual vs expected pronunciation if available
+        // Include actual vs expected pronunciation if available
         let description = `- Mispronounced: "${error.word}" (accuracy: ${error.accuracyScore}%)`;
         if (error.actualPronunciation && error.expectedPronunciation) {
           description += ` - Student said: "${error.actualPronunciation}", Expected: "${error.expectedPronunciation}"`;

--- a/bot/shared/services/redis-comprehension.service.js
+++ b/bot/shared/services/redis-comprehension.service.js
@@ -1,7 +1,7 @@
 /**
  * Database-Based Comprehension Flow State Management
  *
- * Bug #17 Fix: Replaced Redis with database for reliable state persistence
+ * Replaced Redis with database for reliable state persistence
  *
  * Purpose: Track active comprehension question flows using Supabase
  * Pattern: Database is single source of truth - no Redis state to lose
@@ -9,8 +9,8 @@
  * Key insight: current_question_index = comprehension_answers.length
  *
  * History:
- * - Original: Redis-based (Bug #33 fix for context_data)
- * - Updated: Database-based (Bug #17 fix for Redis state loss)
+ * - Original: Redis-based (fix for context_data)
+ * - Updated: Database-based (fix for Redis state loss)
  */
 
 const { createClient } = require('@supabase/supabase-js');
@@ -24,7 +24,7 @@ const supabase = createClient(
 class RedisComprehensionService {
   /**
    * Start a new comprehension flow
-   * Bug #17 Fix: Now stores in database instead of Redis
+   * Now stores in database instead of Redis
    * @param {string} assessmentId - Reading assessment UUID
    * @param {Array} questions - Array of 5 comprehension questions
    * @param {string} userId - User UUID for ownership tracking
@@ -55,7 +55,7 @@ class RedisComprehensionService {
         started_at: Date.now()
       };
 
-      logToFile('Started comprehension flow in DATABASE (Bug #17 fix)', {
+      logToFile('Started comprehension flow in DATABASE (fix)', {
         assessmentId,
         questionCount: questions.length,
         userId
@@ -74,7 +74,7 @@ class RedisComprehensionService {
 
   /**
    * Get active comprehension flow by assessment ID
-   * Bug #17 Fix: Reads from database instead of Redis
+   * Reads from database instead of Redis
    * @param {string} assessmentId - Reading assessment UUID
    * @returns {Object|null} Flow state or null if not found
    */
@@ -117,7 +117,7 @@ class RedisComprehensionService {
 
   /**
    * Find active comprehension flow by user ID
-   * Bug #17 Fix: Queries database instead of scanning Redis keys
+   * Queries database instead of scanning Redis keys
    * Used when voice/text message arrives without assessment context
    * @param {string} userId - User UUID
    * @returns {Object|null} Flow state or null if not found
@@ -170,7 +170,7 @@ class RedisComprehensionService {
 
   /**
    * Record a comprehension answer and advance to next question
-   * Bug #17 Fix: Writes directly to database instead of Redis
+   * Writes directly to database instead of Redis
    * @param {string} assessmentId - Reading assessment UUID
    * @param {Object} answerResult - Answer data with transcript, analysis, correctness
    * @returns {Object} Updated flow state
@@ -239,7 +239,7 @@ class RedisComprehensionService {
 
   /**
    * Clear comprehension flow (mark as completed or failed)
-   * Bug #17 Fix: No Redis to clear - just for API compatibility
+   * No Redis to clear - just for API compatibility
    * Actual status update happens in handler when saving final results
    * @param {string} assessmentId - Reading assessment UUID
    */

--- a/bot/shared/services/student-list.service.js
+++ b/bot/shared/services/student-list.service.js
@@ -3,7 +3,6 @@
  * CRUD operations for student lists and individual students
  *
  * Created: January 24, 2026
- * Bead: bd-051
  */
 
 const { logToFile } = require('../utils/logger');
@@ -304,7 +303,7 @@ class StudentListService {
    */
   static async addStudentsToList(listId, parsedStudents) {
     try {
-      // bd-212: Check for empty array before inserting
+      // Check for empty array before inserting
       if (!parsedStudents || parsedStudents.length === 0) {
         logToFile('❌ No students to add - empty array', { listId });
         return { data: null, error: new Error('No students to add - student list is empty') };

--- a/bot/shared/services/video/video-script.service.js
+++ b/bot/shared/services/video/video-script.service.js
@@ -138,7 +138,7 @@ class VideoScriptService {
    * @returns {Object} { slides, funFacts }
    */
   static async generateSlideContent(topic, language, slideCount, customization = null) {
-    // BUG-014 FIX: Use comprehensive language instructions from language-prompts.js
+    // Use comprehensive language instructions from language-prompts.js
     // Simple languageNames causes GPT to generate Urdu instead of Punjabi
     const languageNames = {
       en: 'English',

--- a/bot/shared/services/voice-attendance.service.js
+++ b/bot/shared/services/voice-attendance.service.js
@@ -3,7 +3,6 @@
  * Processes voice messages for attendance marking using Soniox V3 + GPT-4o-mini
  *
  * Created: January 24, 2026
- * Bead: bd-061
  *
  * Flow:
  * 1. Teacher records voice message naming absent students

--- a/bot/shared/services/whatsapp.service.js
+++ b/bot/shared/services/whatsapp.service.js
@@ -234,7 +234,7 @@ class WhatsAppService {
    */
   static async sendDocument(to, filePath, filename, caption) {
     try {
-      // Determine MIME type based on file extension (bd-196)
+      // Determine MIME type based on file extension
       const ext = filename.toLowerCase().split('.').pop();
       const mimeTypes = {
         'xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
@@ -776,8 +776,8 @@ class WhatsAppService {
 
   /**
    * Send image with interactive reply buttons (for vocabulary questions)
-   * Bug #7: Word-level comprehension assessment
-   * Bug #14: Fixed R2 private URL issue - now downloads from R2 first, uploads to WhatsApp
+   * Word-level comprehension assessment
+   * Fixed R2 private URL issue - now downloads from R2 first, uploads to WhatsApp
    * @param {string} to - Recipient phone number
    * @param {string} imageUrl - URL of image (R2 or public URL)
    * @param {string} bodyText - Question text (e.g., "Which picture shows 'tree'?")
@@ -804,7 +804,7 @@ class WhatsAppService {
         }
       }));
 
-      // Bug #14 Fix: Check if this is an R2 URL (private endpoint)
+      // Check if this is an R2 URL (private endpoint)
       // R2 URLs contain "r2.cloudflarestorage.com" - WhatsApp can't download from these
       // We need to download first, then upload to WhatsApp to get a media_id
       const isR2Url = imageUrl.includes('r2.cloudflarestorage.com');
@@ -1012,7 +1012,7 @@ class WhatsAppService {
         return false;
       }
 
-      // Determine flow action mode (bd-191):
+      // Determine flow action mode:
       // - If screen is specified: use 'navigate' with flow_action_payload.screen (static flows)
       // - If no screen but flowToken exists: use 'data_exchange' (endpoint-based flows with data_api_version 3.0+)
       const useDataExchange = !screen && flowToken;

--- a/bot/shared/storage/r2.js
+++ b/bot/shared/storage/r2.js
@@ -294,7 +294,7 @@ async function uploadReportPDF(pdfBuffer, userId, sessionId) {
 
 /**
  * Upload image buffer to R2 (for Gemini-generated vocabulary images)
- * Bug #7: Word-level comprehension assessment
+ * Word-level comprehension assessment
  * @param {Buffer} imageBuffer - Image buffer (PNG from Gemini)
  * @param {string} key - R2 object key (e.g., "vocab_images/tree_1234567890.png")
  * @returns {Promise<string>} R2 key
@@ -727,7 +727,7 @@ module.exports = {
   uploadLessonPlanBuffer,
   uploadVoiceDebrief,
   uploadReportPDF,
-  uploadImageBuffer,  // Bug #7: Word-level comprehension vocabulary images
+  uploadImageBuffer, // Word-level comprehension vocabulary images
   uploadImageWithRetry, // Multimodal vision: upload with retry
   uploadFeatureVideo, // Feature introduction videos for onboarding
   downloadFromR2,
@@ -738,5 +738,5 @@ module.exports = {
   isPermanentR2Url,
   getPresignedUrl,  // SECURE: Generate temporary presigned URLs for external access
   toPublicUrl,  // Alias for getPresignedUrl (backward compat, async!)
-  uploadBuffer, // bd-063: Generic buffer upload for attendance Excel
+  uploadBuffer, // Generic buffer upload for attendance Excel
 };

--- a/bot/shared/utils/alphabet-grid-generator.js
+++ b/bot/shared/utils/alphabet-grid-generator.js
@@ -1,6 +1,6 @@
 /**
  * Alphabet Grid Generator
- * Bug #24 Fix: Generate structured 3x4+2 alphabet grid using Canvas
+ * Generate structured 3x4+2 alphabet grid using Canvas
  *
  * Purpose: Create consistent, professional alphabet assessment images
  * without GPT-4 Vision's prompt injection risk
@@ -20,10 +20,10 @@ const CANVAS_WIDTH = 1200;
 const CANVAS_HEIGHT = 800;
 const BACKGROUND_COLOR = '#FFFFFF';
 const TEXT_COLOR = '#1A1A1A';
-const FONT_SIZE = 80; // Bug #26: Increased from 72 for better visibility
+const FONT_SIZE = 80; // Increased from 72 for better visibility
 const CELL_WIDTH = 200; // Bug #XX: Reduced from 300 to fix excessive white space (was 66% wasted)
 const CELL_HEIGHT = 200;
-const START_Y = 50; // Bug #26: Reduced from 100 to prevent top row clipping
+const START_Y = 50; // Reduced from 100 to prevent top row clipping
 
 /**
  * Generate alphabet grid image for reading assessment
@@ -43,7 +43,7 @@ async function generateAlphabetGrid(letters, language, fontFamily) {
   }
 
   try {
-    // Bug #5 Fix: Determine if RTL language (Urdu, Arabic read right-to-left)
+    // Determine if RTL language (Urdu, Arabic read right-to-left)
     const isRTL = ['ur', 'ar'].includes(language);
 
     logToFile('📊 Generating alphabet grid', {
@@ -61,7 +61,7 @@ async function generateAlphabetGrid(letters, language, fontFamily) {
     // Get canvas module
     const { createCanvas } = getCanvas();
 
-    // Bug #5 Fix: For RTL languages, reverse letter order so position 0 is on the RIGHT
+    // For RTL languages, reverse letter order so position 0 is on the RIGHT
     // This allows natural right-to-left reading while maintaining position-based scoring
     const displayLetters = isRTL ? [...letters].reverse() : letters;
 
@@ -92,7 +92,7 @@ async function generateAlphabetGrid(letters, language, fontFamily) {
       const rowWidth = lettersInRow * CELL_WIDTH;
       const rowStartX = (CANVAS_WIDTH - rowWidth) / 2;
 
-      // Bug #5 Fix: Add row number with direction arrow
+      // Add row number with direction arrow
       const rowNumberX = isRTL ? rowStartX + rowWidth + 40 : rowStartX - 40;
       const directionArrow = isRTL ? '←' : '→';
       ctx.fillStyle = '#999999'; // Light gray for row indicators

--- a/bot/shared/utils/constants.js
+++ b/bot/shared/utils/constants.js
@@ -76,7 +76,7 @@ const MMS_TIMEOUT_MS = parseInt(process.env.MMS_TIMEOUT_MS) || 60000; // 60 seco
 const MMS_API_KEY = process.env.MMS_API_KEY || ''; // API key for authentication
 
 // Voice Configuration (Phase 3: Multi-language support)
-// bd-332: Voice IDs are env-var overridable for clone deployments
+// Voice IDs are env-var overridable for clone deployments
 const UPLIFT_VOICE_ID = process.env.UPLIFT_VOICE_ID_UR || 'v_8eelc901'; // Info/Education voice - Fast and easy to understand (Urdu)
 const UPLIFT_SINDHI_VOICE_ID = process.env.UPLIFT_VOICE_ID_SD || 'v_sd0kl3m9'; // Sindhi voice
 const UPLIFT_BALOCHI_VOICE_ID = process.env.UPLIFT_VOICE_ID_BAL || 'v_bl1de2f7'; // Balochi voice
@@ -109,7 +109,7 @@ const PROCESSED_MESSAGES_LIMIT = 1000;
 const PROCESSED_MESSAGES_CLEANUP = 100;
 const CONVERSATION_HISTORY_LIMIT = 11; // System message + 10 messages
 
-// Rate Limiting (bd-338: env-configurable for clone deployments)
+// Rate Limiting (env-configurable for clone deployments)
 const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_MAX, 10) || 30; // Max messages per window
 const RATE_LIMIT_WINDOW_SECONDS = parseInt(process.env.RATE_LIMIT_WINDOW_SECONDS, 10) || 60; // Window in seconds
 

--- a/bot/shared/utils/flow-type-detector.js
+++ b/bot/shared/utils/flow-type-detector.js
@@ -18,7 +18,6 @@
  * 4. Attendance marking
  * 5. Unknown
  *
- * Bead: bd-387
  * Created: February 11, 2026
  */
 
@@ -55,7 +54,7 @@ function detectFlowType(responseJson) {
 
   // 3. Attendance Setup (class creation)
   // Navigate-based format: class_name + student_list/students_text
-  // Endpoint-based format (bd-390): list_id + class_display (from extension_message_response.params)
+  // Endpoint-based format: list_id + class_display (from extension_message_response.params)
   const hasNavigateSetupFields = responseJson.class_name &&
                                  (responseJson.student_list || responseJson.students_text);
   const hasEndpointSetupFields = responseJson.list_id && responseJson.class_display;

--- a/bot/shared/utils/language-detection.js
+++ b/bot/shared/utils/language-detection.js
@@ -1,6 +1,6 @@
 /**
  * Language Detection Utility
- * Bug #10: Language Parameter Passthrough
+ * Language Parameter Passthrough
  *
  * Design Decision:
  * - Default: English (en)

--- a/bot/shared/utils/letter-name-mapping.js
+++ b/bot/shared/utils/letter-name-mapping.js
@@ -1,6 +1,6 @@
 /**
  * Letter Name Mapping Utility
- * Bug #1 Fix: Maps letter symbols to their spoken names for accurate assessment
+ * Maps letter symbols to their spoken names for accurate assessment
  *
  * Problem: Children say "alif" but passage stores "ا" - Levenshtein comparison fails
  * Solution: Map letter symbols to all possible spoken name variations

--- a/bot/shared/utils/setup-validator.js
+++ b/bot/shared/utils/setup-validator.js
@@ -67,7 +67,7 @@ function validateBootRequirements() {
   }
 
   // -----------------------------------------------------------------------
-  // 3. Check INTERNAL_API_KEY — warn if not set (bd-331)
+  // 3. Check INTERNAL_API_KEY — warn if not set
   // -----------------------------------------------------------------------
   if (!process.env.INTERNAL_API_KEY) {
     const msg = `${PREFIX} INTERNAL_API_KEY not set — internal admin API routes will be inaccessible. Set a random key in .env`;
@@ -76,7 +76,7 @@ function validateBootRequirements() {
   }
 
   // -----------------------------------------------------------------------
-  // 4. Check MMS_SERVICE_URL in production — warn if localhost (bd-336)
+  // 4. Check MMS_SERVICE_URL in production — warn if localhost
   // -----------------------------------------------------------------------
   if (process.env.NODE_ENV === 'production') {
     const mmsUrl = process.env.MMS_SERVICE_URL || '';

--- a/bot/shared/utils/word-grid-generator.js
+++ b/bot/shared/utils/word-grid-generator.js
@@ -1,6 +1,6 @@
 /**
  * Word Grid Generator
- * Bug #27 Fix: Generate structured 2-column word grid using Canvas
+ * Generate structured 2-column word grid using Canvas
  *
  * Purpose: Create consistent, professional word assessment images
  * with GPT-4 age-appropriate words + guaranteed word count
@@ -26,10 +26,10 @@ const openai = getClient();
 // Grid configuration
 const CANVAS_WIDTH = 1080;
 const CANVAS_PADDING = 60;
-const ROW_INDICATOR_WIDTH = 60; // Bug #17: Space for row indicators
+const ROW_INDICATOR_WIDTH = 60; // Space for row indicators
 const BACKGROUND_COLOR = '#FFFFFF';
 const TEXT_COLOR = '#1A1A1A';
-const ROW_INDICATOR_COLOR = '#999999'; // Bug #17: Light gray for row indicators
+const ROW_INDICATOR_COLOR = '#999999'; // Light gray for row indicators
 const FONT_SIZE = 80; // Match passage-generation.service.js words font size
 const LINE_HEIGHT_MULTIPLIER = 1.8; // Consistent with word rendering
 
@@ -42,7 +42,7 @@ const LINE_HEIGHT_MULTIPLIER = 1.8; // Consistent with word rendering
  */
 async function generateRandomWords(wordCount, gradeLevel, language) {
   if (wordCount !== 14) {
-    throw new Error(`Bug #27 requires exactly 14 words, got ${wordCount}`);
+    throw new Error(`requires exactly 14 words, got ${wordCount}`);
   }
 
   try {
@@ -114,7 +114,7 @@ Example output format: word1, word2, word3, ...`;
       firstFewWords: words.slice(0, 5).join(', ')
     });
 
-    // Bug #27 Fix: Truncate to exactly 14 words (guarantees count compliance)
+    // Truncate to exactly 14 words (guarantees count compliance)
     const selectedWords = words.slice(0, 14);
 
     if (selectedWords.length < 14) {
@@ -208,7 +208,7 @@ async function generateWordGrid(words, language, fontFamily) {
       for (let i = 0; i < leftColumn.length; i++) {
         const word = leftColumn[i];
 
-        // Bug #17: Draw row indicator on the right (←1, ←2, etc. for RTL)
+        // Draw row indicator on the right (←1, ←2, etc. for RTL)
         ctx.fillStyle = ROW_INDICATOR_COLOR;
         ctx.font = `${FONT_SIZE * 0.4}px "${fontFamily}"`;
         ctx.textAlign = 'left';
@@ -240,7 +240,7 @@ async function generateWordGrid(words, language, fontFamily) {
       for (let i = 0; i < leftColumn.length; i++) {
         const word = leftColumn[i];
 
-        // Bug #17: Draw row indicator (1→, 2→, etc.)
+        // Draw row indicator (1→, 2→, etc.)
         ctx.fillStyle = ROW_INDICATOR_COLOR;
         ctx.font = `${FONT_SIZE * 0.4}px "${fontFamily}"`;
         ctx.textAlign = 'right';

--- a/bot/whatsapp-bot.js
+++ b/bot/whatsapp-bot.js
@@ -29,14 +29,14 @@ const { setUserLanguage, setLanguageLock } = require('./shared/utils/language-ca
 const { getOrCreateUser, trackChatStart } = require('./shared/database/bot-helpers');
 const supabase = require('./shared/config/supabase');
 
-// Import Routes (bd-186: Flow encryption endpoints)
+// Import Routes (Flow encryption endpoints)
 const flowEndpointRoutes = require('./shared/routes/flow-endpoint.routes');
 
 // Create Express app
 const app = express();
 app.use(express.json());
 
-// Mount routes (bd-186: Flow encryption endpoints)
+// Mount routes (Flow encryption endpoints)
 app.use('/api/flows', flowEndpointRoutes);
 
 // Create temp directory if it doesn't exist
@@ -56,7 +56,7 @@ async function handleBroadcastStatusWebhook(statuses) {
       const newStatus = status.status; // 'sent', 'delivered', 'read', 'failed'
       const timestamp = status.timestamp ? new Date(parseInt(status.timestamp) * 1000).toISOString() : new Date().toISOString();
 
-      // BUG-001 FIX: Log failed message statuses with error details
+      // Log failed message statuses with error details
       // Error 131042 (payment issue), 131049 (frequency cap), etc. come here
       if (newStatus === 'failed') {
         const errorCode = status.errors?.[0]?.code || 'unknown';
@@ -407,7 +407,7 @@ app.post('/webhook', async (req, res) => {
         const sessionId = buttonId.replace('lessonplan_no_', '');
         await CoachingService.handleLessonPlanResponse(sessionId, from, false);
       }
-      // Bug #9: Stale session reminder buttons - Continue coaching
+      // Stale session reminder buttons - Continue coaching
       else if (buttonId.startsWith('coaching_continue_')) {
         const sessionId = buttonId.replace('coaching_continue_', '');
         logToFile('🔄 User clicked Continue on stale session reminder', { sessionId, from });
@@ -455,7 +455,7 @@ app.post('/webhook', async (req, res) => {
           await WhatsAppService.sendMessage(from, 'Sorry, I could not find that coaching session.');
         }
       }
-      // Bug #9: Stale session reminder buttons - Finish and get partial report
+      // Stale session reminder buttons - Finish and get partial report
       else if (buttonId.startsWith('coaching_finish_')) {
         const sessionId = buttonId.replace('coaching_finish_', '');
         logToFile('📊 User clicked Finish on stale session reminder', { sessionId, from });
@@ -501,18 +501,18 @@ app.post('/webhook', async (req, res) => {
           await WhatsAppService.sendMessage(from, 'Sorry, I could not find that coaching session.');
         }
       }
-      // Bug #7: Vocabulary comprehension button answers
+      // Vocabulary comprehension button answers
       else if (buttonId.startsWith('vocab_answer_')) {
         const selectedOption = buttonId.replace('vocab_answer_', '');  // "1", "2", or "3"
         logToFile('📖 Vocabulary answer button clicked', { buttonId, selectedOption, from });
 
         // Check if user is in comprehension flow
         const RedisComprehensionService = require('./shared/services/redis-comprehension.service');
-        // Bug #15 Fix: Correct function name (was getFlowByUserId, should be findActiveFlowByUser)
+        // Correct function name (was getFlowByUserId, should be findActiveFlowByUser)
         const flowData = await RedisComprehensionService.findActiveFlowByUser(user.id);
 
         if (flowData) {
-          const assessmentId = flowData.assessment_id;  // Bug #15 Fix: Use correct property name
+          const assessmentId = flowData.assessment_id; // Use correct property name
           const questions = flowData.questions;
           const currentQuestionIndex = flowData.current_question_index;
           const currentQuestion = questions[currentQuestionIndex];
@@ -530,7 +530,7 @@ app.post('/webhook', async (req, res) => {
             explanation: isCorrect ? 'Correct button selection' : 'Incorrect button selection'
           };
 
-          // Bug #15 Fix: recordAnswer only takes 2 params (assessmentId, answerResult)
+          // recordAnswer only takes 2 params (assessmentId, answerResult)
           const updatedFlow = await RedisComprehensionService.recordAnswer(
             assessmentId,
             answerResult
@@ -683,7 +683,7 @@ app.post('/webhook', async (req, res) => {
           logToFile('⚠️ No user found for style button', { buttonId, from });
         }
       }
-      // bd-086: Exam Checker buttons
+      // Exam Checker buttons
       else if (ExamCheckerHandler.isExamCheckerButton(buttonId)) {
         if (user) {
           await ExamCheckerHandler.handleExamButton(buttonId, from, user);
@@ -797,6 +797,7 @@ app.post('/webhook', async (req, res) => {
         } catch (err) {
           logToFile('❌ quiz intent button routing failed', { buttonId, error: err.message });
         }
+      }
       // Student Video Library post-delivery survey (👍 Yes / 👎 Not really).
       else if (buttonId.startsWith('student_video_feedback_yes_') || buttonId.startsWith('student_video_feedback_no_')) {
         const StudentVideoFeedbackService = require('./shared/services/student-video-feedback.service');
@@ -922,7 +923,7 @@ app.post('/webhook', async (req, res) => {
         logToFile('❌ Failed to parse flow response_json', { from, error: error.message });
       }
 
-      // Use centralized flow type detection (bd-387: fixes registration→attendance misrouting)
+      // Use centralized flow type detection (fixes registration→attendance misrouting)
       const { detectFlowType } = require('./shared/utils/flow-type-detector');
       const flowType = detectFlowType(responseJson);
 
@@ -959,7 +960,7 @@ app.post('/webhook', async (req, res) => {
           });
         }
       } else if (flowType === 'registration') {
-        // Registration Flow (bd-387: PROJ-010)
+        // Registration Flow
         logToFile('📝 Detected registration flow submission', {
           from,
           responseFields: Object.keys(responseJson)
@@ -1411,9 +1412,9 @@ async function handleDocumentMessage(message, from, user) {
           return; // Exit early - coaching flow will handle everything
         }
 
-        // BUG-005 FIX: Route short audio documents to voice handler for transcription
+        // Route short audio documents to voice handler for transcription
         // Instead of showing confusing "send classroom audio first" message
-        logToFile('🎤 BUG-005: Audio document < 15 min, routing to voice handler for transcription', {
+        logToFile('🎤 Audio document < 15 min, routing to voice handler for transcription', {
           duration: audioDuration,
           durationMinutes: Math.round(audioDuration / 60),
           documentId,

--- a/bot/workers/exam-grading.worker.js
+++ b/bot/workers/exam-grading.worker.js
@@ -13,7 +13,6 @@
  * 6. Deliver results via WhatsApp
  *
  * Created: 2026-01-24
- * Bead: bd-092
  */
 
 const {

--- a/bot/workers/sqs-worker.js
+++ b/bot/workers/sqs-worker.js
@@ -876,7 +876,7 @@ logToFile('🚀 Starting SQS Coaching Worker', {
 
 // Recover stale requests before starting worker
 // Issue #38: Added video request recovery alongside lesson plan recovery
-// bd-092: Added exam grading recovery
+// Added exam grading recovery
 Promise.all([
   recoverStaleLessonPlanRequests(),
   recoverStaleVideoRequests(),

--- a/bot/workers/stale-session.worker.js
+++ b/bot/workers/stale-session.worker.js
@@ -1,6 +1,6 @@
 /**
  * Stale Session Worker
- * Bug #9: Coaching Stuck Sessions - Railway Cron Service
+ * Coaching Stuck Sessions - Railway Cron Service
  *
  * Runs every 15 minutes via Railway Cron
  *

--- a/dashboard/config/database.js
+++ b/dashboard/config/database.js
@@ -1,13 +1,13 @@
 /**
  * PostgreSQL Connection Pool - FIXED VERSION
  *
- * Fixes applied (bd-039):
+ * Fixes applied:
  * - Correct event tracking (acquire/release instead of connect/release)
  * - Pool health monitoring with periodic logging
  * - Automatic alerting when pool is stressed (>80% capacity)
  * - Detection of impossible negative counter (debugging aid)
  *
- * Bead: bd-039 - Fix portal database connection pool leak
+ * Bead: - Fix portal database connection pool leak
  */
 
 require('dotenv').config();

--- a/dashboard/database/queries.js
+++ b/dashboard/database/queries.js
@@ -5,7 +5,7 @@
  * UPDATED: January 12, 2026 - RLS enforcement via req.dbClient
  * All functions now accept dbClient as first parameter
  *
- * UPDATED: January 23, 2026 - Materialized views optimization (bd-044)
+ * UPDATED: January 23, 2026 - Materialized views optimization
  * Added getDashboardStatsOptimized, getAllUsersOptimized with MV fallback
  */
 
@@ -482,7 +482,7 @@ async function getDashboardStats(dbClient) {
 }
 
 // ============================================================================
-// OPTIMIZED FUNCTIONS WITH MATERIALIZED VIEW FALLBACK (bd-044)
+// OPTIMIZED FUNCTIONS WITH MATERIALIZED VIEW FALLBACK
 // ============================================================================
 
 /**
@@ -1972,7 +1972,7 @@ module.exports = {
   getRecentActivity,
   getDashboardStats,
   getDashboardStatsForPeriod,
-  // Optimized functions with MV fallback (bd-044)
+  // Optimized functions with MV fallback
   getDashboardStatsOptimized,
   getAllUsersOptimized,
   getTotalUserCountOptimized,

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -73,7 +73,7 @@ const AMAService = require('./services/ama.service');
 // Access Scope Service (for partner admin RBAC)
 const accessScopeService = require('./services/access-scope.service');
 
-// Materialized Views Service (bd-045: Partner scope filtering)
+// Materialized Views Service (Partner scope filtering)
 const materializedViews = require('./services/materialized-views.service');
 
 // Invitation Service (for partner admin invitations)
@@ -695,7 +695,7 @@ app.post('/observability/reset-password', loginLimiter, async (req, res) => {
 
 // Dashboard home (stats)
 // RBAC: Partner admin or super admin can access dashboard
-// bd-045: Uses partner-scoped MVs for data isolation
+// Uses partner-scoped MVs for data isolation
 app.get('/observability/dashboard',
   requireAuth,
   requirePartnerAdmin,
@@ -707,7 +707,7 @@ app.get('/observability/dashboard',
     let stats;
     let statsSource = 'unknown';
 
-    // bd-045: Route to appropriate MV based on user role and scope
+    // Route to appropriate MV based on user role and scope
     if (userRole === 'super_admin') {
       // Super admin: Use global MV (fastest path)
       stats = await getDashboardStatsOptimized(req.dbClient);
@@ -816,7 +816,7 @@ app.get('/observability/api/dashboard/stats', requireAuth, async (req, res) => {
 
 // Users list (page view)
 // RBAC: Partner admin or super admin can access users list
-// bd-045: Uses partner-scoped MVs for data isolation
+// Uses partner-scoped MVs for data isolation
 app.get('/observability/users',
   requireAuth,
   requirePartnerAdmin,
@@ -830,7 +830,7 @@ app.get('/observability/users',
     const accessScope = req.session.accessScope;
     let users;
 
-    // bd-045: Route to appropriate MV based on user role and scope
+    // Route to appropriate MV based on user role and scope
     if (userRole === 'super_admin' || !accessScope || accessScope.scope_type === 'all') {
       // Super admin or "all" scope: Use global MV
       users = await getAllUsersOptimized(req.dbClient, limit, offset);
@@ -868,7 +868,7 @@ app.get('/observability/users',
 
 // API endpoint for users list (for infinite scroll)
 // RBAC: Partner admin or super admin can access
-// bd-045: Uses partner-scoped MVs for data isolation
+// Uses partner-scoped MVs for data isolation
 app.get('/observability/api/users',
   requireAuth,
   requirePartnerAdmin,
@@ -883,7 +883,7 @@ app.get('/observability/api/users',
     let users;
     let totalCount;
 
-    // bd-045: Route to appropriate MV based on user role and scope
+    // Route to appropriate MV based on user role and scope
     if (userRole === 'super_admin' || !accessScope || accessScope.scope_type === 'all') {
       // Super admin or "all" scope: Use RLS-enforced direct query
       const result = await req.dbClient.query(`
@@ -988,7 +988,7 @@ app.get('/observability/sessions',
   requireFeatureAccess('sessions'),
   async (req, res) => {
   try {
-    // RLS ENFORCED: Using optimized materialized view (bd-044)
+    // RLS ENFORCED: Using optimized materialized view
     const analytics = await getSessionAnalytics(req.dbClient);
     const stats = await getDashboardStatsOptimized(req.dbClient);
 
@@ -1242,7 +1242,7 @@ app.get('/observability/schema',
   requirePartnerAdmin,
   async (req, res) => {
   try {
-    // Get current stats for table record counts - using optimized MV (bd-044)
+    // Get current stats for table record counts - using optimized MV
     const stats = await getDashboardStatsOptimized(req.dbClient);
 
     res.render('schema', {
@@ -1466,7 +1466,7 @@ app.get('/observability/retention',
     const endDate = req.query.dateTo || null;
 
     // RLS ENFORCED: All retention service functions now use req.dbClient (Batch 7 ✅)
-    // bd-044: Fetch data ONCE, then reuse for curve and summary (3x → 1x queries)
+    // Fetch data ONCE, then reuse for curve and summary (3x → 1x queries)
     const retentionResult = await getRetentionData(req.dbClient, featureType, weeksBack, startDate, endDate);
     const { cohorts, summary: baseSummary } = retentionResult;
 
@@ -3651,7 +3651,7 @@ app.listen(PORT, '0.0.0.0', () => {
   console.log(`   (Default password_hash: admin123 - change via ADMIN_PASSWORD_HASH env var)`);
   console.log(`${'='.repeat(70)}\n`);
 
-  // Start materialized view refresh scheduler (bd-044)
+  // Start materialized view refresh scheduler
   const mvScheduler = require('./services/mv-refresh-scheduler.service');
   mvScheduler.start({
     connectionString: process.env.DATABASE_URL,

--- a/dashboard/middleware/rbac/database-context.js
+++ b/dashboard/middleware/rbac/database-context.js
@@ -1,7 +1,7 @@
 /**
  * Database Context Middleware - FIXED VERSION
  *
- * Fixes applied (bd-039):
+ * Fixes applied:
  * - Uses res.on('finish') for reliable cleanup (works with ALL response types)
  * - No method overriding (res.send/json) - avoids race conditions
  * - Single release point with 'released' flag (no double release)
@@ -17,7 +17,7 @@
  * 5. Attach client to req.dbClient for use in route handlers
  * 6. Ensure RESET ROLE and release happen after response via res.on('finish')
  *
- * Bead: bd-039 - Fix portal database connection pool leak
+ * Bead: - Fix portal database connection pool leak
  */
 
 const pool = require('../../config/database');

--- a/dashboard/middleware/timeout.js
+++ b/dashboard/middleware/timeout.js
@@ -21,7 +21,7 @@ const GPT_HEAVY_ROUTES = [
   '/observability/api/ama',
   '/api/portal/coaching-session/',
   '/api/portal/coaching-analytics',
-  '/observability/retention' // bd-044: MV fallback can be slow during optimization
+  '/observability/retention' // MV fallback can be slow during optimization
 ];
 
 // Static file patterns

--- a/dashboard/services/materialized-views.service.js
+++ b/dashboard/services/materialized-views.service.js
@@ -17,7 +17,7 @@
  * - Staleness indicator when data is older than threshold
  *
  * @module materialized-views.service
- * @bead bd-044
+ * @bead
  *
  * References:
  * - https://sngeth.com/rails/performance/postgresql/2025/10/03/materialized-views-performance-case-study/
@@ -29,7 +29,7 @@ const VIEW_NAMES = [
   'mv_dashboard_stats',
   'mv_users_activity',
   'mv_retention_cohorts',
-  'mv_dashboard_stats_by_country'  // bd-045: Pre-aggregated country stats for partners
+  'mv_dashboard_stats_by_country' // Pre-aggregated country stats for partners
 ];
 
 /**
@@ -330,7 +330,7 @@ async function getTotalUserCountFromView(dbClient) {
 }
 
 // ============================================
-// PARTNER SCOPE FUNCTIONS (bd-045)
+// PARTNER SCOPE FUNCTIONS
 // ============================================
 
 /**
@@ -456,7 +456,7 @@ function buildScopeWhereClause(scope, startParamIndex = 3) {
  * @param {number} offset - Pagination offset (default 0)
  * @returns {Array} Scoped users
  * @throws {Error} If scope is null/invalid
- * @bead bd-045
+ * @bead
  */
 async function getUsersWithScopeFromView(dbClient, scope, limit = 100, offset = 0) {
   const startTime = Date.now();
@@ -526,7 +526,7 @@ async function getUsersWithScopeFromView(dbClient, scope, limit = 100, offset = 
  * @param {Object} scope - Partner scope { type, value }
  * @returns {Object} Dashboard stats for scope
  * @throws {Error} If scope is null/invalid
- * @bead bd-045
+ * @bead
  */
 async function getDashboardStatsForScope(dbClient, scope) {
   const startTime = Date.now();
@@ -602,7 +602,7 @@ async function getDashboardStatsForScope(dbClient, scope) {
  * @param {Object} dbClient - Database client
  * @param {Object} scope - Partner scope { type, value }
  * @returns {number} Total user count within scope
- * @bead bd-045
+ * @bead
  */
 async function getTotalUserCountForScope(dbClient, scope) {
   try {
@@ -660,7 +660,7 @@ module.exports = {
   viewsExist,
   getTotalUserCountFromView,
 
-  // Partner scope functions (bd-045)
+  // Partner scope functions
   getUsersWithScopeFromView,
   getDashboardStatsForScope,
   getTotalUserCountForScope,

--- a/dashboard/services/mv-refresh-scheduler.service.js
+++ b/dashboard/services/mv-refresh-scheduler.service.js
@@ -13,7 +13,7 @@
  * Recommended for production: pg_cron for reliability
  *
  * @module mv-refresh-scheduler.service
- * @bead bd-044
+ * @bead
  */
 
 const { Pool } = require('pg');

--- a/dashboard/services/retention.service.js
+++ b/dashboard/services/retention.service.js
@@ -7,7 +7,7 @@
  * - Activation: Did user use features on Day 0? (separate metric)
  * - Cohorts: Weekly groups of users by registration date
  *
- * Performance: Uses materialized views when available (bd-044)
+ * Performance: Uses materialized views when available
  */
 
 const materializedViews = require('./materialized-views.service');
@@ -29,7 +29,7 @@ async function getRetentionData(
   endDate = null
 ) {
   try {
-    // Try materialized view first for 'overall' without date filters (bd-044)
+    // Try materialized view first for 'overall' without date filters
     // MV is ~527x faster (0.6ms vs 317ms)
     const mvStart = Date.now();
     console.log(`[Retention] Checking MV: featureType=${featureType}, startDate=${startDate}, endDate=${endDate}`);
@@ -40,7 +40,7 @@ async function getRetentionData(
       console.log(`[Retention] MV query returned ${mvData ? mvData.length : 'null'} rows in ${Date.now() - mvStart}ms`);
 
       if (mvData && mvData.length > 0) {
-        console.log('[Retention] Using materialized view (bd-044)');
+        console.log('[Retention] Using materialized view');
         // Transform MV data to match expected format
         const cohorts = mvData.map(cohort => ({
           cohortWeek: cohort.cohort_week,
@@ -167,15 +167,15 @@ function calculateSummaryStats(cohorts) {
  * @param {string} featureType - 'overall', 'coaching', 'lesson_plans', 'reading'
  * @param {Array} cohortWeeks - Specific cohorts to include (optional, max 5 for readability)
  * @param {number} weeksBack - How many weeks of cohorts (default 12)
- * @param {Array} precomputedCohorts - Optional pre-computed cohorts to avoid re-fetching (bd-044)
+ * @param {Array} precomputedCohorts - Optional pre-computed cohorts to avoid re-fetching
  * @returns {Promise<Object>} Chart.js compatible dataset
  */
 async function getRetentionCurve(dbClient, featureType = 'overall', cohortWeeks = null, weeksBack = 12, precomputedCohorts = null) {
   try {
-    // Use pre-computed cohorts if provided (bd-044 optimization)
+    // Use pre-computed cohorts if provided (optimization)
     let cohorts;
     if (precomputedCohorts) {
-      console.log('[Retention] getRetentionCurve using pre-computed cohorts (bd-044)');
+      console.log('[Retention] getRetentionCurve using pre-computed cohorts');
       cohorts = precomputedCohorts;
     } else {
       // Get full retention data
@@ -348,15 +348,15 @@ async function compareCohorts(cohort1Week, cohort2Week, featureType = 'overall')
  * Get overall retention summary for dashboard cards
  * @param {Object} dbClient - Database client with RLS context (from req.dbClient)
  * @param {number} weeksBack - How many weeks to analyze (default 12)
- * @param {Object} precomputedData - Optional pre-computed { cohorts, summary } to avoid re-fetching (bd-044)
+ * @param {Object} precomputedData - Optional pre-computed { cohorts, summary } to avoid re-fetching
  * @returns {Promise<Object>} Summary statistics
  */
 async function getRetentionSummary(dbClient, weeksBack = 12, precomputedData = null) {
   try {
-    // Use pre-computed data if provided (bd-044 optimization)
+    // Use pre-computed data if provided (optimization)
     let cohorts, summary;
     if (precomputedData) {
-      console.log('[Retention] getRetentionSummary using pre-computed data (bd-044)');
+      console.log('[Retention] getRetentionSummary using pre-computed data');
       cohorts = precomputedData.cohorts;
       summary = precomputedData.summary;
     } else {

--- a/tests/setup/source-hygiene.test.js
+++ b/tests/setup/source-hygiene.test.js
@@ -1,0 +1,71 @@
+/**
+ * Source Hygiene (Phase 6) — two conformance guards for the public repo:
+ *
+ * 1. No internal ticket references (bd-NNN / BUG-NNN / "Bug #NN" / PROJ-/FEAT-/TASK-NNN)
+ *    in shipped source. These leak internal tracking into a public repo and gitleaks
+ *    doesn't catch them (they aren't secrets). Scans non-test bot/dashboard/infra source.
+ *
+ * 2. Entry-point files parse. The bot entry (whatsapp-bot.js), workers, and CLI scripts
+ *    are run via `node`, never imported by a test — so a syntax error (e.g. a missing
+ *    brace from a bad merge) sails through the jest suite and lint, and the process just
+ *    fails to boot. `node --check` each of them here.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+const REF_RE = /\b(?:bd-\d+|BUG-\d+|PROJ-\d+|FEAT-\d+|TASK-\d+|[Bb][Uu][Gg]\s*#\d+)\b/;
+
+function collect(dir, exts) {
+  const out = [];
+  const abs = path.join(ROOT, dir);
+  if (!fs.existsSync(abs)) return out;
+  const walk = (d) => {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) {
+        if (['node_modules', '.git', 'dist', 'build', 'coverage', 'tests', '__tests__'].includes(e.name)) continue;
+        walk(p);
+      } else if (exts.some((x) => e.name.endsWith(x)) && !e.name.endsWith('.test.js')) {
+        out.push(p);
+      }
+    }
+  };
+  walk(abs);
+  return out;
+}
+
+describe('Source Hygiene', () => {
+  describe('no internal ticket references in shipped source', () => {
+    it('bot/dashboard/infrastructure source is free of bd-/BUG-/PROJ-/FEAT-/TASK-/Bug # refs', () => {
+      const files = [
+        ...collect('bot', ['.js']),
+        ...collect('dashboard', ['.js', '.ts', '.tsx']),
+        ...collect('infrastructure', ['.js']),
+      ];
+      const offenders = [];
+      for (const f of files) {
+        const lines = fs.readFileSync(f, 'utf-8').split('\n');
+        lines.forEach((line, i) => {
+          if (REF_RE.test(line)) offenders.push(`${path.relative(ROOT, f)}:${i + 1}`);
+        });
+      }
+      expect(offenders).toEqual([]);
+    });
+  });
+
+  describe('entry-point files parse (node --check)', () => {
+    // Files run via `node` and never imported by a test → not syntax-covered by jest.
+    const entries = [
+      'bot/whatsapp-bot.js',
+      ...collect('bot/workers', ['.js']).map((f) => path.relative(ROOT, f)),
+      ...collect('infrastructure/scripts', ['.js']).map((f) => path.relative(ROOT, f)),
+    ];
+    it.each(entries)('%s has valid syntax', (rel) => {
+      expect(() => execFileSync('node', ['--check', path.join(ROOT, rel)], { stdio: 'pipe' })).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## What
Public-repo hygiene sweep (the Phase 6 follow-up), plus a **critical entry-file fix** surfaced while verifying.

### 1. Stripped internal ticket refs (448 across 99 files)
Removed `bd-NNN` / `BUG-NNN` / `Bug #NN` / `PROJ-/FEAT-/TASK-NNN` from shipped source — in comments **and** a few `logToFile()`/`throw` strings — inherited from the prod→OSS sync. gitleaks doesn't catch ticket IDs, so these were public. Done with an indentation-preserving scripted sweep; technical meaning preserved, only the ref tokens (and label-only comment lines) removed.

### 2. Critical fix: unparseable entry file
While running `node --check`, found **`bot/whatsapp-bot.js` was missing a closing brace** on the `quiz_send_to_class` else-if block (pre-existing on main, from an earlier quiz merge) — the entry file **does not parse**, so the bot can't boot. It slipped through CI because no test imports the entry point and lint doesn't syntax-fail it. Added the brace.

### 3. New conformance guards (`tests/setup/source-hygiene.test.js`)
- **No internal ticket refs** in bot/dashboard/infra source → prevents recurrence.
- **`node --check` every entry-point file** (whatsapp-bot.js, workers, CLI scripts) → closes the CI gap that let the unparseable entry file merge.

## Tests
Full suite **82 suites / 1075 tests green** (+1 suite, +15 tests). Every entry point now syntax-verified; all bot/dashboard/infra source confirmed parseable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)