### PR TITLE
Phase 7A: progressive-disclosure agent scaffolding + guard

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,61 +1,33 @@
-# Rumi Platform - AI Teaching Assistant
+# .claude/ — Agent & skill config (L1)
 
-This is the open-source Rumi platform for deploying AI-powered educational chatbots on WhatsApp.
+**Parent:** [../CLAUDE.md](../CLAUDE.md) · Claude Code configuration for this repo.
 
-## Quick Start
+## What's here
 
-Run `/setup` to start the automated setup process, or follow SETUP.md for manual instructions.
+| Path | Purpose |
+|------|---------|
+| `skills/<name>/SKILL.md` | On-demand domain knowledge an agent loads when a task matches |
+| `settings.json` | MCP servers (e.g. Supabase) — secrets via `${ENV_VAR}` interpolation, never inline |
 
-## Project Structure
+## Skills
 
-| Directory | Purpose |
-|-----------|---------|
-| `bot/` | WhatsApp Bot (Node.js, Express) |
-| `bot/shared/config/` | Branding, feature tiers, capabilities |
-| `bot/shared/services/` | AI, queue, database services |
-| `bot/workers/` | BullMQ background job worker |
-| `bot/scripts/` | CLI simulator, validators |
-| `dashboard/` | Observability Portal (Phase 2) |
-| `portal/` | Teacher Portal (Phase 2) |
-| `infrastructure/` | Database schema, deployment configs |
-| `tests/` | Test suites for all sprints |
-| `docs/` | Architecture, setup, customization |
+Skills are loaded **on demand** — keep this router lean and let the skill hold the depth. Each skill is a
+folder with a `SKILL.md` (+ optional reference files).
 
-## Feature Tiers
+| Skill | Use for |
+|-------|---------|
+| `setup` | Guided clone setup — env, DB bootstrap, flow registration, preflight (`/setup`) |
 
-Set `RUMI_TIER` in your `.env`:
+> **More skills are being ported from the production bot in batches** (operational core: coaching,
+> reading-assessment, registration, whatsapp-flows, debugging, cross-agent-safety, qa-testing,
+> video-generation, feature-tracer, pre-merge-checklist, database-analysis, logging, ab-testing,
+> digital-coach). Each is hand-reviewed and stripped of any internal/credential content before it lands —
+> CI (gitleaks + the source-hygiene guard) enforces that no secrets or internal references ship.
 
-- **minimal**: AI Chat + Registration (1 API key: OpenRouter)
-- **recommended**: + Coaching + Reading Assessment (2 keys: + Soniox)
-- **full**: All features (5 keys: + ElevenLabs, Azure, Gamma)
+## Rules for adding/editing skills here
 
