### PR TITLE
Phase 7E: logging + feature-tracer (completes the 14 operational-core skills)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,10 +29,13 @@ folder with a `SKILL.md` (+ optional reference files).
 | [qa-testing](skills/qa-testing/SKILL.md) | Test runner, conformance guards, the route-contract pattern |
 | [video-generation](skills/video-generation/SKILL.md) | The educational-video pipeline, presigned-URL gotcha, checkpoint/resume |
 | [ab-testing](skills/ab-testing/SKILL.md) | Thompson-sampling multi-armed bandit (ab_tests tables) |
+| [logging](skills/logging/SKILL.md) | Structured console logs, correlation IDs, semantic events, optional external backend |
+| [feature-tracer](skills/feature-tracer/SKILL.md) | Trace any feature end to end — the map of handler/service/worker/table per feature |
 
-> **More skills are being ported from the production bot in batches** (operational core still pending:
-> feature-tracer, logging). Each is hand-reviewed and stripped of any internal/credential content before it
-> lands — CI (gitleaks + the source-hygiene guard) enforces that no secrets or internal references ship.
+> Skills are loaded **on demand** — an agent reads the one whose description matches the task. The set above
+> is the operational core (run / extend / debug the open bot); internal-ops skills from the production bot
+> are intentionally not ported. CI (gitleaks + the source-hygiene guard) enforces that no secrets or internal
+> references ever ship in a skill.
 
 ## Rules for adding/editing skills here
 

--- a/.claude/skills/feature-tracer/SKILL.md
+++ b/.claude/skills/feature-tracer/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: feature-tracer
+description: Trace any feature end to end — webhook → handler → service → queue → worker → DB → storage → delivery — to find where a user's request actually broke. The map that points you at the right service, worker, table, and skill for each feature.
+---
+
+# Feature Tracer Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [debugging](../debugging/SKILL.md), [digital-coach](../digital-coach/SKILL.md), [logging](../logging/SKILL.md), [coaching](../coaching/SKILL.md), [reading-assessment](../reading-assessment/SKILL.md), [registration](../registration/SKILL.md), [video-generation](../video-generation/SKILL.md)
+
+This is the **"where do I look?"** hub. A tracer is a disciplined walk of one request through the system to
+find where it broke. The investigation rules and correlation-id mechanics live in [debugging](../debugging/SKILL.md)
+and [logging](../logging/SKILL.md); this skill maps each feature to the exact code path and storage so you
+know *which* service/worker/table to trace.
+
+## The trace path (every feature)
+
+```
+WhatsApp webhook → bot/whatsapp-bot.js
+  → bot/shared/handlers/<type>.handler.js     (routed by message type / button / flow)
+    → bot/shared/services/<feature>/…         (business logic; LLM, STT, TTS)
+      → enqueue a job (the QUEUE_DRIVER queue)
+        → bot/workers/<feature>.worker.js      (long work: transcribe / generate / score)
+          → Postgres rows + object storage (bot/shared/storage/r2.js)
+            → delivery (bot/shared/services/whatsapp.service.js)
+```
+
+At each hop, the questions are: did the request reach this layer (a log line for the correlation id), did it
+leave (a `.completed` event or the next layer's `.started`), and did it persist what it should (query the
+table)? The hop where the trace goes quiet is the failure point.
+
+## Non-negotiables
+
+1. **Query real data** — pull the actual row by `users.id` (UUID), don't assume.
+2. **Trace by correlation id** — follow the full flow, unprojected first (see [debugging](../debugging/SKILL.md) Rule D).
+3. **"generated" ≠ "delivered"** — a `*_requests.status='completed'` is not proof the user received anything; verify the send event.
+4. **Count real usage** — how many of this artifact does the user actually have?
+
+## Feature map
+
+| Feature | Entry handler | Core service | Worker | Tables | Deep-dive skill |
+|---------|---------------|--------------|--------|--------|-----------------|
+| Coaching | voice / text handler | `coaching-orchestrator.service.js` | `sqs-worker.js` → `coaching-processor.js` | `coaching_sessions` | [coaching](../coaching/SKILL.md) |
+| Reading assessment | `text-message.handler.js` (`/reading`) | `reading-assessment.service.js` + `reading/*` | (inline / queue) | `reading_assessments` | [reading-assessment](../reading-assessment/SKILL.md) |
+| Lesson plans | `lesson-plan-v2.handler.js`, `image-message.handler.js` | `lesson-planning` / router services | `lesson-plan-generation.worker.js`, `lesson-plan-extraction.worker.js`, `pic-lp-kieai.worker.js` | `lesson_plans`, `lesson_plan_requests` | — (see [debugging](../debugging/SKILL.md)) |
+| Registration | `text-message.handler.js`, `flow-response.handler.js` | `feature-registration.service.js` | — | `users` | [registration](../registration/SKILL.md) |
+| Video | (video orchestrator) | `video/video-orchestrator.service.js` | `video-generation.worker.js` | `video_requests`, `video_tasks` | [video-generation](../video-generation/SKILL.md) |
+| Quiz | `text-message.handler.js` (`/quiz`) | `quiz/*` services | `quiz-job-handler.js` | `quizzes`, `quiz_sessions`, `quiz_answers` | — |
+| Exam checker | `exam-checker.handler.js` | exam services | `exam-grading.worker.js` | `exam_grades` | — |
+| Homework | `homework-trigger.js` | `homework-lookup` service | `homework-bundle.worker.js` | `homework_chapters` | — |
+| Text chat | `text-message.handler.js` | chat / context services | — | `conversations` | — |
+
+(Exact file list: [bot/CLAUDE.md](../../../bot/CLAUDE.md). Schema: [infrastructure/supabase/00_complete-schema.sql](../../../infrastructure/supabase/00_complete-schema.sql).)
+
+## Common queries
+
+```sql
+-- Find the user (by UUID downstream; phone only to look them up)
+SELECT id, phone_number, first_name, preferred_language, registration_completed, created_at
+FROM users WHERE phone_number = '<normalised phone>';
+
+-- Recent activity for a user (swap the table per the feature map)
+SELECT id, status, created_at FROM coaching_sessions
+WHERE user_id = '<uuid>' ORDER BY created_at DESC LIMIT 20;
+```
+
+For artifacts in object storage (audio, PDFs, video), the row holds the key/URL — confirm the file exists
+and was delivered, don't infer it from `status`. Ready-to-run analytics SQL:
+[database-analysis](../database-analysis/SKILL.md).
+
+## Related Skills
+
+- [debugging](../debugging/SKILL.md) — the investigation discipline + correlation-id mechanics.
+- [logging](../logging/SKILL.md) — what the logs contain and how the correlation id is propagated.
+- [coaching](../coaching/SKILL.md) · [reading-assessment](../reading-assessment/SKILL.md) · [registration](../registration/SKILL.md) · [video-generation](../video-generation/SKILL.md) — per-feature depth.

