### PR TITLE
Phase 7D: skill ports (database-analysis, qa-testing, video-generation, ab-testing)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,11 +25,14 @@ folder with a `SKILL.md` (+ optional reference files).
 | [whatsapp-flows](skills/whatsapp-flows/SKILL.md) | Building & publishing WhatsApp Flows (endpoint data exchange, the publish lifecycle) |
 | [cross-agent-safety](skills/cross-agent-safety/SKILL.md) | Safety checklist before editing shared services/workers |
 | [pre-merge-checklist](skills/pre-merge-checklist/SKILL.md) | Defensive pre-flight checks for recurring bug classes |
+| [database-analysis](skills/database-analysis/SKILL.md) | Read-only analyst guide: connection, query patterns, anti-sprawl |
+| [qa-testing](skills/qa-testing/SKILL.md) | Test runner, conformance guards, the route-contract pattern |
+| [video-generation](skills/video-generation/SKILL.md) | The educational-video pipeline, presigned-URL gotcha, checkpoint/resume |
+| [ab-testing](skills/ab-testing/SKILL.md) | Thompson-sampling multi-armed bandit (ab_tests tables) |
 
 > **More skills are being ported from the production bot in batches** (operational core still pending:
-> qa-testing, video-generation, feature-tracer, database-analysis, logging, ab-testing). Each is
-> hand-reviewed and stripped of any internal/credential content before it lands — CI (gitleaks + the
-> source-hygiene guard) enforces that no secrets or internal references ship.
+> feature-tracer, logging). Each is hand-reviewed and stripped of any internal/credential content before it
+> lands — CI (gitleaks + the source-hygiene guard) enforces that no secrets or internal references ship.
 
 ## Rules for adding/editing skills here
 

--- a/.claude/skills/ab-testing/SKILL.md
+++ b/.claude/skills/ab-testing/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: ab-testing
+description: A/B testing via a Thompson-sampling multi-armed bandit. DB-driven tests (ab_tests / ab_test_variants / ab_test_events) that learn the best-performing variant online. Use when adding or measuring a message/content experiment.
+---
+
+# A/B Testing Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router)
+
+A/B testing here is a **multi-armed bandit** using Thompson sampling, not a fixed percentage split. Instead
+of hard-assigning 50/50, the bandit *learns*: it samples each variant in proportion to how well it's
+converting, so traffic shifts toward the winner over time while still exploring the others.
+
+## Core pieces
+
+- **Service**: [bot/shared/services/bandit.service.js](../../../bot/shared/services/bandit.service.js) — `BanditService`.
+- **Tables**: `ab_tests` (one row per test), `ab_test_variants` (the arms, each with `successes`/`failures` counts), `ab_test_events` (impressions/conversions log). Schema: [infrastructure/supabase/00_complete-schema.sql](../../../infrastructure/supabase/00_complete-schema.sql).
+
+## How it works
+
+1. Each **arm** is a variant (e.g. message phrasing A / B / C), tracked by a Beta(α, β) where α = successes + 1, β = failures + 1.
+2. `selectVariant(testName, language)` samples from each arm's Beta distribution and returns the highest sample — so better-converting arms are chosen more often, but every arm keeps a chance.
+3. You record the outcome: `recordImpression(...)` when shown, then `recordConversion(...)` or `recordNonConversion(...)`. These update the arm's `successes`/`failures`.
+4. `getTestStats(testName)` returns per-arm counts + a Wilson-score confidence interval for reporting.
+
+```js
+const BanditService = require('../services/bandit.service');
+
+// pick a variant for this user
+const choice = await BanditService.selectVariant('feature_suggestion_copy', user.preferred_language);
+if (choice) {
+  await BanditService.recordImpression(choice.testId, choice.variantName, user.id, phone);
+  await sendMessage(phone, BanditService.getLocalizedMessage(choice.content, user.preferred_language));
+  // later, when the user acts (or doesn't):
+  // await BanditService.recordConversion(choice.testId, choice.variantName, user.id, phone);
+}
+```
+
+`selectVariant` returns `null` when there's no **active** test of that name — always handle that (fall back
+to your default copy).
+
+## Creating a test
+
+Insert one `ab_tests` row (`test_name`, `status='active'`) and one `ab_test_variants` row per arm
+(`variant_name`, `variant_content` — a JSON object, optionally keyed by language). The bandit starts at
+α=β=1 for each arm (uniform) and adapts as events arrive. Set `status` to something other than `active` to
+stop a test (the bot then falls back to the default).
+
+```sql
+SELECT v.variant_name, v.successes, v.failures
+FROM ab_test_variants v JOIN ab_tests t ON v.test_id = t.id
+WHERE t.test_name = 'feature_suggestion_copy';
+```
+
+## Measuring
+
+Read `ab_test_events` (or `getTestStats`) for impressions and conversions per arm. Because the bandit
+shifts traffic toward the leader, don't expect equal sample sizes across arms — judge by **conversion
+rate** and the Wilson interval, not raw counts. Deterministic variant tests that just need an impression
+counter (e.g. an LP variant) can use the `increment_variant_impressions(test_id, variant_name)` RPC instead
+of the full bandit.