-## Key Configuration Files
-
-- `.env.template` - Copy to `.env` and fill in values
-- `bot/shared/config/branding.js` - Customize bot name, org, languages
-- `bot/shared/config/feature-tiers.js` - Feature tier definitions
-- `bot/shared/services/llm-client.js` - LLM provider (OpenRouter/OpenAI)
-
-## Running Tests
-
-```bash
-npm test              # All tests
-npm run test:security # Sprint 0: Security scan
-npm run test:sprint1  # Sprint 1: Core features
-npm run test:schema   # Sprint 2: Schema validation
-npm run validate:env  # Check environment variables
-```
-
-## Customization
-
-For deep customization (swapping frameworks, changing assessments, adding features), see:
-- `docs/agent-customization.md` — Agent-first guide with file maps for every change type
-- `docs/customization.md` — Basic branding, tiers, LLM provider
-- `docs/monitoring.md` — Observability, dashboards, debugging
-
-## Important Rules
-
-1. Never commit `.env` files
-2. Use `bot/shared/config/branding.js` for customization, not hardcoded values
-3. All LLM calls go through `bot/shared/services/llm-client.js`
-4. Background jobs use BullMQ (Redis), not SQS
+1. **No secrets, no internal references.** Skill markdown is public. Use env-var names and placeholders, never
+   real keys, phone numbers, org names, or internal ticket IDs. The `tests/setup/source-hygiene.test.js` guard
+   scans `.claude/**/*.md` and fails the build on a violation.
+2. **Generic, not deployment-specific.** Describe how the open platform works, not how one operator runs it.
+3. **Point, don't duplicate.** A skill should reference code by path, not paste large code blocks that go stale.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 > Universal agent configuration for AI coding assistants.
 > See [agents.md](https://agents.md) for the specification.
+> **Claude Code agents:** [CLAUDE.md](CLAUDE.md) is the canonical, progressively-disclosed agent guide
+> (root → folder routers → skills). This file is the universal-spec summary of the same facts.
 
 ## Project Overview
 
@@ -10,8 +12,8 @@ Open-source AI teaching companion on WhatsApp. Teachers get 24/7 coaching, readi
 ## Tech Stack
 
 - **Runtime**: Node.js 18+ (Express.js)
-- **Database**: Supabase (PostgreSQL, 52+ tables, Row Level Security)
-- **Queue**: BullMQ (Redis) — 7 async job types
+- **Database**: Supabase (PostgreSQL, 73 tables, Row Level Security)
+- **Queue**: pluggable via `QUEUE_DRIVER` — AWS SQS (default) or BullMQ/Redis (no AWS)
 - **AI**: OpenRouter (500+ models via single API)
 - **Messaging**: WhatsApp Business Cloud API
 
@@ -21,7 +23,7 @@ Open-source AI teaching companion on WhatsApp. Teachers get 24/7 coaching, readi
 rumi-platform/
 ├── bot/                    # WhatsApp Bot (main application)
 │   ├── whatsapp-bot.js     # Entry point (webhook, message routing)
-│   ├── shared/config/      # Branding, feature tiers, capabilities
+│   ├── shared/config/      # Branding, presence-based feature gating, region config
 │   ├── shared/services/    # 39+ service modules
 │   ├── shared/handlers/    # Message handlers (text, voice, image, flow)
 │   ├── workers/            # 8 background workers
@@ -29,7 +31,7 @@ rumi-platform/
 ├── infrastructure/
 │   ├── supabase/           # SQL schema, RLS policies, seed data
 │   └── railway/            # Deployment configs
-├── tests/                  # 158 tests across 11 suites
+├── tests/                  # Jest suites (82 suites / 1075 tests)
 ├── docs/                   # Architecture, customization, monitoring
 └── .claude/                # Claude Code config + /setup skill
 ```
@@ -39,7 +41,7 @@ rumi-platform/
 ```bash
 npm install               # Install root dependencies
 cd bot && npm install     # Install bot dependencies
-npm test                  # Run all 158 tests
+npm test                  # Run all tests (Jest via tests/run.js)
 npm run test:security     # Security scan (no hardcoded secrets)
 npm run test:sprint1      # Core feature tests
 npm run test:schema       # Database schema validation
@@ -52,8 +54,9 @@ npm run simulate          # CLI simulator (test without WhatsApp)
 1. **No credentials in code** — use `.env` (copy from `.env.template`)
 2. **Branding via config** — edit `bot/shared/config/branding.js`, not hardcoded values
 3. **LLM calls via service** — all AI calls go through `bot/shared/services/llm-client.js`
-4. **Background jobs use BullMQ** (Redis), not SQS
-5. **Feature tiers** — set `RUMI_TIER` to `minimal`, `recommended`, or `full`
+4. **Background jobs go through the pluggable queue** — `QUEUE_DRIVER` selects SQS (default) or BullMQ/Redis
+5. **Feature gating is presence-based** — a feature is on iff its env keys are present
+   (`bot/shared/config/feature-availability.js`); there is no `RUMI_TIER`
 
 ## Key Configuration Files
 
@@ -61,7 +64,7 @@ npm run simulate          # CLI simulator (test without WhatsApp)
 |------|---------|
 | `.env.template` | Copy to `.env` and fill in values |
 | `bot/shared/config/branding.js` | Bot name, org, languages |
-| `bot/shared/config/feature-tiers.js` | Feature tier definitions |
+| `bot/shared/config/feature-availability.js` | Presence-based feature gating (feature → env key) |
 | `bot/shared/services/llm-client.js` | LLM provider (OpenRouter/OpenAI) |
 
 ## Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# Rumi Platform — Agent Guide (L0)
+
+Open-source AI teaching companion on WhatsApp: 24/7 coaching, reading assessments, lesson plans, quizzes,
+and PD — in the teacher's own language. This file is the **entry point for AI coding agents**. (Other tools:
+see [AGENTS.md](AGENTS.md), which points here.)
+
+## How to navigate (progressive disclosure)
+
+Read top-down, only as deep as the task needs:
+
+```
+CLAUDE.md (this file)  →  <folder>/CLAUDE.md (router)  →  .claude/skills/<skill>/ (deep knowledge)
+```
+
+| Need | Go to |
+|------|-------|
+| The bot codebase (handlers, services, workers) | [bot/CLAUDE.md](bot/CLAUDE.md) |
+| Database schema, RLS, seed, one-command bootstrap | [infrastructure/CLAUDE.md](infrastructure/CLAUDE.md) |
+| Agent/skill config + what skills exist | [.claude/CLAUDE.md](.claude/CLAUDE.md) |
+| Set up a clone from scratch | [SETUP.md](SETUP.md) · `npm run doctor` (preflight) |
+| Customize branding / swap a framework / add a feature | [docs/agent-customization.md](docs/agent-customization.md) |
+| Architecture, cost, monitoring | [docs/architecture.md](docs/architecture.md) · [docs/cost-guide.md](docs/cost-guide.md) · [docs/monitoring.md](docs/monitoring.md) |
+
+## Architecture facts that change how you write code
+
+1. **Feature gating is presence-based.** A feature is ON iff its env keys are present —
+   `bot/shared/config/feature-availability.js` is the single source of truth (`FEATURES` maps feature →
+   real env key). There is **no `RUMI_TIER`** and no tier system.
+2. **The queue backend is pluggable** via `QUEUE_DRIVER` (default `sqs`; `bullmq` runs the whole async
+   pipeline on Redis with no AWS). Producers/consumers require `bot/shared/services/queue/` (the index),
+   never a specific driver. See [bot/CLAUDE.md](bot/CLAUDE.md).
+3. **All LLM calls go through** `bot/shared/services/llm-client.js` (OpenRouter — one API, many models).
+4. **Region behaviour is config-driven** (`region_features` table, fail-open) — never hardcode a country,
+   phone-number-id, or region name.
+5. **No credentials in code.** Everything comes from `.env` (copy `.env.template`). The repo is public —
+   no secrets, no internal phone numbers, no internal ticket refs in source (CI enforces all three).
+
+## Working rules
+
+- **TDD**: tests live at repo-root `tests/<domain>/` and require bot code via `../../bot/shared/...`.
+  Run `npm test` (Jest via `tests/run.js`). CI runs root `npm test` **before** `bot/ npm ci`, so a test that
+  loads bot code must mock bot-only deps (`aws-sdk`, `bullmq`, `pdfkit`, …) virtually.
+- **Conformance guards** (`tests/setup/`) enforce: every `.from()` table + every `.rpc()` exists in the
+  schema, every insert/select column exists, every schema table is referenced, entry files parse, and no
+  secrets/internal-refs ship. Keep them green.
+- **DB bootstrap**: `npm run bootstrap:db` applies schema → RLS → seed (idempotent).
+
+## Repo map
+
+`bot/` WhatsApp bot (Node/Express; entry `bot/whatsapp-bot.js`; 10 handlers, 49 services, 10 workers) ·
+`infrastructure/` Supabase schema (73 tables) + deploy configs · `tests/` Jest suites (82 suites / 1075
+tests) · `docs/` architecture & customization · `dashboard/` + `portal/` observability/teacher UIs.

