### PR TITLE
Phase 7-final: link-integrity guard + presence-based /setup

### DIFF
--- a/.claude/skills/setup/skill.md
+++ b/.claude/skills/setup/skill.md
@@ -1,11 +1,15 @@
-# /setup - Rumi Platform Setup
+# /setup - Platform Setup
 
-Automated setup guide for deploying the Rumi AI Teaching Assistant. This skill walks through the complete setup interactively.
+> **Up:** [.claude/CLAUDE.md](../../CLAUDE.md) (config & skills router) · **Architecture overview:** [digital-coach](../digital-coach/SKILL.md)
+
+Automated setup guide for deploying the AI teaching-assistant bot. This skill walks through the complete
+setup interactively. Once the bot is running, the [digital-coach](../digital-coach/SKILL.md) skill is the
+map to everything else.
 
 ## What This Does
 
-1. **Pre-flight checks**: Verifies Node.js 18+, git, npm
-2. **Tier selection**: Asks which feature tier (minimal/recommended/full)
+1. **Pre-flight checks**: Verifies Node.js 18+, git, npm (`npm run doctor`)
+2. **Feature selection (presence-based)**: there are **no tiers** — a feature turns on when the env vars it needs are present. Set the keys for the features you want; leave the rest unset and the bot degrades gracefully.
 3. **Infrastructure setup**: Creates Supabase project + Railway project + Redis manually
 4. **WhatsApp config**: Set webhook URL, verify handshake
 5. **Register flows**: WhatsApp Flows for interactive forms
@@ -26,15 +30,23 @@ The agent will guide you through each step interactively.
 - Supabase account (free tier works)
 - Railway account (free tier works)
 
-## Tier Options
+## Feature selection (presence-based, no tiers)
 
-When asked "Which tier?":
+Gating is by **presence of keys**, not a tier flag. Start with the required core; add each feature's keys
+when you want it on. `.env.template` documents every feature's keys under an `ENABLES:` heading, and
+`npm run validate:env` reports which features are currently switched on.
 
-| Tier | Features | Required Services |
-|------|----------|------------------|
-| **Minimal** | AI Chat + Registration | Supabase, Railway, Redis, OpenRouter |
-| **Recommended** | + Coaching + Reading Assessment | + Soniox STT |
-| **Full** | All features (voice, video, lesson plans, attendance) | + ElevenLabs TTS, Azure Speech |
+| To run… | Set these (on top of the core) |
+|---------|-------------------------------|
+| **Core** (AI chat + registration) | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `REDIS_URL`, `OPENROUTER_API_KEY`, WhatsApp creds |
+| Voice transcription | `SONIOX_API_KEY` |
+| Spoken replies (TTS) | `ELEVENLABS_API_KEY` (+ `UPLIFT_API_KEY` for Urdu/regional) |
+| Reading pronunciation scoring | `AZURE_SPEECH_KEY` |
+| Lesson-plan generation | `GAMMA_API_KEY` |
+| Educational video | `KIE_API_KEY` + the `R2_*` storage keys |
+
+The single source of truth for what each key enables is
+[bot/shared/config/feature-availability.js](../../../bot/shared/config/feature-availability.js).
 
 ## Setup Steps (Detailed)
 
@@ -48,20 +60,29 @@ git --version
 
 ### Step 2: Create Infrastructure
 
-Follow [SETUP.md](../../SETUP.md) to manually create:
+Follow [SETUP.md](../../../SETUP.md) to manually create:
 - Supabase project (copy URL + service role key)
 - Railway project + Redis plugin
 - OpenRouter API key
 
 Copy the credentials into `.env` based on `.env.template`.
 
-### Step 3: Run Database Schema
+### Step 3: Bootstrap the Database
+
+One command applies the schema, RLS policies, and seed data in order:
 
 ```bash
-# Apply schema to your Supabase project
-psql $DATABASE_URL -f infrastructure/supabase/00_complete-schema.sql
-psql $DATABASE_URL -f infrastructure/supabase/01_rls-policies.sql
-psql $DATABASE_URL -f infrastructure/supabase/02_seed-data.sql
+npm run bootstrap:db
+```
+
+(Equivalent manual apply: `psql $DATABASE_URL -f infrastructure/supabase/00_complete-schema.sql`, then
+`01_rls-policies.sql`, then `02_seed-data.sql`.)
+
+Then confirm your environment is wired correctly before deploying:
+
+```bash
+npm run validate:env   # which features are switched on (by key presence)
+npm run doctor         # connection + config preflight
 ```
 
 ### Step 4: Add WhatsApp Credentials
