### PR TITLE
Phase 7B: hub skills (coaching, debugging, digital-coach, registration)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,13 +16,17 @@ folder with a `SKILL.md` (+ optional reference files).
 
 | Skill | Use for |
 |-------|---------|
-| `setup` | Guided clone setup — env, DB bootstrap, flow registration, preflight (`/setup`) |
+| [setup](skills/setup/skill.md) | Guided clone setup — env, DB bootstrap, flow registration, preflight (`/setup`) |
+| [digital-coach](skills/digital-coach/SKILL.md) | **Start here** — architecture map of the whole bot; routes to everything else |
+| [coaching](skills/coaching/SKILL.md) | Classroom-observation coaching: frameworks, the queue worker, LP integration |
+| [debugging](skills/debugging/SKILL.md) | Investigation discipline + correlation-id tracing |
+| [registration](skills/registration/SKILL.md) | New-user name capture + the WhatsApp Registration Flow |
 
-> **More skills are being ported from the production bot in batches** (operational core: coaching,
-> reading-assessment, registration, whatsapp-flows, debugging, cross-agent-safety, qa-testing,
-> video-generation, feature-tracer, pre-merge-checklist, database-analysis, logging, ab-testing,
-> digital-coach). Each is hand-reviewed and stripped of any internal/credential content before it lands —
-> CI (gitleaks + the source-hygiene guard) enforces that no secrets or internal references ship.
+> **More skills are being ported from the production bot in batches** (operational core still pending:
+> reading-assessment, whatsapp-flows, cross-agent-safety, qa-testing, video-generation, feature-tracer,
+> pre-merge-checklist, database-analysis, logging, ab-testing). Each is hand-reviewed and stripped of any
+> internal/credential content before it lands — CI (gitleaks + the source-hygiene guard) enforces that no
+> secrets or internal references ship.
 
 ## Rules for adding/editing skills here
 