--- a/bot/CLAUDE.md
+++ b/bot/CLAUDE.md
@@ -1,0 +1,37 @@
+# bot/ — WhatsApp Bot codebase (L1)
+
+**Parent:** [../CLAUDE.md](../CLAUDE.md) · Node/Express WhatsApp bot. Entry point: `whatsapp-bot.js`
+(webhook + button/message routing).
+
+## Layout
+
+| Path | What's there |
+|------|--------------|
+| `whatsapp-bot.js` | Express webhook, interactive-button router, message dispatch |
+| `shared/handlers/` | Message handlers (text, voice, image, flow-response, …) — 10 files |
+| `shared/services/` | Domain services (49) — AI, coaching, reading, quiz, pic-to-LP, whatsapp, R2, … |
+| `shared/services/queue/` | **Pluggable queue** — `index.js` selects driver by `QUEUE_DRIVER` (sqs\|bullmq) |
+| `shared/routes/` | WhatsApp Flow endpoints (registration, attendance, settings, status, …) |
+| `shared/config/` | `feature-availability.js` (presence gating), `branding.js`, `region-config.js` |
+| `shared/utils/` | logger, structured-logger (correlation IDs), constants, phone-validation |
+| `workers/` | Background job workers (10) — `sqs-worker.js` is the poll loop; one handler per job type |
+| `scripts/` | CLI simulator, validators, setup `doctor.js` |
+
+## Things to know before editing
+
+- **Queue:** never import a specific driver. Require `shared/services/queue` (the index); both drivers
+  expose the same surface (`queueJob`/`receiveJobs`/`completeJob`/`extendJobTimeout`/`cancelByGroupId`/…).
+  Adding a job type = add a `case` in `workers/sqs-worker.js`'s `executeJob` switch + a handler.
+- **Feature gating:** check `feature-availability.js`, not env vars directly; a feature is on iff its keys exist.
+- **Shared-service edits are high-blast-radius** — grep consumers, verify imports, run the suite. See the
+  `cross-agent-safety` skill.
+- **LLM:** all model calls go through `shared/services/llm-client.js`.
+- **Flows:** a new Flow = `shared/routes/<x>-endpoint.js` + mount in `flow-endpoint.routes.js` + `<X>_FLOW_ID`
+  in `shared/utils/constants.js` + `.env.template` + a `/command` trigger in `shared/handlers/text-message.handler.js`
+  + sanitized JSON in `docs/flows/`. See the `whatsapp-flows` skill.
+
+## Deep-dive skills
+
+`.claude/skills/` — `coaching`, `reading-assessment`, `registration`, `whatsapp-flows`, `feature-tracer`
+(trace a feature end-to-end), `debugging`, `cross-agent-safety`, `qa-testing`, `video-generation`,
+`pre-merge-checklist`, `database-analysis`, `digital-coach` (full technical KB).