@@ -136,13 +157,13 @@ Once running, see these docs for customization:
 
 | Want to... | Read |
 |-----------|------|
-| Swap coaching framework (OECD to Teach) | [docs/agent-customization.md](../../docs/agent-customization.md) section 1 |
-| Change reading assessment method | [docs/agent-customization.md](../../docs/agent-customization.md) section 2 |
-| Add new languages | [docs/agent-customization.md](../../docs/agent-customization.md) section 4 |
-| Set up monitoring | [docs/monitoring.md](../../docs/monitoring.md) |
-| Change branding | [docs/customization.md](../../docs/customization.md) |
-| Add new features | [docs/agent-customization.md](../../docs/agent-customization.md) section 7 |
+| Swap coaching framework (OECD to Teach) | [docs/agent-customization.md](../../../docs/agent-customization.md) section 1 |
+| Change reading assessment method | [docs/agent-customization.md](../../../docs/agent-customization.md) section 2 |
+| Add new languages | [docs/agent-customization.md](../../../docs/agent-customization.md) section 4 |
+| Set up monitoring | [docs/monitoring.md](../../../docs/monitoring.md) |
+| Change branding | [docs/customization.md](../../../docs/customization.md) |
+| Add new features | [docs/agent-customization.md](../../../docs/agent-customization.md) section 7 |
 
 ## Full Manual Setup
 
-For detailed step-by-step instructions, follow [SETUP.md](../../SETUP.md).
+For detailed step-by-step instructions, follow [SETUP.md](../../../SETUP.md).

