### PR TITLE
Phase 7C: skill ports (reading-assessment, whatsapp-flows, cross-agent-safety, pre-merge-checklist)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,12 +21,15 @@ folder with a `SKILL.md` (+ optional reference files).
 | [coaching](skills/coaching/SKILL.md) | Classroom-observation coaching: frameworks, the queue worker, LP integration |
 | [debugging](skills/debugging/SKILL.md) | Investigation discipline + correlation-id tracing |
 | [registration](skills/registration/SKILL.md) | New-user name capture + the WhatsApp Registration Flow |
+| [reading-assessment](skills/reading-assessment/SKILL.md) | Oral-reading-fluency pipeline, WCPM benchmarks, multilingual rules |
+| [whatsapp-flows](skills/whatsapp-flows/SKILL.md) | Building & publishing WhatsApp Flows (endpoint data exchange, the publish lifecycle) |
+| [cross-agent-safety](skills/cross-agent-safety/SKILL.md) | Safety checklist before editing shared services/workers |
+| [pre-merge-checklist](skills/pre-merge-checklist/SKILL.md) | Defensive pre-flight checks for recurring bug classes |
 
 > **More skills are being ported from the production bot in batches** (operational core still pending:
-> reading-assessment, whatsapp-flows, cross-agent-safety, qa-testing, video-generation, feature-tracer,
-> pre-merge-checklist, database-analysis, logging, ab-testing). Each is hand-reviewed and stripped of any
-> internal/credential content before it lands — CI (gitleaks + the source-hygiene guard) enforces that no
-> secrets or internal references ship.
+> qa-testing, video-generation, feature-tracer, database-analysis, logging, ab-testing). Each is
+> hand-reviewed and stripped of any internal/credential content before it lands — CI (gitleaks + the
+> source-hygiene guard) enforces that no secrets or internal references ship.
 
 ## Rules for adding/editing skills here
 