--- a/infrastructure/CLAUDE.md
+++ b/infrastructure/CLAUDE.md
@@ -1,0 +1,30 @@
+# infrastructure/ — Database & deploy (L1)
+
+**Parent:** [../CLAUDE.md](../CLAUDE.md) · Supabase (Postgres) schema + deployment configs.
+
+## Layout
+
+| Path | What's there |
+|------|--------------|
+| `supabase/00_complete-schema.sql` | The single fresh-install artifact — 73 tables, functions, triggers, + an idempotent column-reconcile section at the end |
+| `supabase/01_rls-policies.sql` | Row-level security policies |
+| `supabase/02_seed-data.sql` | Reference data (reading benchmarks) + `region_features` default row (fail-open gating) |
+| `supabase/migrations/V*.sql` | Versioned upgrades, tracked in `schema_versions` |
+| `supabase/verify-schema.sql` | Sanity checks |
+| `scripts/bootstrap-db.js` | **`npm run bootstrap:db`** — applies schema → RLS → seed in order (idempotent, stops on first error) |
+| `scripts/migrate.js` | Applies pending `V*.sql` migrations via the `exec_sql` RPC |
+| `scripts/test-connections.js` | `npm run validate:connections` |
+| `railway/` | Deployment configs |
+
+## Rules
+
+- **Fresh install** = `npm run bootstrap:db` (needs `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` and an
+  `exec_sql` function — see the script header). It is idempotent, so re-running is safe.
+- **Schema is the source of truth, and CI enforces it both ways:** every `.from()` table and every `.rpc()`
+  function the bot uses must exist here, every insert/select column must exist, and every table must be
+  referenced somewhere. If you add a `.from('x')` / new column / new `.rpc()`, add it here or the
+  `tests/setup/{schema,column}-completeness` + `table-usage-conformance` guards fail.
+- **Adding a column to an existing table:** put it in the column-reconcile `ALTER … ADD COLUMN IF NOT EXISTS`
+  section at the bottom (keeps fresh-install + re-run both correct), and keep the trailing `NOTIFY pgrst`
+  last so PostgREST reloads the cache.
+- **Region gating** lives in `region_features` (DB, fail-open) — not in code constants.