--- a/.claude/skills/coaching/SKILL.md
+++ b/.claude/skills/coaching/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: coaching
+description: Classroom-observation coaching pipeline — pluggable scoring frameworks (OECD/HOTS/TEACH/FICO), the async queue worker, lesson-plan integration, and session debugging.
+---
+
+# Coaching Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [debugging](../debugging/SKILL.md), [digital-coach](../digital-coach/SKILL.md)
+
+The coaching feature takes a teacher's classroom-observation audio, transcribes it, scores it against a
+pedagogical framework with the LLM, and returns a written + voice report. It runs asynchronously on the
+queue worker so a long transcription never blocks the webhook.
+
+## Quick Reference
+
+- **Orchestration**: [bot/shared/services/coaching-orchestrator.service.js](../../../bot/shared/services/coaching-orchestrator.service.js) — the end-to-end pipeline the worker calls.
+- **Session lifecycle**: [bot/shared/services/coaching/coaching-session.service.js](../../../bot/shared/services/coaching/coaching-session.service.js) — creates/updates rows in the `coaching_sessions` table.
+- **Report**: [bot/shared/services/coaching/report-generator.service.js](../../../bot/shared/services/coaching/report-generator.service.js).
+- **Frameworks**: [bot/shared/services/coaching/frameworks/](../../../bot/shared/services/coaching/frameworks/) — `framework-registry.js` plus one module per framework.
+- **Worker**: [bot/workers/sqs-worker.js](../../../bot/workers/sqs-worker.js) — pulls coaching jobs off the queue and invokes the orchestrator.
+- **LP extraction**: [bot/workers/lesson-plan-extraction.worker.js](../../../bot/workers/lesson-plan-extraction.worker.js).
+
+## Domain Knowledge
+
+### Pluggable scoring frameworks
+
+Scoring is **not** hard-wired to one rubric. The active framework is chosen at runtime through the
+registry at [frameworks/framework-registry.js](../../../bot/shared/services/coaching/frameworks/framework-registry.js):
+
+```js
+const FRAMEWORKS = {
+  oecd:  () => require('./oecd-framework'),
+  hots:  () => require('./hots-framework'),
+  teach: () => require('./teach-framework'),
+  fico:  () => require('./fico-framework'),
+};
+```
+
+Each module exports its goal/criterion structure, the marks scheme, and the prompt fragments the LLM
+uses. The default `oecd` framework scores 5 goals across 19 classroom criteria + 4 reflective-debrief
+criteria (23 total). To add a region's own rubric, drop a new `*-framework.js` module and register its key
+— no orchestrator changes needed.
+
+> The framework used for a given session is recorded inside `coaching_sessions.analysis_data.framework`
+> (there is no dedicated column). Each framework writes a different `analysis_data` shape, so always read
+> the `framework` field first before parsing scores.
+
+### Async pipeline
+
+1. Audio arrives → the orchestrator (or the voice handler) creates a row in `coaching_sessions` and enqueues a job.
+2. The job lands on whichever queue driver is configured — see `QUEUE_DRIVER` in [bot/CLAUDE.md](../../../bot/CLAUDE.md) (`sqs` default, or `bullmq` for a Redis-only deploy). Both expose the same surface; the worker code is identical.
+3. [bot/workers/sqs-worker.js](../../../bot/workers/sqs-worker.js) dequeues → transcription (STT provider) → framework scoring (LLM via [bot/shared/services/llm-client.js](../../../bot/shared/services/llm-client.js)) → report generation.
+4. Results + status are written back to `coaching_sessions`.
+
+### Lesson-plan integration
+
+A teacher can attach a lesson plan before the observation. It is extracted by
+[bot/workers/lesson-plan-extraction.worker.js](../../../bot/workers/lesson-plan-extraction.worker.js)
+(PDF / DOCX / image), and the text is passed into the scoring prompt so the report can comment on
+**fidelity to the plan** — what was planned vs. what the transcript shows was executed. The fidelity block
+(`score`, `evidence` pairs, `strengths`, `gaps`) lands under `coaching_sessions.analysis_data`.
+
+## Common Issues & Solutions
+
+| Symptom | Where to look |
+|---------|---------------|
+| Report generated but no voice note delivered | `coaching_sessions.voice_feedback_url`; confirm the audio uploaded to object storage and the send call succeeded (trace the correlation id — see [debugging](../debugging/SKILL.md)). |
+| "Session not found" / generic error to the user | `coaching_sessions.status` and the error/stack columns for the failed step. |
+| Session stuck in a non-terminal state (>24h) | [bot/workers/stale-session.worker.js](../../../bot/workers/stale-session.worker.js) sweeps these; check for a job that errored after dequeue. |
+| Scores look wrong / empty | Read `analysis_data.framework`, then parse with *that* framework's shape — a mismatch reads as missing scores. |
+
+## Example — coaching stats
+
+```sql
+SELECT status, COUNT(*) FROM coaching_sessions GROUP BY status;
+```
+
+## Related Skills
+
+- [debugging](../debugging/SKILL.md) — trace a failed or stuck coaching session by correlation id.
+- [digital-coach](../digital-coach/SKILL.md) — where coaching sits in the overall bot architecture.