--- a/.claude/skills/cross-agent-safety/SKILL.md
+++ b/.claude/skills/cross-agent-safety/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: cross-agent-safety
+description: Safety checks before modifying shared bot services. Verify imports, check downstream consumers, run the suite. Use when editing anything in bot/shared/services/ or bot/workers/ — files many features depend on.
+paths: bot/shared/services/**,bot/workers/**
+user-invocable: false
+---
+
+# Cross-Agent Safety Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [coaching](../coaching/SKILL.md), [pre-merge-checklist](../pre-merge-checklist/SKILL.md)
+
+A checklist for editing **shared** code — services and workers that many features import. A careless change
+to one of these crashes features far from the file you touched. Run these before you push.
+
+## MANDATORY steps before modifying anything in `bot/shared/services/`
+
+### 1. Verify ALL imports
+
+If you add a function call (e.g. `logEvent()`), confirm its import exists at the top of the file:
+
+```bash
+grep -n "logEvent" path/to/file.js   # must appear as an import, not just a usage
+```
+
+### 2. Check downstream consumers BEFORE renaming or removing
+
+```bash
+grep -rn "methodName" bot/shared/ bot/workers/ --include="*.js"
+```
+
+Count the call sites; update **all** of them, not just the definition.
+
+### 3. Run the test suite BEFORE and AFTER
+
+```bash
+npm test
+```
+
+This catches `ReferenceError` / `TypeError` from a missing import. Run it before every push.
+
+### 4. Verify column names before using them in queries
+
+The `users` table uses `phone_number` (not `phone`) and `first_name` (not `name`). Always confirm a column
+exists before referencing it in `.select()` / `.update()`.
+
+### 5. Don't chain `.update().eq().in().select().single()`
+
+A chained Supabase update with multiple WHERE conditions + `.select().single()` can return
+`{ data: null, error: null }` even when the WHERE matches a row — silently swallowing constraint violations.
+Split it (fetch → JS-check → plain update → check `error`). Full pattern + the failure modes it hides:
+[pre-merge-checklist/reference/db-mutation-safety.md](../pre-merge-checklist/reference/db-mutation-safety.md).
+
+**Apply when**: any UPDATE with two or more WHERE conditions beyond `eq('id', ...)`, or where the new value
+is enum-like (status, kind, type).
+
+## High-blast-radius files
+
+| File | Used by | Risk |
+|------|---------|------|
+| [bot/shared/services/llm-client.js](../../../bot/shared/services/llm-client.js) / [openai.service.js](../../../bot/shared/services/openai.service.js) | Coaching, lesson plans, quiz, chat | ANY change can break ALL LLM features |
+| [bot/shared/services/whatsapp.service.js](../../../bot/shared/services/whatsapp.service.js) | Every outbound message | ANY change can silence the bot |
+| [bot/shared/services/cache/railway-redis.service.js](../../../bot/shared/services/cache/railway-redis.service.js) | State, rate limiting | Changes break session flows |
+| [bot/shared/storage/r2.js](../../../bot/shared/storage/r2.js) | Coaching, reading, video media | Storage changes break media delivery |
+
+## Never bundle critical-path and best-effort DB writes
+
+If one column in an atomic update doesn't exist (or violates a constraint), the **entire** update fails —
+taking the critical write down with the best-effort one.
+
+```js
+// BAD — if best_effort_col doesn't exist, the whole update fails
+await supabase.from('t').update({ sent_at: new Date(), best_effort_col: x }).eq('id', id);
+
+// GOOD — critical write first, best-effort separately (allowed to fail)
+await supabase.from('t').update({ sent_at: new Date() }).eq('id', id);
+await supabase.from('t').update({ best_effort_col: x }).eq('id', id);  // non-fatal
+```
+
+## Pre-push checklist
+
+```bash
+npm test                                                  # 1. full suite
+grep -rn "functionYouChanged" bot/shared/ bot/workers/ --include="*.js"  # 2. no broken references
+```
+
+## Related Skills
+
+- [pre-merge-checklist](../pre-merge-checklist/SKILL.md) — the bug classes these checks defend against.
+- [coaching](../coaching/SKILL.md) — a heavy consumer of the shared services above.

--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -5,7 +5,7 @@ description: Investigation discipline and correlation-id tracing for the bot —
 
 # Debugging Skill
 
-> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [coaching](../coaching/SKILL.md), [digital-coach](../digital-coach/SKILL.md), [registration](../registration/SKILL.md)
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [coaching](../coaching/SKILL.md), [digital-coach](../digital-coach/SKILL.md), [reading-assessment](../reading-assessment/SKILL.md), [registration](../registration/SKILL.md)
 
 This bot emits structured logs tagged with a **correlation id** that threads a single user request across
 the webhook, the queue, and the workers. Debugging is the practice of following that thread to **one
@@ -127,4 +127,5 @@ idempotency gap.
 
 - [coaching](../coaching/SKILL.md) — debugging a failed or stuck coaching session.
 - [digital-coach](../digital-coach/SKILL.md) — the architecture map that tells you which worker to trace.
+- [reading-assessment](../reading-assessment/SKILL.md) — debugging a stuck or mis-scored assessment.
 - [registration](../registration/SKILL.md) — debugging the registration state machine.

--- a/.claude/skills/pre-merge-checklist/SKILL.md
+++ b/.claude/skills/pre-merge-checklist/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: pre-merge-checklist
+description: Pre-merge defensive checks for recurring, predictable bug classes — run before merging code that (a) emits new interactive button/list/Flow IDs, (b) edits or sends a Flow, (c) writes new enum/status values, (d) chains Supabase update+filter+select, (e) sends to a dormant user, or (f) tracks files toxic to a fresh clone. Each class has a concrete grep/SQL pre-flight and the failure mode it prevents.
+---
+
+# Pre-Merge Checklist
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [whatsapp-flows](../whatsapp-flows/SKILL.md), [coaching](../coaching/SKILL.md), [digital-coach](../digital-coach/SKILL.md), [registration](../registration/SKILL.md)
+
+These bugs are not hard — they are **predictable**. Each one has a 30-second pre-flight check. Read the
+relevant section, run the verification, fix what it surfaces, then merge.
+
+---
+
+## Class A — Orphan dispatch: a service emits IDs nothing handles
+
+Service code emits an `id` for an interactive button, list row, or template quick-reply. The user taps it.
+Nothing happens; the bot logs `⚠️ Unknown button ID` (or similar) and silently no-ops.
+
+WhatsApp delivers user actions through **four separate webhook shapes**, and *each* needs its own handler:
+
+| Webhook shape | Origin | Where to wire |
+|---|---|---|
+| `interactive` / `button_reply` (`id`) | Free-message button | `whatsapp-bot.js` button_reply branch |
+| `interactive` / `list_reply` (`id`) | Free-message list row | `whatsapp-bot.js` list_reply branch |
+| `button` (`button.text` / `button.payload`) | Template quick-reply | `whatsapp-bot.js` button (template) branch — match by text |
+| `text` (free text) | User typing `A`/`B`/`STOP` instead of tapping | `text-message.handler.js` — intercept **before** the registration gate if the recipient may be unregistered |
+
+**Pre-flight:**
+
+```bash
+# 1. Find every interactive ID your new code emits
+grep -rEn "id:\s*['\"]?\$?\{?[a-z_]+_" --include="*.js" bot/shared/services/ | grep -i your_prefix
+# 2. Confirm each prefix has a dispatcher in the receivers
+grep -n "your_prefix" bot/whatsapp-bot.js bot/shared/handlers/text-message.handler.js
+```
+
+If a prefix is emitted but absent from the receivers, it's an orphan. **Lock it in with a mock-free
+"route-contract" test** that greps the source and asserts the dispatcher exists — service-layer unit tests
+mock the receivers and cannot catch this. Full grep patterns + handler stubs:
+[reference/dispatch-wiring.md](reference/dispatch-wiring.md).
+
+---
+
+## Class B — WhatsApp Flow gotchas
+
+Covered in full by [whatsapp-flows](../whatsapp-flows/SKILL.md). The pre-merge summary:
+
+- **Edit-then-republish**: editing the Flow JSON does NOT update Meta — re-run the registration script.
+- **Forward-only `routing_model`**: any backward route → `INVALID_ROUTING_MODEL` on publish.
+- **~10s `data_exchange` timeout**: long work (LLM, uploads) must run async via `setImmediate` after returning SUCCESS.
+- **Endpoint health-check blocks publish**: deploy the endpoint *before* publishing (`error_subcode: 4233014` if not).
+- **A new Flow ID needs three wiring points**: flow-type-detector + the `nfm_reply` branch + flow-response.handler.
+
+---
+
+## Class C — Database schema surprises
+
+### C.1 — CHECK constraints on enum-like columns
+
+Postgres CHECK constraints silently reject values outside the whitelist (and the Supabase JS chain in
+Class D can hide the rejection). Before writing a new value:
+
+```sql
+SELECT pg_get_constraintdef(oid) FROM pg_constraint
+WHERE conrelid = 'YOUR_TABLE'::regclass AND contype = 'c';
+```
+
+If the new value isn't in the whitelist, ship a migration that expands the constraint **before** the code
+that writes it.
+
+### C.2 — Unique indexes that don't match your application WHERE
+
+If a unique index covers `(a, b, c)` but your "look up, insert if missing" check uses `(a, b, d)`, you'll
+hit duplicate-key violations on rows your code thinks don't exist.
+
+```sql
+SELECT indexname, indexdef FROM pg_indexes
+WHERE tablename = 'YOUR_TABLE' AND indexdef LIKE '%UNIQUE%';
+```
+
+Make the application-level lookup match the indexed columns exactly, or catch the duplicate-key error as a
+recovery path.
+
+### C.3 — Inconsistent storage formats
+
+Phone numbers, emails, normalised text — sample the actual stored format before assuming one. A
+`.eq('+<countrycode>…')` lookup against rows stored without the leading `+` matches nothing.
+
+```sql
+SELECT col, COUNT(*) FROM your_table GROUP BY 1 LIMIT 10;  -- eyeball the real shapes first
+```
+
+Full SQL pre-flights + recovery patterns: [reference/db-mutation-safety.md](reference/db-mutation-safety.md).
+
+---
+
+## Class D — The Supabase JS chain hides errors
+
+```js
+// ❌ can return {data:null, error:null} even on a constraint rejection
+await supabase.from('t').update({status:'x'}).eq('id', x).in('status', [...]).select().single();
+
+// ✅ split: fetch → JS-check → plain update → check error
+const { data: row, error: fetchErr } = await supabase.from('t').select('id,status').eq('id', x).single();
+if (fetchErr || !row) { /* not-found */ }
+if (!['a','b'].includes(row.status)) { /* invalid-state */ }
+const { error: updErr } = await supabase.from('t').update({status:'x'}).eq('id', x);
+if (updErr) { /* surface the real SQL error */ }
+```
+
+**Apply when**: any UPDATE with two or more WHERE conditions beyond `eq('id', ...)`, or an enum-like new value.
+
+---
+
+## Class E — JS short-circuit hides a ReferenceError in untested branches
+
+A multi-arm ternary referencing an undeclared variable only throws when execution *reaches* that arm. If
+your tests only exercise the first arm, the broken arm is physically unreachable from your test inputs and
+ships silently.
+
+```js
+const isUrduLike = lang === 'ur' || lang === 'sd';
+// ❌ isSwahili never declared — throws ONLY when isUrduLike is false
+const yes = isUrduLike ? '👍 ہاں' : isSwahili ? '👍 Ndiyo' : '👍 Yes';
+```
+
+**The habits that catch it:**
+1. **Test every branch** of a multi-arm ternary — one case per arm, not just the default.
+2. **Enable `no-undef`** in ESLint — catches it deterministically at lint time.
+3. **Grep the whole file** when you add a flag — function scope doesn't leak; declare it in every function that uses it.
+4. **Treat `.catch()` on `setTimeout`/`Promise` as deliberately silent** — an error logged at `info` there is a silent failure. Surface it loudly.
+
+---
+
+## Class F — Files that work locally but are toxic to a fresh clone
+
+Critical for a repo anyone can clone. A tracked symlink (git mode `120000`) pointing at an operator-local
+path (`node_modules`, a local cache) builds fine on your laptop but **breaks every CI build / fresh clone** —
+the symlink target doesn't exist there, and the install step aborts.
+
+**Pre-flight:**
+
+```bash
+git ls-tree -r HEAD | grep "^120000"        # expect ZERO matches in an app repo
+git clone . /tmp/fresh && cd /tmp/fresh && npm ci   # reproduce a clean clone in 30s
+```
+
+If there are tracked symlinks, untrack them (`git rm --cached <path>`) and add to `.gitignore`. When
+cherry-picking a feature set, don't skip the source branch's `chore: untrack …` cleanup commits — skipping
+them surfaces this bug on the target branch.
+
+> **Deploy-verification corollary**: many platforms keep the *previous* deployment serving when a new build
+> fails, so `/health` still returns 200 and looks fine. The only reliable "new code is live" signal is the
+> process **start time being after your push** plus uptime past the build window — not "a deploy happened".
+
+---
+
+## Class G — Sending to a dormant user needs a template, not free text
+
+WhatsApp rejects free-form messages outside the 24-hour customer-service window (error `131047`). Anywhere
+the user did **not** just trigger the message — a reset code, a portal-initiated invite, a cron nudge — you
+must send a Meta-approved **AUTHENTICATION** or **UTILITY** template, not `sendMessage`.
+
+**Pre-flight:**
+
+```bash
+grep -rn "WhatsAppService\.sendMessage" bot/shared/services/ bot/shared/handlers/ bot/workers/
+# For each: "is the user guaranteed to have messaged us in the last 24h?" If not → sendTemplate.
+```
+
+Rules: the template must be **APPROVED** on the WABA (and in the right language) before merge; **always
+check the boolean return** of the send and surface a real error on `false` — never report success when the
+send was rejected; fall back to English with a warning when the user's language has no approved template.
+
+---
+
+## When something goes wrong post-deploy: investigate, don't guess
+
+Pull the logs for the exact reported time window and read the real error — see [debugging](../debugging/SKILL.md).
+The bot's own log line is often generic, but the underlying `err`/`error.message` field usually carries the
+real Postgres/Meta error (`violates check constraint "…"`, `duplicate key value violates unique constraint
+"…"`) that points straight at the fix. Don't speculate a root cause the logs can settle.
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| [reference/dispatch-wiring.md](reference/dispatch-wiring.md) | Grep patterns + handler-stub examples for each of the four WhatsApp webhook shapes |
+| [reference/db-mutation-safety.md](reference/db-mutation-safety.md) | SQL pre-flights for CHECK constraints, unique indexes, inconsistent formats, and the Supabase JS chain |
+
+## Related Skills
+
+- [whatsapp-flows](../whatsapp-flows/SKILL.md) — the full Flow rules behind Class B.
+- [registration](../registration/SKILL.md) · [coaching](../coaching/SKILL.md) · [digital-coach](../digital-coach/SKILL.md) — common emitters of new IDs / DB writes.

--- a/.claude/skills/pre-merge-checklist/reference/db-mutation-safety.md
+++ b/.claude/skills/pre-merge-checklist/reference/db-mutation-safety.md
@@ -1,0 +1,94 @@
+# DB Mutation Safety — Pre-Flight Checks
+
+Run these before merging any code that writes to the database. They catch the recurring DB bug classes.
+Use a read-only role for inspection (`$DATABASE_URL` / your analyst connection — from env, never inline).
+
+## 1. Before writing a new value to an enum-like column
+
+```sql
+SELECT pg_get_constraintdef(oid) FROM pg_constraint
+WHERE conrelid = 'YOUR_TABLE'::regclass AND contype = 'c';
+```
+
+If the new value is missing from the CHECK whitelist, ship a migration that expands the constraint **before**
+the code that writes the value goes live.
+
+```sql
+-- migration: add NEW_VALUE to YOUR_TABLE.col
+ALTER TABLE your_table DROP CONSTRAINT IF EXISTS your_table_col_check;
+ALTER TABLE your_table ADD CONSTRAINT your_table_col_check
+  CHECK (col IN ('existing', 'values', 'NEW_VALUE'));
+```
+
+**Failure mode if skipped**: a `status` CHECK allowed only `('generating','ready','sent','failed')`; the
+cancel path wrote `'cancelled'`, Postgres silently rejected it, and the Supabase JS chain (§4) hid the
+rejection — so the logs blamed "already finalized" instead of a constraint violation.
+
+## 2. Before writing to a column with a unique index
+
+```sql
+SELECT indexname, indexdef FROM pg_indexes
+WHERE tablename = 'YOUR_TABLE' AND indexdef LIKE '%UNIQUE%';
+```
+
+Read the column list inside `(...)`. If your "look up, insert if missing" check uses a *different* column
+set than the index, you'll hit `duplicate key value violates unique constraint` on rows your code thinks
+don't exist. Match the index exactly, or catch the duplicate-key error as a recovery path:
+
+```js
+const { data: row, error: insertErr } = await supabase.from('t').insert({...}).select().single();
+if (insertErr && /duplicate key/.test(insertErr.message || '')) {
+  const { data: existing } = await supabase.from('t').select('*')
+    .ilike('column_in_index', value)   // match the index's lower()/normalisation
+    .single();
+  return existing;
+}
+if (insertErr) throw insertErr;
+```
+
+## 3. Before querying a column with possibly-inconsistent storage formats
+
+```sql
+SELECT
+  COUNT(*) FILTER (WHERE col LIKE '+%')  AS with_plus,
+  COUNT(*) FILTER (WHERE col ~ '^[0-9]') AS without_plus,
+  COUNT(*) AS total
+FROM your_table;
+```
+
+If formats are mixed, your `.eq()` must match both, or normalise at write-time and migrate existing rows.
+
+```js
+// try both formats — cheap, two round-trips at worst
+const noPlus   = phone.startsWith('+') ? phone.slice(1) : phone;
+const withPlus = phone.startsWith('+') ? phone : `+${phone}`;
+let { data: user } = await supabase.from('users').select('id').eq('phone_number', noPlus).single();
+if (!user) ({ data: user } = await supabase.from('users').select('id').eq('phone_number', withPlus).single());
+```
+
+**Failure mode if skipped**: `users.phone_number` stored without a leading `+` for nearly all rows, but new
+code wrote `+<countrycode>…` — the `.eq()` lookup matched almost nobody, and the free-message path was
+effectively dead.
+
+## 4. The Supabase JS chain pitfall
+
+```js
+// ❌ returns {data:null, error:null} even on a constraint rejection
+await supabase.from('t').update({...}).eq('id', x).in('status', [...]).select(...).single();
+
+// ✅ split — errors are explicit
+const { data: row, error: fetchErr } = await supabase.from('t').select('id, status, ...').eq('id', x).single();
+if (fetchErr || !row) { /* not-found */ }
+if (!['allowed_a','allowed_b'].includes(row.status)) { /* invalid-state */ }
+const { error: updErr } = await supabase.from('t').update({...}).eq('id', x);
+if (updErr) { /* surface the real SQL error — typically a constraint violation */ }
+```
+
+**Apply when**: any UPDATE with two or more WHERE conditions beyond `eq('id', ...)`, or an enum-like new value.
+Cost: one extra SELECT. Benefit: correct error attribution and explicit guards.
+
+## When something goes wrong in production
+
+The bot's own log line is often generic, but the underlying `err`/`error.message` field usually carries the
+real Postgres error (`violates check constraint "X"`, `duplicate key value violates unique constraint "Y"`)
+that points straight at the fix. Query the logs for the reported window and read that field — don't speculate.

--- a/.claude/skills/pre-merge-checklist/reference/dispatch-wiring.md
+++ b/.claude/skills/pre-merge-checklist/reference/dispatch-wiring.md
@@ -1,0 +1,120 @@
+# Dispatch Wiring — Concrete Patterns
+
+WhatsApp delivers four distinct webhook shapes. Each ID your bot emits arrives through ONE of them, and
+only ONE handler branch can dispatch it. Before merging, verify every emitted ID is matched by a dispatcher.
+
+## The four webhook shapes
+
+### 1. Free-message interactive button
+
+**Webhook**: `messageType === 'interactive'`, `interactive.type === 'button_reply'`, `id` = your string.
+
+```js
+// emit
+await WhatsAppService.sendInteractiveButtons(phone, {
+  body: '...',
+  buttons: [
+    { id: 'my_feature_yes_<ctx>', title: 'Yes' },
+    { id: 'my_feature_no_<ctx>',  title: 'No' },
+  ],
+});
+
+// receive — whatsapp-bot.js button_reply branch
+} else if (messageType === 'interactive' && message.interactive?.type === 'button_reply') {
+  const buttonId = message.interactive.button_reply.id;
+  if (buttonId.startsWith('my_feature_')) { /* dispatch */ }
+  else { logToFile('⚠️ Unknown button ID', { buttonId }); }
+}
+```
+
+### 2. Free-message interactive list row
+
+**Webhook**: `messageType === 'interactive'`, `interactive.type === 'list_reply'`, `id` = your string.
+
+```js
+// emit
+await WhatsAppService.sendInteractiveMessage(phone, {
+  body: '...',
+  action: { button: 'Pick one', sections: [{ title: 'Options', rows: [
+    { id: 'my_feature_pick_<itemId>', title: 'Item' },
+  ]}]},
+});
+
+// receive — whatsapp-bot.js list_reply branch
+} else if (messageType === 'interactive' && message.interactive?.type === 'list_reply') {
+  const listId = message.interactive.list_reply.id;
+  if (listId.startsWith('my_feature_pick_')) { /* dispatch */ }
+  else { logToFile('⚠️ Unknown list item ID', { listId }); }
+}
+```
+
+### 3. Template quick-reply button
+
+**Webhook**: `messageType === 'button'`, `button.text` = the button label, `button.payload` empty unless set
+in the template definition. Templates don't carry a custom `id` — **match by `button.text`** (include every
+language string), or by `button.payload` if you set one.
+
+```js
+// receive — whatsapp-bot.js button (template) branch
+} else if (messageType === 'button' && message.button) {
+  const buttonText = message.button.text;
+  if (buttonText && /^(My Feature Action|<other-language label>)$/i.test(buttonText.trim())) {
+    /* dispatch — match by TEXT since most templates don't set a payload */
+  }
+}
+```
+
+### 4. Free text
+
+**Webhook**: `messageType === 'text'`, `text.body` = whatever the user typed (e.g. `A`/`B`/`STOP` instead of
+tapping). Intercept it in `text-message.handler.js` **before the registration gate** if the recipient may be
+an unregistered user (parents, students), so they aren't forced through onboarding:
+
+```js
+// EARLY intercept — before the registration gate
+if (messageBody) {
+  try {
+    const MyService = require('../services/my-feature/my-service');
+    const state = await MyService.getActiveState(from);
+    if (state) {
+      const t = messageBody.trim();
+      if (/^[ABC]$/i.test(t) && state.currentQuestionId) { await MyService.handleAnswer(from, t, state); return; }
+      if (t.toUpperCase() === 'STOP') { await MyService.endSession(from, state, 'incomplete'); return; }
+      await WhatsAppService.sendMessage(from, '❓ Type A, B, or C — or STOP to exit.'); return;
+    }
+  } catch (e) { /* non-fatal — fall through */ }
+}
+```
+
+## Whole-feature wiring checklist
+
+For a feature emitting IDs across several shapes (invite buttons → answer buttons → text answers):
+
+```bash
+# 1. List every ID the service emits
+grep -rEn "id:\s*['\"]?(\$\{)?[a-z_]+" --include="*.js" bot/shared/services/<feature>/ | sort -u
+# 2. Each prefix must turn up a dispatcher:
+grep -n "your_prefix" bot/whatsapp-bot.js                               # button_reply / list_reply / template
+grep -n "your_prefix\|state.currentQuestionId" bot/shared/handlers/text-message.handler.js  # text intercept
+grep -n "your_flow_id" bot/shared/utils/flow-type-detector.js          # if you added a Flow
+grep -n "your_flow_id" bot/shared/handlers/flow-response.handler.js    # if you added a Flow
+```
+
+Any prefix with a service-side emit but no receiver-side dispatcher is an orphan that no-ops in production.
+
+## Lock it in with a mock-free test
+
+```js
+describe('My feature dispatch contract', () => {
+  test('my_feature_start has a button_reply dispatcher', () => {
+    const src = fs.readFileSync('bot/whatsapp-bot.js', 'utf8');
+    expect(src).toMatch(/buttonId === ['"]my_feature_start['"]/);
+  });
+  test('my_feature_pick_* has a list_reply dispatcher', () => {
+    const src = fs.readFileSync('bot/whatsapp-bot.js', 'utf8');
+    expect(src).toMatch(/listId\.startsWith\(['"]my_feature_pick_['"]\)/);
+  });
+});
+```
+
+These just grep the source — cheap, fast, and they catch the orphan-dispatch class entirely.

--- a/.claude/skills/reading-assessment/SKILL.md
+++ b/.claude/skills/reading-assessment/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: reading-assessment
+description: Oral-reading-fluency assessment (EGRA/ASER-style) — the passage→record→transcribe→score pipeline, WCPM benchmarks, multilingual rules, and debugging.
+---
+
+# Reading Assessment Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [coaching](../coaching/SKILL.md), [debugging](../debugging/SKILL.md)
+
+A teacher runs a student through a short oral-reading assessment: the bot generates a passage, the student
+reads it aloud, and the bot transcribes the audio, scores fluency against grade benchmarks, and returns a
+report with voice feedback.
+
+## Quick Reference
+
+- **Orchestration**: [bot/shared/services/reading-assessment.service.js](../../../bot/shared/services/reading-assessment.service.js).
+- **Pipeline stages**: [bot/shared/services/reading/](../../../bot/shared/services/reading/) — `passage-generation`, `transcription`, `pronunciation`, `fluency`, `analysis`, `comprehension`, `report`, `voice-feedback`.
+- **Report template**: [bot/shared/templates/reading-report.template.js](../../../bot/shared/templates/reading-report.template.js).
+- **Entry**: a `/reading` command routed through [bot/shared/handlers/text-message.handler.js](../../../bot/shared/handlers/text-message.handler.js).
+
+## Domain Knowledge
+
+### Methodology
+
+EGRA/ASER-style **Oral Reading Fluency (ORF)** assessment. Primary metric is **WCPM** (Words Correct Per
+Minute); alphabet assessments use **LCPM** (Letters Correct Per Minute). Passage types scale by difficulty:
+letters → words → sentences → paragraphs → story.
+
+### The pipeline
+
+1. Teacher submits student details (name, grade, language, mode) via a Flow, then picks reading level + scope.
+2. A passage is generated for the target level by [reading/passage-generation.service.js](../../../bot/shared/services/reading/passage-generation.service.js) (LLM, with diversity controls so passages don't repeat).
+3. A reading grid PDF is produced.
+4. Student records → audio transcribed in [reading/transcription.service.js](../../../bot/shared/services/reading/transcription.service.js).
+5. (English) pronunciation scored in [reading/pronunciation.service.js](../../../bot/shared/services/reading/pronunciation.service.js); other languages fall back to LLM analysis.
+6. Levenshtein alignment of transcript vs passage → error detection → WCPM.
+7. WCPM compared to benchmarks in [reading/analysis.service.js](../../../bot/shared/services/reading/analysis.service.js) (`compareToBenchmarks` → the `check_benchmark_status` RPC) → report + voice feedback.
+
+### `grade_level`
+
+`grade_level` is the difficulty proxy (0 = letters … up to story) and drives both passage generation and the
+benchmark lookup. The benchmark RPC `check_benchmark_status(p_wcpm, p_grade, p_language, p_is_l2)` returns
+`(benchmark_min, benchmark_max, on_track, percentile_rank)`, reading from the `wcpm_percentiles` table
+(25th percentile = min, 75th = max; season auto-derived from the current month).
+
+### Assessment-language rule
+
+Once the teacher picks the assessment language, **every** bot-generated string for the rest of that
+assessment must be in *that* language — not the user's stored `preferred_language`. The welcome message
+before the pick still uses the user's language. Pin each prompt with an explicit
+`MUST be written entirely in language code "${lang}"`, because the model otherwise drifts back to the
+default. (Comprehension answers are preserved verbatim for non-English; the report renderer handles RTL +
+Nastaliq natively.)
+
+### Language support
+
+| Language | Pronunciation scoring | Benchmarks |
+|----------|----------------------|------------|
+| English | Full (provider-based) | Hasbrouck-Tindal ORF norms |
+| Urdu | LLM fallback (no provider scoring) | L2-adjusted (~70% of EN; recalibrate after enough production data) |
+| Arabic | LLM fallback, RTL | L2-adjusted |
+| Others | LLM fallback | extrapolated |
+
+RTL languages (Urdu/Arabic) render grids right-to-left with reversed letter order and direction indicators.
+
+### Benchmark labels (EGRA convention)
+
+| Comprehension score | Label |
+|---------------------|-------|
+| ≥ 80% | On Track |
+| 60–79% | Approaching Benchmark |
+| < 60% | Needs Support |
+
+Performance tiers off the fluency percentile: ≥75 Excellent · on-track & ≥50 Proficient · on-track
+Developing · else Emerging — applied identically in the HTML template and the legacy renderer so both look
+consistent.
+
+## Common Issues & Solutions
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Voice feedback has nonsensical corrections | Transcript not cleaned (diarization labels left in) | Clean the transcript before word alignment. |
+| Only one comprehension question asked | Voice routing priority wrong (reading handler before comprehension) | Check routing order in [voice-message.handler.js](../../../bot/shared/handlers/voice-message.handler.js). |
+| Repetitive passages | No diversity controls in the prompt | Use the theme/name/avoid arrays in passage generation. |
+| Wrong benchmark | Grade/language/L2 args mismatched | Confirm the `check_benchmark_status` args; trace the correlation id — see [debugging](../debugging/SKILL.md). |
+
+## Example — WCPM
+
+```js
+const correctWords = passageWords.filter((w, i) =>
+  transcriptWords[i]?.toLowerCase() === w.toLowerCase()).length;
+const wcpm = (correctWords / (durationSeconds / 60)).toFixed(1);
+```
+
+## Related Skills
+
+- [coaching](../coaching/SKILL.md) — shares the LLM-analysis + report-generation patterns.
+- [debugging](../debugging/SKILL.md) — investigate a stuck or wrong assessment by correlation id.

--- a/.claude/skills/whatsapp-flows/SKILL.md
+++ b/.claude/skills/whatsapp-flows/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: whatsapp-flows
+description: Build and manage WhatsApp Flows — endpoint data exchange, form pre-fill, DRAFT vs PUBLISHED, the Meta publish lifecycle, and the three wiring points a new Flow needs.
+---
+
+# WhatsApp Flows Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [registration](../registration/SKILL.md), [debugging](../debugging/SKILL.md)
+
+WhatsApp Flows are interactive forms rendered inside WhatsApp. The bot drives them through a webhook
+**endpoint** (data exchange) and registers/publishes the Flow JSON via the Meta Graph API. These rules are
+the hard-won ones — get any wrong and the Flow fails silently with "Something went wrong".
+
+## Critical rules
+
+### 1. NEVER include a `version` field in the endpoint response
+
+```js
+return { screen: 'NEXT_SCREEN', data: { field1: 'value1' } };          // CORRECT
+return { version: '3.0', screen: 'NEXT_SCREEN', data: { ... } };       // WRONG — silent failure
+```
+
+### 2. DRAFT flows do NOT reliably apply init-values — publish before testing pre-fill
+
+| Status | init-values | Can edit JSON? |
+|--------|-------------|----------------|
+| DRAFT | unreliable | yes |
+| PUBLISHED | works | **no — irreversible** |
+
+Publishing is irreversible; to change a published Flow's JSON, create a **new** Flow.
+
+### 3. Flow token MUST be the user id (not auto-generated)
+
+```js
+await WhatsAppService.sendFlow(from, { flowId: FLOW_ID, flowToken: user.id });   // CORRECT
+await WhatsAppService.sendFlow(from, { flowId: FLOW_ID });                       // WRONG — useless "flow_123..." token
+```
+
+### 4. Use Form-level `init-values`, not component-level `init-value`
+
+Component-level `init-value` on a `TextInput` inside a `Form` is not supported by Meta. Always bind at the
+Form level with an object literal.
+
+### 5. Every returned field MUST be declared in the screen's `data` object
+
+If `${data.xxx}` renders as literal text, the field is missing from that screen's `data` declaration.
+
+### 6. Edit-then-REPUBLISH — a local JSON change does NOT update Meta
+
+Editing the Flow JSON on disk does **not** update Meta. Meta keeps serving the previously-published JSON
+until you re-run the Flow registration script (and the Flow is in that script's list). When you add a new
+Flow, add it to the registration script too.
+
+### 7. `routing_model` is FORWARD-ONLY
+
+Meta rejects publish (`INVALID_ROUTING_MODEL`) if `routing_model` declares any backward route. Instead,
+re-fetch state on the destination screen, or accept "one edit per visit" and re-enter the Flow.
+
+### 8. `data_exchange` has a ~10s timeout — long work goes async
+
+Meta times the endpoint out at ~10s. LLM generation, uploads, slow third-party calls **must** be kicked off
+via `setImmediate` *after* returning SUCCESS; the user gets a chat confirmation a few seconds later.
+
+```js
+async function handleCompleteAction(userId, payload) {
+  setImmediate(async () => { await SomeService.doExpensiveWork(userId, payload); }); // ~30s
+  return { screen: 'SUCCESS', data: { success_message: 'Working on it…', extension_message_response: { params: {} } } };
+}
+```
+
+### 9. The endpoint health-check blocks publish
+
+Meta probes the endpoint URL before allowing publish; if it isn't deployed yet, publish fails with
+`error_subcode: 4233014` ("Endpoint not available"). **Order: commit + push → wait for deploy → publish.**
+
+### 10. A NEW Flow ID requires THREE wiring points
+
+Without all three, submissions fall through to the generic unknown-flow reply:
+
+1. [bot/shared/utils/flow-type-detector.js](../../../bot/shared/utils/flow-type-detector.js) — recognise the submission shape (cleanest: tag it in `extension_message_response.params` and detect by that field).
+2. [bot/whatsapp-bot.js](../../../bot/whatsapp-bot.js) — a handler branch in the `nfm_reply` switch (alongside the existing flow-type branches).
+3. [bot/shared/handlers/flow-response.handler.js](../../../bot/shared/handlers/flow-response.handler.js) — at minimum a no-op return.
+
+### 11. Contextual chat ack after submit
+
+Don't bounce the user to "Type /menu". Tag the action in `extension_message_response.params` and dispatch a
+contextual ack from the `nfm_reply` branch.
+
+## Endpoint response formats
+
+```js
+return { screen: 'NEXT_SCREEN', data: { field1: 'value1' } };                  // navigate
+return { data: { error: { message: 'User-friendly error' } } };                // error
+return { screen: 'SUCCESS', data: { extension_message_response: { params: { flow_token: flowToken } } } }; // complete
+```
+
+## Common errors
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| "Something went wrong" | `version` field in response | Remove it |
+| `${data.xxx}` literal text | Field not in screen `data` | Add it |
+| Dropdown blank | Dynamic data-source issue | Use an inline static data-source |
+| init-values not applying | Flow is DRAFT | Publish it |
+| "loop detected in routing" | Screen routes to itself | Remove the self-reference |
+
+## Debugging checklist
+
+1. Check the bot's logs — the real error is there, not in the WhatsApp UI (see [debugging](../debugging/SKILL.md)).
+2. No `version` field in the response.
+3. All returned fields declared in the screen `data`.
+4. `flow_token` is the user id.
+5. Flow is PUBLISHED if testing init-values.
+6. Re-publish after any Flow JSON change.
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| [reference/flow-schemas.md](reference/flow-schemas.md) | Flow JSON structure, screen schema, data binding, looping screens, init-values component support |
+| [reference/publishing-guide.md](reference/publishing-guide.md) | Meta Graph API commands (publish/list/download), sending flows (data_exchange vs navigate), action handling, testing patterns |
+
+## Related Skills
+
+- [registration](../registration/SKILL.md) — the Registration Flow is the canonical example of these rules.
+- [debugging](../debugging/SKILL.md) — where the real Flow error surfaces.

--- a/.claude/skills/whatsapp-flows/reference/flow-schemas.md
+++ b/.claude/skills/whatsapp-flows/reference/flow-schemas.md
@@ -1,0 +1,120 @@
+# WhatsApp Flows — Schema Reference
+
+## Flow JSON top-level structure
+
+```json
+{
+  "version": "6.3",
+  "data_api_version": "3.0",
+  "routing_model": {
+    "SCREEN_A": ["SCREEN_B", "SCREEN_C"],
+    "SCREEN_B": ["SUCCESS"],
+    "SCREEN_C": ["SUCCESS"],
+    "SUCCESS": []
+  },
+  "screens": []
+}
+```
+
+## Screen structure
+
+```json
+{
+  "id": "SCREEN_NAME",
+  "title": "Display Title",
+  "terminal": false,
+  "refresh_on_back": true,
+  "data": {
+    "field_name":   { "type": "string", "__example__": "example value" },
+    "numeric_field":{ "type": "number", "__example__": 42 },
+    "array_field": {
+      "type": "array",
+      "items": { "type": "object", "properties": {
+        "id":    { "type": "string" },
+        "title": { "type": "string" }
+      } },
+      "__example__": [{ "id": "1", "title": "Item 1" }]
+    }
+  },
+  "layout": {}
+}
+```
+
+## Data binding rules
+
+Every field your endpoint returns MUST be declared in the screen's `data` object.
+
+```json
+{ "type": "TextHeading", "text": "Students in ${data.class_display}" }
+```
+
+If `${data.xxx}` shows as literal text, check:
+1. the field is declared in the screen's `data` object;
+2. the endpoint response includes the field;
+3. the data types match the declaration;
+4. there is no `version` field in the endpoint response.
+
+## Looping screens
+
+For a screen that returns to itself (e.g. adding multiple items):
+
+```json
+{
+  "id": "ADD_ITEM",
+  "refresh_on_back": true,
+  "data": {
+    "item_count":  { "type": "number", "__example__": 0 },
+    "items_added": { "type": "array", "items": {}, "__example__": [] }
+  }
+}
+```
+
+- `routing_model` must NOT include the self-loop: use `"ADD_ITEM": ["SUCCESS"]`, not `["ADD_ITEM", "SUCCESS"]`.
+- The screen CAN navigate to itself via `data_exchange`, just not in `routing_model`.
+- The endpoint response for the loop must include ALL declared fields:
+
+```js
+return { screen: 'ADD_ITEM', data: { item_count: newCount, items_added: updatedList } };
+```
+
+## Form init-values (pre-filling fields)
+
+Form-level `init-values` pre-selects/pre-fills form children. Keys must match each child component's `name`.
+
+```json
+{
+  "type": "Form",
+  "name": "settings_form",
+  "init-values": {
+    "language":  "${data.current_language}",
+    "framework": "${data.current_framework}"
+  },
+  "children": [
+    { "type": "Dropdown", "name": "language",  "data-source": "${data.languages}" },
+    { "type": "Dropdown", "name": "framework", "data-source": "${data.frameworks}" }
+  ]
+}
+```
+
+| Component | init-values works? | Notes |
+|-----------|-------------------|-------|
+| Dropdown | yes | pre-selects matching id |
+| RadioButtonsGroup | yes | pre-selects matching option |
+| CheckboxGroup | yes | pre-checks matching options |
+| TextInput | yes | MUST use Form-level init-values |
+| TextArea | likely | treat like TextInput |
+
+**Component-level `init-value` on a TextInput inside a Form is NOT supported — always use Form-level
+`init-values`.** Each pre-fill value needs its own `data` declaration on the screen.
+
+## Errors history (common root causes)
+
+| Error | Root cause | Fix |
+|-------|-----------|-----|
+| "Something went wrong" | `version` field in response | Remove the version field |
+| Dropdown blank | dynamic data-source not resolving | Use an inline static data-source |
+| `${data.xxx}` literal | field not declared in screen `data` | Add it to the screen's `data` object |
+| UUID invalid syntax | `flow_token` auto-generated | Pass `flowToken: user.id` |
+| Loop in `routing_model` | self-reference in routing | Remove the self-loop |
+| Duplicate key constraint | creating an existing record | Check existence before insert |
+| init-values not applying | Flow is DRAFT | Publish the Flow |

--- a/.claude/skills/whatsapp-flows/reference/publishing-guide.md
+++ b/.claude/skills/whatsapp-flows/reference/publishing-guide.md
@@ -1,0 +1,112 @@
+# WhatsApp Flows — Publishing & API Management
+
+All commands use the Meta Graph API. `$TOKEN` is your WhatsApp access token, `$WABA_ID` your WhatsApp
+Business Account id, `$FLOW_ID` the Flow's id — all from env, never inline.
+
+## Upload / register a Flow's JSON
+
+Register the Flow JSON through the bot's registration script (it reads the local Flow configs and pushes
+them to your WABA). Re-run it after **any** local JSON change — editing the file alone does not update Meta.
+
+## Publish a Flow (IRREVERSIBLE)
+
+```bash
+curl -X POST "https://graph.facebook.com/v18.0/$FLOW_ID/publish" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+After publishing, the JSON can no longer be edited — create a new Flow if you need changes.
+
+## Check Flow status
+
+```bash
+curl "https://graph.facebook.com/v18.0/$FLOW_ID?fields=name,status" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## Download the current Flow JSON from Meta
+
+```bash
+curl "https://graph.facebook.com/v18.0/$FLOW_ID/assets" \
+  -H "Authorization: Bearer $TOKEN"
+# then GET the returned download_url
+```
+
+## List all Flows on the WABA
+
+```bash
+curl "https://graph.facebook.com/v18.0/$WABA_ID/flows" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## Sending a Flow from code
+
+### data_exchange mode (endpoint-driven)
+
+```js
+// No screen param → data_exchange mode (the endpoint handles INIT)
+await WhatsAppService.sendFlow(phone, {
+  flowId: FLOW_ID,
+  flowToken: `${userId}:flowtype:${Date.now()}`,
+  header: 'Flow Title',
+  body: 'Description text',
+  buttonText: 'Open',
+});
+```
+
+### navigate mode (static, pre-fill on first screen)
+
+```js
+// screen param → navigate mode (pre-fills ONLY the first screen)
+await WhatsAppService.sendFlow(phone, {
+  flowId: FLOW_ID,
+  flowToken: `${userId}:flowtype:${Date.now()}`,
+  screen: 'FIRST_SCREEN',
+  navigateData: { field1: 'value1' },
+  header: 'Flow Title',
+  body: 'Description text',
+  buttonText: 'Open',
+});
+```
+
+For endpoint-based flows, prefer data_exchange + INIT pre-fill over navigate mode.
+
+## Endpoint action handling
+
+```js
+if (action === 'INIT')          return { screen: 'FIRST_SCREEN', data: {} };
+if (action === 'data_exchange') return { screen: 'NEXT_SCREEN', data: {} }; // validate + save first
+if (action === 'BACK')          return { screen: 'PREVIOUS_SCREEN', data: {} };
+if (action === 'ping')          return { data: { status: 'active' } };
+```
+
+## Flow token best practice
+
+```js
+await WhatsAppService.sendFlow(from, { flowId: FLOW_ID, flowToken: user.id }); // CORRECT
+// parse in the endpoint:
+const userId = (flow_token || '').split(':')[0];
+```
+
+## Testing
+
+```js
+it('returns a screen with no version field', async () => {
+  const result = await handleSetupInit('user-123');
+  expect(result.version).toBeUndefined();   // CRITICAL
+  expect(result.screen).toBe('CLASS_INFO');
+  expect(result.data).toBeDefined();
+});
+
+it('returns all declared data fields', async () => {
+  const result = await handleAddItem(/* ... */);
+  expect(result.data.list_id).toBeDefined();
+  expect(result.data.item_count).toBeDefined();
+});
+```
+
+## External references
+
+- [Meta — WhatsApp Flows](https://developers.facebook.com/docs/whatsapp/flows)
+- [Meta — Flow JSON reference](https://developers.facebook.com/docs/whatsapp/flows/reference/flowjson)
+- [Meta — Flows data-exchange endpoint](https://developers.facebook.com/docs/whatsapp/flows/guides/implementingyourflowendpoint)


### PR DESCRIPTION
## What

Second operational-core skill-port batch (Phase 7). Four skills + four reference files, hand-authored OSS-generic and hand-wired into the 7B hub web.

| Skill | Notes |
|-------|-------|
| `reading-assessment` | ORF/WCPM pipeline, benchmark RPC, multilingual + RTL. Grounded in the **shipped** single-`grade_level` model (not the prod two-key `child_grade` model OSS doesn't have). |
| `whatsapp-flows` | The 11 hard Flow rules + 2 reference files. Stripped the leaky Flow-inventory/WABA/phone table; publishing-guide points at Meta's public docs. |
| `cross-agent-safety` | Generic shared-service edit checklist; high-blast-radius table repointed to real OSS paths; `npm test`. |
| `pre-merge-checklist` | Portable bug classes (orphan dispatch, Flow gotchas, DB CHECK/unique-index/format, Supabase JS chain, JS short-circuit ternary, clone-toxic symlinks) + 2 reference files. |

## Linking (per the Link Map)

- All four up-link to `.claude/CLAUDE.md` and cross-link only to already-ported skills.
- `pre-merge-checklist` **strips** the `notion-board` and `staging-to-production` links (both DROPPED skills).
- Back-link added: `debugging` now lists `reading-assessment`.
- The `logging` cross-link (pre-merge) lands in 7E when that skill is ported.

## Safety

- Leak-grepped: no phones / tokens / names / org refs / ticket IDs / pooler host / analyst role / Axiom tokens. Genericised two illustrative `+92…` → `+<countrycode>…`.
- All relative links resolve (manually verified — link-integrity guard is 7-final).
- Full suite green: **82 suites / 1077 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)