--- a/tests/setup/source-hygiene.test.js
+++ b/tests/setup/source-hygiene.test.js
@@ -19,6 +19,45 @@ const ROOT = path.resolve(__dirname, '../..');
 
 const REF_RE = /\b(?:bd-\d+|BUG-\d+|PROJ-\d+|FEAT-\d+|TASK-\d+|[Bb][Uu][Gg]\s*#\d+)\b/;
 
+// Internal context that must never appear in public agent-native docs (org/partner names,
+// tester names, deployment phone numbers). Env-var names like SUPABASE_SERVICE_ROLE_KEY are
+// legitimate and intentionally NOT listed here.
+const INTERNAL_RE = /\b(?:Taleemabad|TaleemHub|Rawalpindi|Silverleaf|Junaid|Aloyce|Shams|Attar)\b|\+92\d|\+255\d|\b0?329[\s-]?5012345\b|\b5012345\b/i;
+
+// Agent-native markdown: progressive-disclosure routers + skill docs (all public).
+function collectAgentDocs() {
+  const docs = [];
+  for (const top of ['CLAUDE.md', 'AGENTS.md']) {
+    const p = path.join(ROOT, top);
+    if (fs.existsSync(p)) docs.push(p);
+  }
+  const walk = (d) => {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) {
+        if (['node_modules', '.git', 'dist', 'build', 'coverage'].includes(e.name)) continue;
+        walk(p);
+      } else if (e.name === 'CLAUDE.md') {
+        docs.push(p);
+      }
+    }
+  };
+  walk(ROOT);
+  // every .md under .claude/ (skill docs)
+  const claudeDir = path.join(ROOT, '.claude');
+  if (fs.existsSync(claudeDir)) {
+    const walkMd = (d) => {
+      for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+        const p = path.join(d, e.name);
+        if (e.isDirectory()) { if (e.name !== 'node_modules') walkMd(p); }
+        else if (e.name.endsWith('.md')) docs.push(p);
+      }
+    };
+    walkMd(claudeDir);
+  }
+  return [...new Set(docs)];
+}
+
 function collect(dir, exts) {
   const out = [];
   const abs = path.join(ROOT, dir);
@@ -51,6 +90,19 @@ describe('Source Hygiene', () => {
         const lines = fs.readFileSync(f, 'utf-8').split('\n');
         lines.forEach((line, i) => {
           if (REF_RE.test(line)) offenders.push(`${path.relative(ROOT, f)}:${i + 1}`);
+        });
+      }
+      expect(offenders).toEqual([]);
+    });
+  });
+
+  describe('agent-native docs carry no internal refs or context', () => {
+    it('CLAUDE.md routers + AGENTS.md + .claude/**/*.md are free of ticket refs and internal context', () => {
+      const offenders = [];
+      for (const f of collectAgentDocs()) {
+        const lines = fs.readFileSync(f, 'utf-8').split('\n');
+        lines.forEach((line, i) => {
+          if (REF_RE.test(line) || INTERNAL_RE.test(line)) offenders.push(`${path.relative(ROOT, f)}:${i + 1}`);
         });
       }
       expect(offenders).toEqual([]);

--- a/tests/unit/sprint-3/setup-infrastructure.test.js
+++ b/tests/unit/sprint-3/setup-infrastructure.test.js
@@ -73,11 +73,19 @@ describe('Setup Infrastructure', () => {
       expect(fs.existsSync(path.join(ROOT, '.claude/CLAUDE.md'))).toBe(true);
     });
 
-    test('CLAUDE.md mentions key project sections', () => {
+    test('.claude/CLAUDE.md is a progressive-disclosure router (skills + parent link, no stale tiers)', () => {
       const content = fs.readFileSync(path.join(ROOT, '.claude/CLAUDE.md'), 'utf8');
-      expect(content).toContain('bot/');
-      expect(content).toContain('Feature Tiers');
-      expect(content).toContain('branding.js');
+      expect(content).toContain('skills');            // describes the on-demand skill system
+      expect(content).toContain('settings.json');     // MCP/config router
+      expect(content).toContain('../CLAUDE.md');       // links to the L0 parent (progressive disclosure)
+      expect(content).not.toContain('RUMI_TIER');      // tiers were removed (presence-based gating)
+    });
+
+    test('root CLAUDE.md (L0) exists and routes to folder guides', () => {
+      const root = fs.readFileSync(path.join(ROOT, 'CLAUDE.md'), 'utf8');
+      expect(root).toContain('bot/CLAUDE.md');
+      expect(root).toContain('infrastructure/CLAUDE.md');
+      expect(root).toContain('presence');             // documents presence-based gating
     });
 
     test('.claude/settings.json exists with MCP config', () => {


### PR DESCRIPTION
## What
First sub-stage of agent-native packaging: the **progressive-disclosure context architecture** so a cloning agent can navigate the repo, plus a guard so the skills ported next can't leak.

OSS had **no root `CLAUDE.md`** and a **stale `.claude/CLAUDE.md`** (still preached the deleted `RUMI_TIER` and "BullMQ not SQS," pre-`QUEUE_DRIVER`).

- **NEW root `CLAUDE.md` (L0)** — swim pattern (`CLAUDE.md → folder/CLAUDE.md → skill`), the architecture facts that change how you write code (presence-based gating, `QUEUE_DRIVER`, LLM via `llm-client`, `region_features`, no-secrets), accurate repo map.
- **NEW `bot/CLAUDE.md` + `infrastructure/CLAUDE.md`** routers, accurate to shipped code.
- **Rewrote `.claude/CLAUDE.md`** as a lean skill/config router (drops the stale tiers/queue content).
- **De-staled `AGENTS.md`** (RUMI_TIER→presence, BullMQ-only→`QUEUE_DRIVER`, 52→73 tables, 158→1075 tests) and pointed it at `CLAUDE.md`.
- **Extended the source-hygiene guard** to scan `CLAUDE.md` routers + `AGENTS.md` + `.claude/**/*.md` for ticket refs **and** internal context (org/tester names, deployment phone numbers) — the net for the skills ported in 7B+.

## Scope
Skeleton only. The curated **operational-core skills** (~14: coaching, reading-assessment, registration, whatsapp-flows, debugging, cross-agent-safety, qa-testing, video-generation, feature-tracer, pre-merge-checklist, database-analysis, logging, ab-testing, digital-coach) are hand-reviewed + secret-stripped and ported in following PRs.

## Tests
Full suite **82 suites / 1077 tests green**. Updated the `setup-infrastructure` test off its stale "Feature Tiers" assertion onto the new router structure + a root-CLAUDE.md check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)