--- a/.claude/skills/database-analysis/SKILL.md
+++ b/.claude/skills/database-analysis/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: database-analysis
+description: Query the bot's Postgres database with a read-only role. Use when analysing user metrics, debugging DB state, or exploring the schema. Column names: phone_number (not phone), first_name (not name) in the users table.
+---
+
+# Database Analysis Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [coaching](../coaching/SKILL.md), [debugging](../debugging/SKILL.md), [registration](../registration/SKILL.md)
+
+The bot runs on Postgres (via Supabase by default). For analysis, connect with a **read-only** role — never
+the service role — so an exploratory query can't mutate production data.
+
+## Critical rules
+
+1. **Filter test users**: `WHERE COALESCE(is_test_user, false) = false`.
+2. **Column names in `users`**: `phone_number` (NOT `phone`), `first_name` (NOT `name`).
+3. **JOIN via UUID**: always join on `users.id` (UUID), never on phone number.
+4. **Read-only**: a read-only role returns "permission denied" on INSERT/UPDATE/DELETE — by design.
+5. **LIMIT first**: start with `LIMIT 100` before a full scan.
+6. **Schema-first when proposing changes (anti-sprawl)**: this schema is large and growing. Before proposing a new table/column, query the **live** schema (`information_schema.columns`, `pg_indexes`), and prove the change is minimal — can an existing table/column hold it (`app_settings` for config, `feature_suggestions` for nudge funnels), or can the value be **computed** by a query or materialized view? A new table/column is the last resort. (See root [CLAUDE.md](../../../CLAUDE.md).)
+
+## Connection
+
+Use a read-only connection string from the environment — never inline credentials.
+
+```bash
+psql "$ANALYST_DATABASE_URL"      # a read-only role; falls back to $DATABASE_URL if you only have one role
+```
+
+Prefer the **transaction pooler** (Supabase port 6543) for ad-hoc analysis — the session pooler (5432)
+holds a slot per connection and exhausts under multiple idle analysts. Use 5432 only when you need
+session-scoped state (prepared statements, temp tables, `SET`, `LISTEN`). For GUI clients set
+SSL = `require` (the pooler uses a self-signed cert; `verify-full` will fail). Close idle transactions
+promptly — a leaked `BEGIN` that idles pins the vacuum horizon and bloats tables.
+
+## Schema
+
+The canonical schema is a single file — read it rather than trusting a copy that can drift:
+[infrastructure/supabase/00_complete-schema.sql](../../../infrastructure/supabase/00_complete-schema.sql)
+(overview + how to bootstrap it: [infrastructure/CLAUDE.md](../../../infrastructure/CLAUDE.md)).
+
+Core tables you'll touch most:
+
+```
+users:              id (UUID), phone_number, first_name, last_name, school_name,
+                    registration_completed, is_test_user, preferred_language, created_at
+conversations:      id, user_id, session_id, role ('user'|'assistant'), content, language, created_at
+chat_sessions:      id, user_id, session_type, message_count, started_at, ended_at
+coaching_sessions:  id, user_id, status, audio_duration_seconds, analysis_data (JSONB), created_at
+reading_assessments:id, user_id, passage_type, language, grade_level, wcpm, benchmark_status, status
+lesson_plans:       id, user_id, topic, grade, type, created_at
+```
+
+## Analyst tips
+
+- **Timestamps are UTC** (`created_at` / `completed_at`).
+- **JSONB**: `->` for object, `->>` for text — e.g. `analysis_data->>'overall_score'`.
+- **Country from phone**: `LEFT(phone_number, 2)`.
+- **Slow query**: prefix `EXPLAIN ANALYZE`; bound by `created_at >= NOW() - INTERVAL '30 days'`; check indexes with `\di`.
+- If your deployment maintains **materialized views** (`mv_*`) for dashboards, prefer them — they're pre-computed; check their refresh status before trusting the numbers.
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| [reference/query-patterns.md](reference/query-patterns.md) | Ready-to-run SQL: user growth, DAU, feature usage, reading/coaching analysis, cohort retention, language distribution |
+
+## Related Skills
+
+- [coaching](../coaching/SKILL.md) · [registration](../registration/SKILL.md) — the features whose tables you'll query most.
+- [debugging](../debugging/SKILL.md) — when a metric looks wrong, trace the writing code by correlation id.