--- a/tests/setup/link-integrity.test.js
+++ b/tests/setup/link-integrity.test.js
@@ -1,0 +1,101 @@
+/**
+ * Link Integrity (Phase 7-final) — the rot-prevention backstop for the progressive-disclosure web.
+ *
+ * The agent-native docs (root CLAUDE.md, the folder routers, and the skill markdown under
+ * .claude) are wired together by hand into a link web: each skill up-links to .claude/CLAUDE.md, cross-links to
+ * sibling skills, and code-links to real bot/ paths. This guard asserts every one of those
+ * relative markdown links resolves to a real file/dir — so a renamed skill, a deleted reference
+ * file, or a typo'd path fails CI instead of silently rotting and misleading a future agent.
+ *
+ * It deliberately only checks RELATIVE links (./ ../ or bare in-repo paths). External links
+ * (http/https/mailto) and pure in-page anchors (#section) are skipped.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+// Same agent-native doc set the source-hygiene guard scans.
+function collectAgentDocs() {
+  const docs = [];
+  for (const top of ['CLAUDE.md', 'AGENTS.md']) {
+    const p = path.join(ROOT, top);
+    if (fs.existsSync(p)) docs.push(p);
+  }
+  const walk = (d) => {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) {
+        if (['node_modules', '.git', 'dist', 'build', 'coverage'].includes(e.name)) continue;
+        walk(p);
+      } else if (e.name === 'CLAUDE.md') {
+        docs.push(p);
+      }
+    }
+  };
+  walk(ROOT);
+  const claudeDir = path.join(ROOT, '.claude');
+  if (fs.existsSync(claudeDir)) {
+    const walkMd = (d) => {
+      for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+        const p = path.join(d, e.name);
+        if (e.isDirectory()) { if (e.name !== 'node_modules') walkMd(p); }
+        else if (e.name.endsWith('.md')) docs.push(p);
+      }
+    };
+    walkMd(claudeDir);
+  }
+  return [...new Set(docs)];
+}
+
+// Extract relative link targets from a markdown file, with their line numbers.
+function relativeLinks(file) {
+  const text = fs.readFileSync(file, 'utf8');
+  const lines = text.split('\n');
+  const re = /\[[^\]]*\]\(([^)]+)\)/g;
+  const out = [];
+  lines.forEach((line, idx) => {
+    let m;
+    while ((m = re.exec(line)) !== null) {
+      let target = m[1].trim();
+      // skip external + anchor-only links
+      if (/^(https?:|mailto:|tel:)/i.test(target)) continue;
+      if (target.startsWith('#')) continue;
+      // strip any #anchor / ?query suffix
+      target = target.split('#')[0].split('?')[0].trim();
+      if (!target) continue;
+      out.push({ target, line: idx + 1 });
+    }
+  });
+  return out;
+}
+
+describe('Link Integrity (agent-native progressive-disclosure web)', () => {
+  const docs = collectAgentDocs();
+
+  test('agent docs exist to scan', () => {
+    expect(docs.length).toBeGreaterThan(0);
+  });
+
+  test('every relative markdown link resolves to a real file or directory', () => {
+    const broken = [];
+    for (const doc of docs) {
+      const dir = path.dirname(doc);
+      for (const { target, line } of relativeLinks(doc)) {
+        // decode %20 etc. so "Open%20Source" style paths resolve like the editor opens them
+        const decoded = (() => { try { return decodeURIComponent(target); } catch { return target; } })();
+        const resolved = path.resolve(dir, decoded);
+        if (!fs.existsSync(resolved)) {
+          broken.push(`${path.relative(ROOT, doc)}:${line} → ${target}`);
+        }
+      }
+    }
+    if (broken.length) {
+      throw new Error(
+        `Dangling internal link(s) in agent-native docs:\n  ${broken.join('\n  ')}\n` +
+        `Fix the path, restore the target, or update the link.`
+      );
+    }
+  });
+});

--- a/tests/unit/sprint-3/setup-infrastructure.test.js
+++ b/tests/unit/sprint-3/setup-infrastructure.test.js
@@ -105,10 +105,17 @@ describe('Setup Infrastructure', () => {
     test('skill.md describes the setup flow', () => {
       const content = fs.readFileSync(path.join(ROOT, '.claude/skills/setup/skill.md'), 'utf8');
       expect(content).toContain('/setup');
-      expect(content).toContain('Tier');
       expect(content).toContain('Supabase');
       expect(content).toContain('Railway');
       expect(content).toContain('OpenRouter');
+    });
+
+    test('skill.md uses presence-based gating, not tiers, and links into the doc web', () => {
+      const content = fs.readFileSync(path.join(ROOT, '.claude/skills/setup/skill.md'), 'utf8');
+      expect(content).not.toContain('RUMI_TIER');          // tiers removed — gating is presence-based
+      expect(content).toMatch(/presence/i);                // documents the presence model
+      expect(content).toContain('../../CLAUDE.md');         // up-links to the config router (progressive disclosure)
+      expect(content).toContain('npm run doctor');          // wires in the real preflight tooling
     });
 
     test('skill.md mentions resume capability', () => {


### PR DESCRIPTION
## What

Closes out Phase 7 (agent-native packaging). With all 14 skills hand-authored and hand-linked (7A–7E), the deterministic guard lands **last** — a backstop, not the driver of the linking.

### Link-integrity guard — `tests/setup/link-integrity.test.js`
Scans every agent-native markdown (root `CLAUDE.md`, folder routers, `.claude` skill docs) and asserts every **relative** markdown link resolves to a real file/dir (external + anchor links skipped, `%20` decoded). A renamed skill or a typo'd path now fails CI instead of silently rotting.

It earned its keep immediately: caught real pre-existing dangling links in `setup/skill.md` that used `../../` (→ `.claude/docs/...`) where the root-level `docs/` needs `../../../`. **Fixed.**

### /setup alignment (the original Phase-7 scope)
- The setup skill still preached the **deleted tier model**. Replaced with the **presence-based** gating the repo has used since Phase 2 (feature on ⇔ its keys present), with a feature→keys table pointing at `feature-availability.js` and `npm run validate:env`.
- Wired in the real preflight tooling — `npm run bootstrap:db`, `validate:env`, `npm run doctor` — instead of raw `psql` only.
- Added the up-link into the progressive-disclosure web.
- Updated `setup-infrastructure.test.js` in lockstep (dropped the stale `Tier` assertion; added presence + web-link + preflight assertions).

## Safety / status

- Suite green: **83 suites / 1080 tests** (+1 suite, the new guard).
- The setup skill and the new guard are leak-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)