--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: debugging
+description: Investigation discipline and correlation-id tracing for the bot — how to find ONE evidence-backed root cause instead of guessing, and the log queries that get you there.
+---
+
+# Debugging Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [coaching](../coaching/SKILL.md), [digital-coach](../digital-coach/SKILL.md), [registration](../registration/SKILL.md)
+
+This bot emits structured logs tagged with a **correlation id** that threads a single user request across
+the webhook, the queue, and the workers. Debugging is the practice of following that thread to **one
+root cause backed by evidence** — a row count, a commit hash, a log line — never a guess.
+
+## Investigation Non-Negotiables
+
+Every investigation must:
+
+1. **Query real data, don't assume.** Pull the actual DB row for the affected user (by `id` — the UUID — not by phone) before theorising.
+2. **Trace by correlation id.** Follow the full request flow through the logs, start to finish.
+3. **Verify with proof.** "LP not created" is a hypothesis until a `SELECT` confirms zero rows.
+4. **Count real usage.** How many LPs / coaching sessions / videos does this user actually have?
+
+## Investigation discipline rules
+
+These exist because each one, skipped, has produced a wrong conclusion. Apply them on every investigation.
+
+### Rule A — One root cause, not "either X or Y"
+
+If your report says *"either X or Y"* about the root cause, you are not done. Competing hypotheses are
+**research notes**, not a conclusion. When you catch yourself writing two causes, **stop**, find the
+smallest query that distinguishes them, run it, and only then write the report. Exactly one hypothesis
+survives the query — that is the root cause. If you genuinely cannot disambiguate (no access, no
+telemetry), say *that* and name the query that would resolve it. Don't dress up uncertainty as a finding.
+
+### Rule B — Find the source, don't add a guard
+
+For LLM-behaviour bugs (verbal tics, format leakage, register slips), the first move is to find **what
+prompted** the behaviour: read the actual rendered system prompt for the failing turn (not the template),
+the context that was loaded, and the prior turn (the model mirrors what it just saw). The fix is almost
+always to **remove the source** — strip the phrasing the model is echoing, delete the few-shot example
+that anchored the tic. Adding a "don't do X" rule on top is the worst fix: it concedes the cause exists,
+the model still violates it a few percent of the time, and the prompt grows two instructions that fight
+each other.
+
+### Rule C — Check adjacent changes before saying "regression"
+
+When a feature breaks, before blaming the most recent change *to that feature*, check recent commits
+touching **shared** code paths (anything under `bot/shared/services/`). A change to a neighbouring
+feature regularly breaks a shared service. `git log --since='N hours ago' --oneline` the affected files.
+If you find no adjacent commit, say *"no adjacent commit found"* — that is itself a finding.
+
+### Rule D — A projected query manufactures false negatives; pull RAW rows before asserting "no X"
+
+Before concluding "the bot didn't reply" / "the event never fired", pull the **full raw log rows** for the
+correlation id — every field — not a projected subset. A projection that drops the send/delivery fields
+*looks* like silence even when the send succeeded. Trace with no projection first; project only once
+you've seen the whole shape.
+
+### Rule E — "generated/stored" ≠ "delivered"; verify the delivery event, scoped to that user
+
+A `*_requests.status = 'completed'` means generation finished, **not** that the user received anything.
+For "did the user actually get X", verify the **delivery/send** event AND scope the filter strictly to
+that user's id **and** phone. A loose filter returns *other* users' delivery events that look like a false
+positive.
+
+### Rule F — For "what the user saw", the screenshot is ground truth; reconcile its clock
+
+When a user reports "no response / wrong reply", align their phone's clock to the log timestamps **before**
+naming a cause. A screenshot taken in the async gap (instant ack, substantive reply lands seconds/minutes
+later) looks identical to a failure but is a latency-perception issue, not a drop.
+
+### Rule G — Don't publish a root cause to an external artifact until it's evidence-complete
+
+A root cause or a scale claim ("N users affected") read by non-engineers drives triage and is often hard
+to retract. Don't publish one until Rules A, D, and E are satisfied. Investigate to evidence-complete,
+*then* publish.
+
+### Rule H — Before proposing "route to existing flow X", verify X exists AND that the path reaches it
+
+When a fix says "send them to the existing flow", (a) confirm that flow/UI actually exists in the code
+(don't invent one), and (b) trace the *specific* entry path — two entry points for the "same" feature
+often diverge. Enumerate **every** gating predicate for a cohort feature and verify the data feeding it is
+actually populated (a column the code reads may not exist).
+
+## Logging & tracing
+
+The bot logs structured JSON through [bot/shared/utils/structured-logger.js](../../../bot/shared/utils/structured-logger.js),
+which wraps each request in `runWithCorrelation(correlationId, ...)` so every downstream line carries the
+same id (the simpler [bot/shared/utils/logger.js](../../../bot/shared/utils/logger.js) is the underlying writer). Out of the box this writes to the console (and to a file in development) — see the logging notes
+in [bot/CLAUDE.md](../../../bot/CLAUDE.md) for wiring an optional external log backend.
+
+**The core workflow:**
+
+1. **Get the correlation id** from the error or the user's request.
+2. **Trace the full flow** — every line for that id, time-ordered, *unprojected* (Rule D).
+3. **Find the failure point** — where does the trace stop? Look for the `*.failed` event and its error/stack.
+4. **Check semantic events** — `*.started` / `*.completed` / `*.failed` pairs reveal which stage hung.
+
+```text
+# pattern: filter logs to one request, oldest-first
+correlationId == "corr-xxx"  → order by time asc
+```
+
+### Duplicate processing
+
+When debugging duplicate deliveries, look for the same `requestId` processed more than once. Workers are
+idempotent — they check status before processing:
+
+```js
+if (existingRequest?.status === 'completed') return;        // already done
+if (existingRequest?.status === 'processing' && ageMs < 120000) return; // another worker has it
+```
+
+Multiple "starting generation" lines for one `requestId`, or multiple PDFs to one user, point at an
+idempotency gap.
+
+## Common Issues & Solutions
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| No logs appearing | Logger not initialised / env vars missing | Confirm the log backend env vars on the running service. |
+| Code change not reflected | Deploy still building | Wait for the deploy to finish; confirm the new process actually started. |
+| Can't find a correlation id | Log entry predates the request, or id wasn't propagated | Filter by user id + time range instead. |
+| Silent failure, no error log | Missing defensive logging at the boundary | Add checkpoint logs before/after the suspect call, redeploy, reproduce. |
+
+## Related Skills
+
+- [coaching](../coaching/SKILL.md) — debugging a failed or stuck coaching session.
+- [digital-coach](../digital-coach/SKILL.md) — the architecture map that tells you which worker to trace.
+- [registration](../registration/SKILL.md) — debugging the registration state machine.

--- a/.claude/skills/digital-coach/SKILL.md
+++ b/.claude/skills/digital-coach/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: digital-coach
+description: Architecture map for the WhatsApp teaching-assistant bot — what it does, how the pieces fit, and where to drill in. The orientation hub for development, debugging, and extension.
+---
+
+# Digital Coach — Bot Knowledge Base
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [debugging](../debugging/SKILL.md)
+
+This is the **orientation hub**. Read it first to understand how the bot is shaped, then drill into a
+folder router or a feature skill. Don't load everything at once — be strategic about context.
+
+## What it is
+
+An AI WhatsApp assistant for teachers. Core capabilities:
+
+- **Conversational teaching advice** via an LLM.
+- **Voice-message transcription** (speech-to-text) so teachers can talk, not type.
+- **Lesson-plan generation** and **classroom-observation [coaching](../coaching/SKILL.md)**.
+- **Text-to-speech** replies for low-literacy / low-bandwidth contexts.
+
+It is region-agnostic: language, curriculum, and which features are switched on are all driven by
+configuration, never hard-coded. See the **presence-based gating** model below.
+
+## Tech stack
+
+| Layer | Choice |
+|-------|--------|
+| Runtime | Node.js + Express |
+| Messaging | WhatsApp Cloud API (webhook in, Graph API out) |
+| LLM | Pluggable through [bot/shared/services/llm-client.js](../../../bot/shared/services/llm-client.js) (e.g. an OpenRouter gateway) |
+| Datastore | Postgres (via Supabase) |
+| Async work | Pluggable queue — `QUEUE_DRIVER=sqs` (default) or `bullmq` (Redis-only). See [bot/CLAUDE.md](../../../bot/CLAUDE.md). |
+| STT / TTS | External providers, configured by env |
+
+## How the code is laid out
+
+Start from the routers — they are kept accurate to the shipped code:
+
+- **[CLAUDE.md](../../../CLAUDE.md)** (repo root, L0) — overview, swim pattern, presence-gating, `QUEUE_DRIVER`, the repo map.
+- **[bot/CLAUDE.md](../../../bot/CLAUDE.md)** (L1) — the bot codebase: entry point, handlers, services, workers, the queue abstraction.
+- **[infrastructure/CLAUDE.md](../../../infrastructure/CLAUDE.md)** (L1) — schema, RLS, seed data, the DB bootstrap script.
+
+The request path, end to end:
+
+```
+WhatsApp webhook → bot/whatsapp-bot.js (entry)
+   → bot/shared/handlers/*.handler.js   (route by message type)
+      → bot/shared/services/*           (business logic; LLM, STT, TTS, persistence)
+         → enqueue long jobs onto the queue
+            → bot/workers/*.js          (transcribe, generate, score, deliver)
+```
+
+## Presence-based feature gating
+
+There is **no tier system**. A feature turns on when the env vars it needs are present — checked through
+[bot/shared/config/feature-availability.js](../../../bot/shared/config/feature-availability.js). Set the
+coaching keys and coaching works; leave them unset and the bot degrades gracefully. Per-region toggles can
+additionally be stored in the `region_features` table (fail-open). This is what makes the same codebase
+deployable by anyone with their own credentials — see [.env.template](../../../.env.template).
+
+## Where to go next
+
+| You want to… | Go to |
+|--------------|-------|
+| Set up locally | [.env.template](../../../.env.template) + [infrastructure/CLAUDE.md](../../../infrastructure/CLAUDE.md) (bootstrap the DB) |
+| Understand the bot code | [bot/CLAUDE.md](../../../bot/CLAUDE.md) |
+| Debug a failing request | [debugging](../debugging/SKILL.md) |
+| Work on coaching | [coaching](../coaching/SKILL.md) |
+| Work on registration | [registration](../registration/SKILL.md) |
+
+## Working style
+
+When documenting or communicating about the bot: technical accuracy over marketing; problem → solution →
+trade-offs (be transparent about limitations); show code, don't just describe it; note when a fact was
+last verified, since pricing and provider behaviour drift. When in doubt, check the git history and the
+running service's logs for the latest state.
+
+## Related Skills
+
+- [debugging](../debugging/SKILL.md) — investigation discipline and correlation-id tracing.

--- a/.claude/skills/registration/SKILL.md
+++ b/.claude/skills/registration/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: registration
+description: How a new user becomes a registered teacher — the post-first-feature name capture, the WhatsApp Registration Flow form, and the user fields that gate it.
+---
+
+# Registration Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [debugging](../debugging/SKILL.md)
+
+A new user can talk to the bot and use features before they're "registered". Registration captures their
+name (and, via the Flow form, richer profile fields) so later interactions are personalised. There are
+**two paths**, both converging on the same `users` columns.
+
+## Quick Reference
+
+- **Service**: [bot/shared/services/feature-registration.service.js](../../../bot/shared/services/feature-registration.service.js) — the trigger logic and name capture.
+- **Flow submission**: `handleRegistrationFlow` in [bot/shared/handlers/flow-response.handler.js](../../../bot/shared/handlers/flow-response.handler.js).
+- **Flow encryption**: [bot/shared/services/flow-encryption.service.js](../../../bot/shared/services/flow-encryption.service.js) — decrypts WhatsApp Flow payloads.
+- **Text entry**: [bot/shared/handlers/text-message.handler.js](../../../bot/shared/handlers/text-message.handler.js) — catches the name reply when a user is pending.
+
+## Domain Knowledge
+
+### Path 1 — conversational name capture (default)
+
+The lightweight path, triggered **after the user's first completed feature**:
+
+1. `FeatureRegistrationService.checkAndTriggerRegistration(userId, ...)` runs after a feature delivers.
+2. It skips if the user is already registered (`first_name` set or `registration_completed = true`) or already mid-flow (`registration_pending_name = true`).
+3. On the user's **first** feature only (`countUserFeatures(userId) === 1`), `sendNameQuestion(...)` asks their name in their language and sets `registration_pending_name = true`.
+4. The next text turn is caught by `isPendingName(userId)` in the text handler → `handleNameResponse(...)` extracts the name, sets `first_name`, `registration_completed = true`, `registration_completed_at`, and clears `registration_pending_name`.
+
+### Path 2 — WhatsApp Registration Flow (form)
+
+A richer path using a WhatsApp Flow form. The submission webhook is decrypted by the flow-encryption
+service and handled by `handleRegistrationFlow` in
+[flow-response.handler.js](../../../bot/shared/handlers/flow-response.handler.js), which writes the full
+profile to the `users` row and sets the same completion fields. The Flow is identified by a Registration
+Flow ID configured in env. (For the Flow plumbing itself — endpoint data exchange, init-values, DRAFT vs
+PUBLISHED — see the WhatsApp Flows skill once it lands.)
+
+### The fields that gate registration
+
+```sql
+-- in the users table
+first_name                  -- presence alone counts as "registered"
+registration_completed      -- boolean; checked FIRST
+registration_completed_at   -- timestamp
+registration_pending_name   -- true while waiting for the name reply (path 1)
+```
+
+To force a clean re-registration, reset **all** of these (a half-reset leaves the user wedged):
+
+```js
+await supabase.from('users').update({
+  first_name: null,
+  registration_completed: false,
+  registration_completed_at: null,
+  registration_pending_name: false,
+}).eq('id', userId);   // by UUID, never by phone
+```
+
+## Common Issues & Solutions
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Registered user re-prompted | A reset left `registration_completed = true` but `first_name` null (or vice-versa) | Reset all four fields together. |
+| Name reply ignored | `registration_pending_name` not set, so the text handler doesn't intercept | Confirm `sendNameQuestion` ran and set the flag. |
+| `value too long for type character varying(N)` on a profile field | A Flow field exceeds its column width | Widen the column to fit the real input. |
+| WhatsApp `(#100)` error on the prompt | Empty message body sent | Guard against an empty prompt string before sending. |
+| Flow submitted but user not updated | Decryption or handler failure | Trace the correlation id through `handleRegistrationFlow` — see [debugging](../debugging/SKILL.md). |
+
+## Example — find users stuck mid-registration
+
+```sql
+SELECT id, phone_number, first_name, registration_completed, registration_pending_name
+FROM users
+WHERE registration_pending_name = true
+ORDER BY updated_at DESC;
+```
+
+## Related Skills
+
+- [debugging](../debugging/SKILL.md) — trace a failed Flow submission or a stuck name capture by correlation id.


### PR DESCRIPTION
## What

First batch of the operational-core skill port (Phase 7). Hand-authored OSS-generic versions of the four most cross-referenced skills and wired them into the progressive-disclosure web.

| Skill | Shape |
|-------|-------|
| `digital-coach` | Region-agnostic architecture map; the orientation hub. Presence-based gating, no tiers. |
| `coaching` | Pluggable framework registry (oecd/hots/teach/fico) + the `QUEUE_DRIVER`-abstracted worker + LP integration. |
| `debugging` | Investigation-discipline rules (one root cause; raw rows before "no X"; generated ≠ delivered) + correlation-id tracing. |
| `registration` | The real OSS model — post-first-feature name capture **and** the WhatsApp Registration Flow. |

## Method (per the locked Phase 7 plan)

Hand-read the production source → retype (not copy) into a clone-safe form → hand-wire links per the Link Map (up-link to `.claude/CLAUDE.md`; cross-links only to skills that already exist; code-links to verified `bot/` paths). The link-integrity guard is the **final** layer (Phase 7-final), not this PR.

## Grounded in shipped code, not stale docs

- `registration` corrected away from the old turn-count → Flow-form state machine; the non-existent `interactive-message.handler.js` and reset-script references were dropped.
- `coaching` documents the multi-framework registry that actually ships, not a single hard-wired OECD rubric.
- `debugging` keeps the methodology but drops Axiom tokens, tester PII, and internal incident anecdotes; points at the console+correlation logger.

## Safety

- Leak-grepped: no phones / tokens / names / org refs / internal ticket IDs.
- All relative links resolve (manually verified — guard comes in 7-final).
- Full suite green: **82 suites / 1077 tests**; source-hygiene guard over `.claude/**/*.md` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)