--- a/.claude/skills/database-analysis/reference/query-patterns.md
+++ b/.claude/skills/database-analysis/reference/query-patterns.md
@@ -1,0 +1,141 @@
+# Database Query Patterns
+
+All queries use a **read-only** role. Always filter `WHERE COALESCE(is_test_user, false) = false`.
+These run against the base tables; adapt table/column names to your deployment's schema
+([infrastructure/supabase/00_complete-schema.sql](../../../../infrastructure/supabase/00_complete-schema.sql)).
+
+## User growth & registration
+
+```sql
+-- Daily new users (last 30 days)
+SELECT DATE(created_at) AS day, COUNT(*) AS new_users,
+       COUNT(*) FILTER (WHERE registration_completed) AS registered
+FROM users
+WHERE created_at >= NOW() - INTERVAL '30 days'
+  AND COALESCE(is_test_user, false) = false
+GROUP BY DATE(created_at) ORDER BY day;
+
+-- Users by country (first two digits of the phone number)
+SELECT LEFT(phone_number, 2) AS country_code, COUNT(*) AS users
+FROM users
+WHERE COALESCE(is_test_user, false) = false
+GROUP BY LEFT(phone_number, 2) ORDER BY users DESC;
+```
+
+## Engagement & activity
+
+```sql
+-- Daily active users (last 30 days)
+SELECT DATE(c.created_at) AS day, COUNT(DISTINCT c.user_id) AS dau
+FROM conversations c
+JOIN users u ON c.user_id = u.id
+WHERE c.created_at >= NOW() - INTERVAL '30 days'
+  AND c.role = 'user'
+  AND COALESCE(u.is_test_user, false) = false
+GROUP BY DATE(c.created_at) ORDER BY day;
+
+-- Session length distribution
+SELECT CASE
+    WHEN message_count <= 2 THEN '1-2 msgs'
+    WHEN message_count <= 5 THEN '3-5 msgs'
+    WHEN message_count <= 10 THEN '6-10 msgs'
+    WHEN message_count <= 20 THEN '11-20 msgs'
+    ELSE '20+ msgs' END AS bucket,
+  COUNT(*) AS sessions
+FROM chat_sessions
+WHERE created_at >= NOW() - INTERVAL '30 days'
+GROUP BY 1 ORDER BY MIN(message_count);
+```
+
+## Feature usage
+
+```sql
+-- Feature usage summary (last 30 days). Adjust the UNION arms to the features your deployment runs.
+SELECT 'Lesson Plans' AS feature, COUNT(*) AS count
+FROM lesson_plan_requests
+WHERE created_at >= NOW() - INTERVAL '30 days' AND status = 'completed'
+UNION ALL
+SELECT 'Coaching', COUNT(*) FROM coaching_sessions
+WHERE created_at >= NOW() - INTERVAL '30 days' AND status = 'completed'
+UNION ALL
+SELECT 'Reading Assessments', COUNT(*) FROM reading_assessments
+WHERE created_at >= NOW() - INTERVAL '30 days' AND status = 'completed'
+ORDER BY count DESC;
+
+-- Feature adoption per user
+SELECT u.id, u.first_name, u.school_name,
+  (SELECT COUNT(*) FROM lesson_plan_requests lpr WHERE lpr.user_id = u.id) AS lesson_plans,
+  (SELECT COUNT(*) FROM coaching_sessions cs WHERE cs.user_id = u.id) AS coaching,
+  (SELECT COUNT(*) FROM reading_assessments ra WHERE ra.user_id = u.id) AS reading
+FROM users u
+WHERE u.registration_completed = true
+  AND COALESCE(u.is_test_user, false) = false
+ORDER BY lesson_plans + coaching + reading DESC
+LIMIT 50;
+```
+
+## Reading assessment analysis
+
+```sql
+-- WCPM distribution by grade and language
+SELECT language, grade_level, passage_type,
+       COUNT(*) AS assessments,
+       ROUND(AVG(wcpm), 1) AS avg_wcpm,
+       ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY wcpm), 1) AS median_wcpm
+FROM reading_assessments
+WHERE status = 'completed' AND wcpm IS NOT NULL
+GROUP BY language, grade_level, passage_type
+ORDER BY language, grade_level;
+```
+
+## Coaching analysis
+
+```sql
+-- Completion rate
+SELECT status, COUNT(*) AS count,
+       ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER(), 1) AS pct
+FROM coaching_sessions
+GROUP BY status ORDER BY count DESC;
+
+-- Average session duration
+SELECT ROUND(AVG(audio_duration_seconds) / 60.0, 1) AS avg_minutes
+FROM coaching_sessions
+WHERE status = 'completed' AND audio_duration_seconds > 0;
+```
+
+## Retention cohort (base tables, no MV required)
+
+```sql
+WITH user_cohorts AS (
+  SELECT id, DATE_TRUNC('week', created_at)::date AS cohort_week
+  FROM users WHERE COALESCE(is_test_user, false) = false
+),
+weekly_activity AS (
+  SELECT DISTINCT c.user_id, DATE_TRUNC('week', c.created_at)::date AS active_week
+  FROM conversations c WHERE c.role = 'user'
+)
+SELECT uc.cohort_week,
+       COUNT(DISTINCT uc.id) AS cohort_size,
+       COUNT(DISTINCT CASE WHEN wa.active_week = uc.cohort_week      THEN uc.id END) AS week0,
+       COUNT(DISTINCT CASE WHEN wa.active_week = uc.cohort_week + 7  THEN uc.id END) AS week1,
+       COUNT(DISTINCT CASE WHEN wa.active_week = uc.cohort_week + 14 THEN uc.id END) AS week2
+FROM user_cohorts uc
+LEFT JOIN weekly_activity wa ON wa.user_id = uc.id
+GROUP BY uc.cohort_week ORDER BY uc.cohort_week DESC LIMIT 12;
+```
+
+## Language distribution
+
+```sql
+SELECT preferred_language, COUNT(*) AS users,
+       ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER(), 1) AS pct
+FROM users
+WHERE COALESCE(is_test_user, false) = false
+GROUP BY preferred_language ORDER BY users DESC;
+```
+
+## Troubleshooting
+
+- **"permission denied for table X" on SELECT**: your role lacks read grants on that table — grant `SELECT` to the read-only role, or use a role that has it.
+- **Materialized views show stale data**: they refresh on a schedule, not live — check your deployment's refresh status before trusting them.
+- **Slow queries**: bound by `created_at >= NOW() - INTERVAL '30 days'`, use `LIMIT`, prefer materialized views, and check indexes with `\di`.