--- a/.claude/skills/logging/SKILL.md
+++ b/.claude/skills/logging/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: logging
+description: How the bot logs — structured single-line JSON to the console, correlation IDs that thread a request across handler/queue/worker, semantic events, and an optional external log backend. Use when adding logging or wiring observability.
+---
+
+# Logging Skill
+
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **See also:** [debugging](../debugging/SKILL.md), [coaching](../coaching/SKILL.md), [digital-coach](../digital-coach/SKILL.md), [registration](../registration/SKILL.md)
+
+The bot logs **structured single-line JSON to the console** by default — no external service required. A
+correlation ID threads one user request across the webhook, the queue, and the workers so you can follow it
+end to end. An external log backend is an **optional** add-on, switched on purely by presence of its env
+vars.
+
+## The pieces
+
+- [bot/shared/utils/structured-logger.js](../../../bot/shared/utils/structured-logger.js) — the core: overrides `console` to emit single-line JSON, manages correlation context, exports `logEvent` / `runWithCorrelation` / `generateCorrelationId` / `getCurrentCorrelationId`.
+- [bot/shared/utils/logger.js](../../../bot/shared/utils/logger.js) — `logToFile(message, data)`: writes a readable file in development *and* logs to the console; auto-enriches `data` with the current correlation ID.
+
+## Correlation IDs
+
+Wrap the handling of an inbound request in `runWithCorrelation` once, and every log line emitted downstream
+(handlers, services, workers) carries the same `correlationId` automatically:
+
+```js
+const { runWithCorrelation, generateCorrelationId } = require('./shared/utils/structured-logger');
+
+await runWithCorrelation(generateCorrelationId(), async () => {
+  await handleMessage(message);   // every logToFile/logEvent inside inherits the id
+});
+```
+
+For a job that crosses the queue boundary, pass the correlation ID in the job envelope and re-enter
+`runWithCorrelation` in the worker so the worker's logs join the same trace.
+
+## Writing logs
+
+```js
+const { logToFile } = require('./shared/utils/logger');
+logToFile('LP generation started', { userId, topic });      // info + context
+
+const { logEvent } = require('./shared/utils/structured-logger');
+logEvent('lesson_plan.generation.started', { userId, requestId });
+logEvent('lesson_plan.generation.completed', { requestId, durationMs });
+logEvent('lesson_plan.generation.failed', { requestId, error: err.message });
+```
+
+**Semantic events** (`feature.stage.started|completed|failed`) are the backbone of tracing: a `.started`
+with no matching `.completed`/`.failed` for the same correlation ID points straight at where a request hung.
+Always log a `.failed` event with the error in your `catch`.
+
+## Optional external backend
+
+`structured-logger.js` ships an HTTP batcher for an external log store; it self-enables only when its env
+vars are present:
+
+```bash
+AXIOM_DATASET=...   # set BOTH to ship logs externally; unset → console-only (the default)
+AXIOM_TOKEN=...
+```
+
+`enabled = !!(AXIOM_DATASET && AXIOM_TOKEN)`. With them unset the batcher is a no-op and you rely on console
++ your platform's log capture — which is sufficient for development and most deploys. Don't make logging
+*depend* on the external backend; it must degrade to console cleanly.
+
+## Conventions
+
+- **One line per log** — single-line JSON is greppable and ingest-friendly; avoid multi-line dumps in hot paths.
+- **Always attach context** (`userId`, `requestId`, ids) so a line is useful out of order.
+- **Never log secrets or PII** — no tokens, no raw phone numbers in message bodies, no full transcripts.
+- **`catch` logs a `.failed` event**, not a swallowed `console.error` — a silent `.catch()` is an invisible failure (see [debugging](../debugging/SKILL.md) and the pre-merge JS-ternary class).
+
+## Related Skills
+
+- [debugging](../debugging/SKILL.md) — how to *read* these logs to find one evidence-backed root cause.
+- [coaching](../coaching/SKILL.md) · [registration](../registration/SKILL.md) · [digital-coach](../digital-coach/SKILL.md) — features whose flows you'll trace by correlation ID.

--- a/.claude/skills/pre-merge-checklist/SKILL.md
+++ b/.claude/skills/pre-merge-checklist/SKILL.md
@@ -177,10 +177,11 @@ send was rejected; fall back to English with a warning when the user's language 
 
 ## When something goes wrong post-deploy: investigate, don't guess
 
-Pull the logs for the exact reported time window and read the real error — see [debugging](../debugging/SKILL.md).
-The bot's own log line is often generic, but the underlying `err`/`error.message` field usually carries the
-real Postgres/Meta error (`violates check constraint "…"`, `duplicate key value violates unique constraint
-"…"`) that points straight at the fix. Don't speculate a root cause the logs can settle.
+Pull the logs for the exact reported time window and read the real error — see [debugging](../debugging/SKILL.md)
+(and [logging](../logging/SKILL.md) for how the correlation id threads the trace). The bot's own log line is
+often generic, but the underlying `err`/`error.message` field usually carries the real Postgres/Meta error
+(`violates check constraint "…"`, `duplicate key value violates unique constraint "…"`) that points
+straight at the fix. Don't speculate a root cause the logs can settle.
 
 ## Reference Files
 
@@ -193,3 +194,4 @@ real Postgres/Meta error (`violates check constraint "…"`, `duplicate key valu
 
 - [whatsapp-flows](../whatsapp-flows/SKILL.md) — the full Flow rules behind Class B.
 - [registration](../registration/SKILL.md) · [coaching](../coaching/SKILL.md) · [digital-coach](../digital-coach/SKILL.md) — common emitters of new IDs / DB writes.
+- [logging](../logging/SKILL.md) — reading the `err` field that carries the real cause.


### PR DESCRIPTION
## What

The final skill-port batch — the two most-connected hubs, saved for last so they link into a fully populated web.

- **logging** — a **rewrite** of the prod `axiom-logging` skill. OSS logging is structured console JSON + correlation IDs + semantic events by default; an external log backend is **opt-in** (`enabled = !!(AXIOM_DATASET && AXIOM_TOKEN)`) and the bot degrades to console-only cleanly. Grounded in `structured-logger.js` + `logger.js`.
- **feature-tracer** — authored as a single lean SKILL.md: the end-to-end trace path + a feature→handler/service/worker/table map grounded in real OSS code, linking to all seven of its Link-Map targets. (The prod skill's 12 per-feature tracer files are superseded by the now-ported feature skills + debugging + database-analysis.)

Also wired the deferred `pre-merge-checklist → logging` link now that `logging` exists.

## Milestone

`.claude/CLAUDE.md` now lists **all 14 operational-core skills** as real links; the "pending port" note is gone. The progressive-disclosure web (L0 → routers → skills) is fully hand-authored and hand-linked.

## Safety

- Leak-grepped: no Axiom tokens/dataset, no DB password / R2 account id, no phones / tester PII / ticket refs.
- All relative links resolve (the link-integrity guard lands next, in 7-final, as the backstop).
- Full suite green: **82 suites / 1077 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)