--- a/.claude/skills/qa-testing/SKILL.md
+++ b/.claude/skills/qa-testing/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: qa-testing
+description: How testing works in this repo — the test runner, the domain-organised jest suites, the conformance guards that lock the schema/docs/source contracts, and the route-contract pattern for catching orphan dispatch. Use before adding tests or diagnosing CI.
+---
+
+# QA Testing Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [coaching](../coaching/SKILL.md), [registration](../registration/SKILL.md)
+
+Tests are plain **jest**, organised by domain, run through a small wrapper. CI runs the full suite on a Node
+version matrix on every PR. Green suite is the merge gate.
+
+## Running tests
+
+Always go through the wrapper — **not** `npx jest` directly (newer Node needs a `--localstorage-file` flag
+that the wrapper supplies; calling jest raw hits a `SecurityError`):
+
+```bash
+npm test                 # full suite → node tests/run.js
+npm run test:security    # one slice (sprint-0)
+npm run test:schema      # schema guards (sprint-2)
+npm run test:setup       # setup/onboarding (sprint-3)
+npm run test:docs        # doc conformance (sprint-4)
+npm test -- --testPathPattern=coaching   # one domain
+```
+
+[tests/run.js](../../../tests/run.js) resolves the jest binary and adds the Node-compatibility flags.
+
+## Layout
+
+```
+tests/
+  setup/            conformance guards (schema, columns, source hygiene, …)
+  unit/sprint-N/    sprint-scoped unit tests
+  coaching/ quiz/ registration/ reading-assessment/ … one folder per feature domain
+  __mocks__/ fixtures/   shared test doubles
+```
+
+Tests `require('../../bot/shared/…')` the real bot code. **Important for CI**: the root suite runs *before*
+the bot's own `npm ci`, so a test that loads bot code must virtually-mock any bot-only dependency:
+
+```js
+jest.doMock('some-bot-only-package', () => ({ /* stub */ }), { virtual: true });
+```
+
+## Conformance guards (the contract layer)
+
+The most valuable suites aren't feature tests — they're guards in [tests/setup/](../../../tests/setup/) that
+keep the repo clone-safe and self-consistent. They fail the build the moment a contract drifts:
+
+| Guard | Asserts |
+|-------|---------|
+| `schema-completeness` | every table the bot `.from()`s exists in the schema file |
+| `column-completeness` | every column the bot reads/writes exists (top-level insert/select keys) |
+| `table-usage-conformance` | every `CREATE TABLE` is actually referenced somewhere (no orphan tables) |
+| `source-hygiene` | no internal ticket refs / no leaked internal context in source + agent docs; entry-point files pass `node --check` |
+| `schema-production-parity` | the consolidated schema stays consistent |
+| `env-template-completeness` / `setup-validator` / `validate-flows` | the clone/setup contract holds |
+
+When you add a table, column, flow, or skill, the matching guard tells you what you forgot — read its
+failure message before "fixing the test".
+
+## The route-contract pattern (catch orphan dispatch)
+
+Service-layer unit tests mock the receivers, so they **cannot** catch an interactive ID that nothing
+dispatches. The cheap, mock-free fix is a test that greps the entry file and asserts the dispatcher exists:
+
+```js
+test('my_feature_start has a button_reply dispatcher', () => {
+  const src = fs.readFileSync('bot/whatsapp-bot.js', 'utf8');
+  expect(src).toMatch(/buttonId === ['"]my_feature_start['"]/);
+});
+```
+
+Add one of these for every new button / list / Flow id you emit. The full rationale + the four webhook
+shapes is in [pre-merge-checklist](../pre-merge-checklist/SKILL.md).
+
+## When to run what
+
+| Situation | Run |
+|-----------|-----|
+| Editing a handler/service | `npm test -- --testPathPattern=<domain>` then the full suite before pushing |
+| Adding a table/column/flow/skill | the relevant `tests/setup/` guard, then `npm test` |
+| Before any push | `npm test` (the whole suite — it's fast) |
+| Editing a shared service | full suite + the checks in [cross-agent-safety](../cross-agent-safety/SKILL.md) |
+
+## Optional: generative / persona testing
+
+Beyond deterministic suites, a deployment can add an LLM-driven layer — "persona" agents that walk
+multi-feature journeys via simulated webhooks, and a judge model that scores the replies — to surface
+unknown-unknowns before release. That's an advanced add-on, not part of the base suite; build it as its own
+opt-in test path (gated behind an env flag so it doesn't run in normal CI).
+
+## Related Skills
+
+- [coaching](../coaching/SKILL.md) · [registration](../registration/SKILL.md) — domains with rich test suites to model new tests on.
+- [pre-merge-checklist](../pre-merge-checklist/SKILL.md) — the bug classes the guards and route-contracts defend against.

--- a/.claude/skills/video-generation/SKILL.md
+++ b/.claude/skills/video-generation/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: video-generation
+description: The educational-video pipeline — script → TTS → image → animation → assembly → delivery — its env vars, the presigned-URL gotcha, the checkpoint/resume system, and common failures.
+---
+
+# Video Generation Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [debugging](../debugging/SKILL.md), [digital-coach](../digital-coach/SKILL.md)
+
+The bot can generate a short narrated educational video from a topic. It's the heaviest async pipeline —
+script, voice, images, animation, and final assembly — so it runs entirely on the queue worker with a
+checkpoint system so a crash mid-way can resume.
+
+## Pipeline
+
+```
+/video or a topic
+  → VideoOrchestrator (language prompt → selection)
+  → creates a video_requests row → enqueues a video_generation job
+  → the queue worker (bot/workers/video-generation.worker.js):
+      script (LLM) → TTS audio → images → (send a PDF) → animation → assembly (FFmpeg)
+  → deliver the video to the user
+```
+
+## Key files
+
+| Component | File |
+|-----------|------|
+| Orchestrator | [bot/shared/services/video/video-orchestrator.service.js](../../../bot/shared/services/video/video-orchestrator.service.js) |
+| Script | [bot/shared/services/video/video-script.service.js](../../../bot/shared/services/video/video-script.service.js) |
+| Image | [bot/shared/services/video/video-image.service.js](../../../bot/shared/services/video/video-image.service.js) |
+| Animation | [bot/shared/services/video/video-animation.service.js](../../../bot/shared/services/video/video-animation.service.js) |
+| Assembly | [bot/shared/services/video/video-assembly.service.js](../../../bot/shared/services/video/video-assembly.service.js) |
+| Watermark | [bot/shared/services/video/video-watermark.service.js](../../../bot/shared/services/video/video-watermark.service.js) |
+| Worker | [bot/workers/video-generation.worker.js](../../../bot/workers/video-generation.worker.js) |
+| Object storage | [bot/shared/storage/r2.js](../../../bot/shared/storage/r2.js) |
+
+> TTS is invoked from the orchestrator/script services (there is no standalone `video-tts` service). The
+> language-id branch that routes the user's pick lives in [bot/whatsapp-bot.js](../../../bot/whatsapp-bot.js).
+
+## The presigned-URL gotcha (most common failure)
+
+The image/animation provider must **fetch your images over HTTP**, but the object-storage bucket is
+private. Don't make the bucket public — generate **presigned URLs** (`getPresignedUrl()` in `r2.js`, which
+uses `@aws-sdk/s3-request-presigner`), valid ~1 hour. Symptom when this is wrong: *"Task failed: Your media
+file is unavailable"* at the animation step. If it still fails, confirm `R2_ACCESS_KEY_ID` /
+`R2_SECRET_ACCESS_KEY` / `R2_ENDPOINT` are set and the logs show "Generated presigned URL for…".
+
+## Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `KIE_API_KEY` | Image + video-animation provider |
+| `R2_ENDPOINT` / `R2_BUCKET_NAME` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | Object storage + presigned URLs |
+| `ELEVENLABS_API_KEY` | TTS (English) |
+| `UPLIFT_API_KEY` | TTS (other languages) |
+| `VIDEO_GENERATION_ENABLED` | Feature flag |
+| `VIDEO_DAILY_LIMIT` | Per-user rate limit |
+
+No public-URL var is needed — presigned URLs cover provider access.
+
+## Checkpoint / resume
+
+The pipeline survives crashes by checkpointing progress on the `video_requests` row (completed image URLs,
+completed segment URLs) and `video_tasks` (provider task ids). On restart the worker skips finished
+images/videos and resumes from the last incomplete task.
+
+```sql
+SELECT id, topic, language, status, error_message, created_at
+FROM video_requests WHERE user_id = '<uuid>' ORDER BY created_at DESC;
+
+SELECT video_request_id, filename, task_id, status, result_url
+FROM video_tasks WHERE video_request_id = '<id>' ORDER BY created_at;
+```
+
+## Common failures
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "media file is unavailable" (animation) | Provider can't fetch a private URL | Use presigned URLs (above) |
+| Language selection does nothing | Missing language-id branch in whatsapp-bot.js | Add the handler for the video language ids |
+| Job lost / reprocessed | Queue visibility timeout too short for a long render | Raise the visibility timeout |
+| TTS fails for non-English | Provider doesn't support the language | Route non-English to the alternate TTS provider |
+| FFmpeg crashes on the host | No FFmpeg binary in the container | Use the bundled `@ffmpeg-installer/ffmpeg` packages |
+
+To investigate a specific failure, trace the request's correlation id through the logs — see
+[debugging](../debugging/SKILL.md).
+
+## Related Skills
+
+- [debugging](../debugging/SKILL.md) — trace a failed render end to end.
+- [digital-coach](../digital-coach/SKILL.md) — where video sits in the overall architecture.


### PR DESCRIPTION
## What

Third operational-core skill-port batch — the standalone skills. All hand-authored OSS-generic and **grounded in the shipped code**, which surfaced three more divergences from the prod docs:

| Skill | Corrected to shipped reality |
|-------|------------------------------|
| `ab-testing` | OSS ships a **Thompson-sampling multi-armed bandit** (`bandit.service.js` + `ab_tests` tables), not the prod `app_settings`+MD5+UGLP pattern (which doesn't exist in OSS). |
| `qa-testing` | OSS has **domain jest suites + `tests/setup/` conformance guards** run via `node tests/run.js`, not the prod 4-layer `tests/qa/` persona framework (absent here). |
| `database-analysis` | Generic read-only analyst guide; dropped the pooler host / analyst role / password / incident refs; schema points at the canonical `00_complete-schema.sql`. + ported `query-patterns.md`. |
| `video-generation` | Paths fixed to the real OSS video services (no `video-tts`; TTS in orchestrator/script); Axiom queries → correlation-id tracing; fixed the self-contradictory presigned-vs-public-bucket checklist. |

## Linking

- Per the Link Map: database-analysis → coaching/debugging/registration · qa-testing → coaching/registration · video-generation → debugging/digital-coach · ab-testing standalone.
- Wired all four into `.claude/CLAUDE.md` (13 real skill links now). Pending-port note down to the 7E pair (feature-tracer, logging).

## Safety

- Leak-grepped: no host/role/password/phones/tokens/names/UGLP/ticket refs.
- All relative links resolve (guard lands in 7-final).
- Full suite green: **82 suites / 1077 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)