### PR TITLE
Phase 8 (docs): LP_PATHS + quiz/homework/pic-to-LP feature docs + presence-based cost guide

### DIFF
--- a/docs/LP_PATHS.md
+++ b/docs/LP_PATHS.md
@@ -1,0 +1,91 @@
+# Lesson-Plan Paths
+
+Rumi can produce a lesson plan three different ways. Which one runs depends on the request (text vs photo)
+and on the region's configuration. This page maps the routing so you know exactly what happens to an LP
+request and how to switch each path on.
+
+All claims here are grounded in the shipped code — the router is
+[bot/shared/services/lesson-plan-router.service.js](../bot/shared/services/lesson-plan-router.service.js).
+
+## The three paths
+
+| Path | When it runs | Output | Switched on by |
+|------|-------------|--------|----------------|
+| **Curriculum (gamma_enriched)** | Region has textbooks for the subject **and** the request names a page/chapter | A pre-generated PDF served instantly **or** a Gamma plan enriched with textbook context | `region_features.curriculum_lp_enabled` + `has_textbooks` + `GAMMA_API_KEY` |
+| **Generic (gamma_standard)** | The default for any free-form topic | A Gamma-generated lesson-plan PDF from the topic | `GAMMA_API_KEY` |
+| **Pic-to-LP** | The teacher sends a **photo** of a textbook page | A 2-page illustrated PDF rendered from the page | `region_features.pic_lp_enabled` + `KIE_API_KEY` (see [features/pic-to-lp.md](features/pic-to-lp.md)) |
+
+## Text request → the router
+
+A text lesson-plan request enters through
+[bot/shared/handlers/text-message.handler.js](../bot/shared/handlers/text-message.handler.js)
+(`handleLessonPlanRequest`), which extracts the topic and queues the work. The async worker calls the router:
+
+```
+LessonPlanRouterService.route({ userId, region, grade, subject, pageNumber })
+  → reads region_features for the region
+  → IF curriculum_lp_enabled AND has_textbooks AND a page number is present AND the subject is supported:
+        return { track: 'gamma_enriched', reason }
+     ELSE:
+        return { track: 'gamma_standard', reason }
+```
+
+There are exactly **two tracks**. The pic-to-LP photo path is separate and never goes through this router.
+
+### gamma_enriched (curriculum)
+
+Handled by [bot/shared/handlers/lesson-plan-v2.handler.js](../bot/shared/handlers/lesson-plan-v2.handler.js)
+(`handleCurriculumLessonPlan`):
+
+1. `TopicMatchingService.findChapterByTopic()` matches the request to a chapter in `textbook_toc`.
+2. `PreGenLookupService.findPreGenLP()` looks for a pre-generated PDF in the `pre_generated_lps` table (R2 keys `pdf_r2_key_en` / `pdf_r2_key_ur`).
+3. **If a pre-generated PDF exists** → it's downloaded from object storage and sent **instantly** (no generation cost or wait).
+4. **If not** → the request falls through to Gamma generation enriched with the textbook context for that page.
+
+### gamma_standard (generic)
+
+The default. The request is persisted to `lesson_plan_requests` (status `pending`) and queued; the worker
+[bot/workers/lesson-plan-generation.worker.js](../bot/workers/lesson-plan-generation.worker.js) calls the
+content service to generate a Gamma plan from the topic, then delivers the PDF and records it in
+`lesson_plans`.
+
+## Photo request → Pic-to-LP
+
+A textbook **photo** is routed by [bot/shared/handlers/image-message.handler.js](../bot/shared/handlers/image-message.handler.js):
+the image is classified, and if it's a book page the teacher is asked what they want (lesson plan / homework /
+…). For a lesson plan, the job goes to [bot/workers/pic-lp-kieai.worker.js](../bot/workers/pic-lp-kieai.worker.js),
+which renders a 2-page illustrated PDF with an image model and delivers it. Full detail:
+[features/pic-to-lp.md](features/pic-to-lp.md).
+
+## Configuration
+
+Path selection for the text routes is driven by the **`region_features`** table (per-region, fail-open), not
+by env vars:
+
+| `region_features` column | Effect |
+|--------------------------|--------|
+| `curriculum_lp_enabled` | Turns on the curriculum (gamma_enriched) path; default off → everyone gets gamma_standard |
+| `has_textbooks` | Region has curriculum textbooks loaded (needed with `curriculum_lp_enabled`) |
+| `supported_subjects` | Subjects that have curriculum textbooks |
+| `pic_lp_enabled` | Turns on the photo path (default on) |
+
+Generation itself needs the API keys: **`GAMMA_API_KEY`** for the text paths, **`KIE_API_KEY`** for pic-to-LP.
+With no `GAMMA_API_KEY`, the text LP feature is off (the bot degrades gracefully — see
+[features/lesson-plans.md](features/lesson-plans.md)).
+
+## Tables involved
+
+| Table | Role |
+|-------|------|
+| `lesson_plan_requests` | Async queue state for a text LP request (`pending`/`processing`/`completed`/`failed`) |
+| `lesson_plans` | Completed LPs (with a `source` of e.g. `gamma_standard`, `pre_generated`, `pic_to_lp_kieai`) |
+| `pre_generated_lps` | Curriculum-aligned PDFs (R2 keys) served by the gamma_enriched path |
+| `textbook_toc` | Curriculum table of contents, used to match a topic to a chapter/page |
+| `pic_lp_sessions` | Photo-path session state |
+| `region_features` | The per-region gating that the router reads |
+
+## Related
+
+- [features/lesson-plans.md](features/lesson-plans.md) — the teacher-facing lesson-plan feature.
+- [features/pic-to-lp.md](features/pic-to-lp.md) — the photo path in depth.
+- The `database-analysis` and `feature-tracer` skills under [.claude/skills/](../.claude/skills/) for tracing an LP request end to end.

--- a/docs/cost-guide.md
+++ b/docs/cost-guide.md
@@ -1,43 +1,38 @@
 # Cost Guide
 
-Estimated monthly costs by tier, based on moderate usage (50-100 teachers, ~500 messages/day).
+Rumi has **no pricing tiers** — you pay for the core platform plus whichever features you switch on
+(features are gated by presence of their API keys; see the [feature library](features/README.md)). This
+guide gives rough monthly estimates at moderate usage (~50–100 teachers, ~500 messages/day). Real costs
+depend on volume and the providers you choose — treat these as order-of-magnitude.
 
-## Tier 1: Minimal (~$15/month)
+## Core baseline (always running) — ~$15–20/month
 
-| Service | Cost | Notes |
-|---------|------|-------|
-| OpenRouter (GPT-4o) | ~$10 | ~500 msgs/day at ~200 tokens each |
-| Supabase | Free | Free tier covers this usage |
-| Railway | ~$5 | Hobby plan |
-| Redis (Railway) | Free | Included in Railway |
-| **Total** | **~$15** | |
+| Service | Rough cost | Notes |
+|---------|-----------|-------|
+| OpenRouter (LLM) | ~$10 | The model behind chat, coaching analysis, quiz, etc. Pick a cheaper model to cut this. |
+| Supabase (Postgres) | Free → $25 | Free tier covers light usage; Pro if you need more storage. |
+| Railway (web + workers) | ~$5–20 | Hobby for a single service; more for separate worker services. |
+| Redis | Free | Included with Railway. |
 
-## Tier 2: Recommended (~$50/month)
+The core (chat + registration + quiz) runs on just these — only `OPENROUTER_API_KEY` is a paid add-on
+beyond hosting.
 
-| Service | Cost | Notes |
-|---------|------|-------|
-| OpenRouter | ~$15 | More tokens for coaching analysis |
-| Soniox | ~$25 | Audio transcription |
-| Supabase | Free | |
-| Railway | ~$10 | More compute for workers |
-| **Total** | **~$50** | |
+## Per-feature add-ons (you only pay if you enable the feature)
 
-## Tier 3: Full (~$200+/month)
+| Feature | Provider | Key | Rough cost | Notes |
+|---------|----------|-----|-----------|-------|
+| Voice transcription (voice notes, coaching, reading) | Soniox | `SONIOX_API_KEY` | ~$25 | Per-minute audio transcription. |
+| Spoken replies (TTS) | ElevenLabs | `ELEVENLABS_API_KEY` | ~$5–50 | Scales with how much speech you generate. |
+| Urdu / regional voices | Uplift | `UPLIFT_API_KEY` | varies | Alternative TTS for non-English. |
+| Reading pronunciation scoring | Azure Speech | `AZURE_SPEECH_KEY` | ~$25 | Only the English pronunciation path. |
+| Lesson plans (text) | Gamma | `GAMMA_API_KEY` | ~$50 | Per-plan generation; pre-generated curriculum LPs are free to serve. |
+| Pic-to-LP + Video | Kie.ai | `KIE_API_KEY` | usage-based | Image/video rendering; the heaviest per-artifact cost. |
+| Exam checker | Mistral (vision) | `MISTRAL_API_KEY` | usage-based | Per-page OCR + grading. |
+| Observability | Axiom | `AXIOM_DATASET` + `AXIOM_TOKEN` | Free → paid | Optional; the bot logs to the console without it. |
 
-| Service | Cost | Notes |
-|---------|------|-------|
-| OpenRouter | ~$25 | |
-| Soniox | ~$25 | |
-| ElevenLabs | ~$50 | Voice generation |
-| Azure Speech | ~$25 | Pronunciation assessment |
-| Gamma | ~$50 | Lesson plan generation |
-| Supabase | Free-$25 | May need Pro for storage |
-| Railway | ~$20 | Multiple workers |
-| **Total** | **~$200+** | |
+## Optimisation tips
 
-## Cost Optimization Tips
-
-1. Use `openai/gpt-4o-mini` instead of `gpt-4o` for non-critical responses
-2. Cache frequent queries in Redis
-3. Use Railway's sleep feature for low-traffic periods
-4. Start with Minimal tier and upgrade as needed
+1. Use a smaller/cheaper LLM (e.g. a mini model) for non-critical responses — set it as the default model.
+2. Cache frequent queries in Redis.
+3. Serve **pre-generated** curriculum lesson plans where possible — they cost nothing to deliver (see [LP_PATHS.md](LP_PATHS.md)).
+4. Start with the core and switch features on one at a time; `npm run doctor` shows what's currently live.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -11,9 +11,16 @@ Run **`npm run doctor`** at any time to see which features are live for your cur
 | 🎯 [Classroom Coaching](coaching.md) | Recording → framework-scored report + reflective conversation | `SONIOX_API_KEY` |
 | 📖 [Reading Assessment](reading-assessment.md) | Student reads aloud → fluency, accuracy, comprehension | `SONIOX_API_KEY` |
 | 📋 [Lesson Plans](lesson-plans.md) | Topic + grade → full lesson-plan PDF | `GAMMA_API_KEY` |
+| 📸 [Pic-to-LP](pic-to-lp.md) | Photo of a textbook page → illustrated 2-page LP | `KIE_API_KEY` |
+| 📚 [Homework](homework.md) | Pick class + chapters → curriculum homework bundle PDF | `HOMEWORK_FLOW_ID` |
+| 🧠 [Quiz](quiz.md) | Topic → interactive multiple-choice quiz in chat | _core — powered by `OPENROUTER_API_KEY`_ |
 | 🗣️ [Voice Messages](voice.md) | Full spoken interaction in many languages | `SONIOX_API_KEY` + `ELEVENLABS_API_KEY` |
 | 🎬 [Video Generation](video.md) | Topic → short narrated educational video | `VIDEO_GENERATION_ENABLED` + `KIE_API_KEY` |
 | ✅ [Attendance](attendance.md) | Tap-based attendance via WhatsApp Flows | _core — always on_ |
 | 🧮 [Exam Checker](exam-checker.md) | Photograph answer sheets → vision OCR + AI grading | `MISTRAL_API_KEY` |
+
+**How lesson plans get routed** (pre-generated vs Gamma vs photo): see [LP_PATHS.md](../LP_PATHS.md).
+
+**Utility flows** (presence-gated on their Flow id, with a text fallback when unset): a **settings** flow (`SETTINGS_FLOW_ID` — language + coaching framework), a **status** flow (`STATUS_FLOW_ID` — your active sessions), an **edit-class** roster editor (`EDIT_CLASS_FLOW_ID`), and a **student-video** library picker (`STUDENT_VIDEOS_FLOW_ID`).
 
 For deep customization of any feature (swapping frameworks, changing benchmarks, adding languages or regions), see the [Agent Customization Guide](../agent-customization.md).

--- a/docs/features/homework.md
+++ b/docs/features/homework.md
@@ -1,0 +1,37 @@
+# 📚 Homework
+
+> Generate a ready-to-assign homework bundle for a class straight from the curriculum — no typing out exercises by hand.
+
+## What it is
+
+A teacher asks Rumi for homework, picks the class/subject/chapters through a short WhatsApp Flow, and Rumi
+assembles a homework bundle (a merged PDF of the relevant exercises) and sends it back. The content is drawn
+from curriculum-aligned chapter data, so it matches what the class is actually studying.
+
+## How it works
+
+1. **Trigger** — the teacher sends `/homework` (or `/hw`, or an Urdu keyword). Entry point: the homework trigger wired into [bot/shared/handlers/text-message.handler.js](../../bot/shared/handlers/text-message.handler.js) via [bot/shared/handlers/homework-trigger.js](../../bot/shared/handlers/homework-trigger.js).
+2. **Collect details** — a WhatsApp Flow (id in `HOMEWORK_FLOW_ID`) collects the class, subject, and chapters taught; the submission is parsed in [bot/shared/handlers/flow-response.handler.js](../../bot/shared/handlers/flow-response.handler.js).
+3. **Lookup** — [bot/shared/services/homework-lookup.service.js](../../bot/shared/services/homework-lookup.service.js) finds the matching exercises in the `homework_chapters` table.
+4. **Bundle** — the worker [bot/workers/homework-bundle.worker.js](../../bot/workers/homework-bundle.worker.js) merges the selected exercise pages into a single PDF (pulling source pages from object storage) and delivers it.
+
+## What the teacher experiences
+
+`/homework` → a short form (class, subject, chapters) → a "putting it together" message → a tidy homework
+PDF they can forward to parents or print.
+
+## Enable it
+
+**Presence-gated on `HOMEWORK_FLOW_ID`** — set the env var to a registered WhatsApp Flow id and the feature
+turns on; leave it unset and the teacher is told it isn't available (no crash). It also needs curriculum
+homework data loaded in `homework_chapters` for the relevant grades/subjects.
+
+## Data
+
+`homework_chapters` (curriculum exercises), plus `student_lists` for the teacher's classes (see
+[infrastructure/supabase/00_complete-schema.sql](../../infrastructure/supabase/00_complete-schema.sql)).
+
+## Related
+
+- [whatsapp-flows](../../.claude/skills/whatsapp-flows/SKILL.md) — how to register and publish the homework Flow.
+- [Lesson Plans](lesson-plans.md) · [LP paths](../LP_PATHS.md) — the sibling curriculum-content feature.

--- a/docs/features/pic-to-lp.md
+++ b/docs/features/pic-to-lp.md
@@ -1,0 +1,41 @@
+# 📸 Pic-to-LP (Photo → Illustrated Lesson Plan)
+
+> Snap a photo of a textbook page and get back a colourful, ready-to-teach 2-page lesson plan built around it.
+
+## What it is
+
+Instead of typing a topic, the teacher photographs the textbook page they're about to teach. Rumi reads the
+page, confirms what the teacher wants, and renders a 2-page **illustrated** lesson-plan PDF — hero artwork,
+a big idea, guided practice, and an exit task — all anchored to that exact page. It's the most visual of the
+lesson-plan paths.
+
+## How it works
+
+1. **Photo in** — the teacher sends one or more photos of a textbook page. Entry point: [bot/shared/handlers/image-message.handler.js](../../bot/shared/handlers/image-message.handler.js) (`tryPicLpRoute`).
+2. **Classify + collect** — incoming images are batched (a short coalesce window groups a burst of photos) and classified; if they're book pages, a session is created in `pic_lp_sessions` and the teacher is asked what they want (lesson plan / homework / …).
+3. **Render** — for a lesson plan, the job goes to the worker [bot/workers/pic-lp-kieai.worker.js](../../bot/workers/pic-lp-kieai.worker.js), which builds prompts from the page and renders two illustrated pages with an image model, then assembles them into a PDF with a footer.
+4. **Deliver** — the PDF is sent on WhatsApp and recorded in `lesson_plans` (with `source = 'pic_to_lp_kieai'` and the originating `pic_lp_session_id`).
+
+The pic-to-LP services live under [bot/shared/services/pic-to-lp/](../../bot/shared/services/pic-to-lp/)
+(session, page collector, classifier, batch coalescer, prompt builder, image-model client).
+
+## What the teacher experiences
+
+Photograph the page → "give me a few minutes" → a polished, illustrated 2-page plan that looks like a
+designer made it — far more engaging than a wall of text.
+
+## Enable it
+
+Needs **`KIE_API_KEY`** (the image model that renders the pages) and the region toggle
+`region_features.pic_lp_enabled` (on by default). Rendering an illustrated page takes longer than a text
+plan, so the teacher gets an upfront wait message.
+
+## Where it fits
+
+Pic-to-LP is the **photo** path of the lesson-plan feature; the text paths (curriculum + generic Gamma) are
+described in [LP_PATHS.md](../LP_PATHS.md). It does **not** go through the text LP router.
+
+## Related
+
+- [LP paths](../LP_PATHS.md) — all three lesson-plan paths side by side.
+- [video-generation](../../.claude/skills/video-generation/SKILL.md) — the other image/render pipeline (presigned-URL pattern, checkpointing).

--- a/docs/features/quiz.md
+++ b/docs/features/quiz.md
@@ -1,0 +1,37 @@
+# 🧠 Quiz
+
+> Turn any topic into a short, interactive quiz the teacher (or their students) can take right in the chat — with instant scoring and a follow-up report.
+
+## What it is
+
+A teacher asks Rumi for a quiz on a topic and answers multiple-choice questions one at a time in WhatsApp.
+Rumi generates the questions with the LLM, tracks the session, scores the answers, and follows up with a
+short report. It's a fast way to check understanding without leaving the chat.
+
+## How it works
+
+1. **Trigger** — the teacher sends `/quiz <topic>` (or asks for a quiz in conversation). Entry point: [bot/shared/handlers/text-message.handler.js](../../bot/shared/handlers/text-message.handler.js).
+2. **Generation** — [bot/shared/services/quiz/quiz-generation.service.js](../../bot/shared/services/quiz/quiz-generation.service.js) produces multiple-choice questions with the LLM; the orchestrator ([quiz-orchestrator.service.js](../../bot/shared/services/quiz/quiz-orchestrator.service.js)) drives generation + delivery.
+3. **Delivery** — questions are sent one at a time; the teacher answers by tapping a button or typing `A` / `B` / `C`. The active-quiz reply is intercepted early in the text handler so a bare `A`/`B`/`C` is scored, not treated as chat.
+4. **Session state** — [quiz-session.service.js](../../bot/shared/services/quiz/quiz-session.service.js) keeps the question list, answers, and progress in the `quiz_sessions` table.
+5. **Report** — when the quiz ends, [quiz-report.service.js](../../bot/shared/services/quiz/quiz-report.service.js) summarises the score and which concepts need work. Long-running pieces run on the worker [bot/workers/quiz-job-handler.js](../../bot/workers/quiz-job-handler.js).
+
+## What the teacher experiences
+
+`/quiz photosynthesis` → a question with options → tap an answer → immediate next question → a friendly
+score summary at the end. They can cancel mid-quiz, and a scheduled follow-up can nudge them later.
+
+## Enable it
+
+Core feature — it rides on the required `OPENROUTER_API_KEY` (the LLM that writes the questions). No extra
+key needed. Optional Flow-based management can be wired via a quiz Flow id if configured.
+
+## Data
+
+`quizzes`, `quiz_sessions`, `quiz_questions`, and `quiz_answers` (see
+[infrastructure/supabase/00_complete-schema.sql](../../infrastructure/supabase/00_complete-schema.sql)).
+
+## Related
+
+- [A/B testing](../../.claude/skills/ab-testing/SKILL.md) — quiz copy/variants can be optimised with the bandit.
+- [feature-tracer](../../.claude/skills/feature-tracer/SKILL.md) — trace a quiz session end to end.


### PR DESCRIPTION
## What

First Phase-8 batch — code-grounded documentation. Every claim verified against shipped OSS code (the doc-accuracy rule that's burned us before), and the exploration map was cross-checked — which caught hallucinated table names (`sessions`/`exam_sessions`/`video_sessions` don't exist; the real ones are `chat_sessions`/`exam_check_sessions`/`video_requests`).

- **`docs/LP_PATHS.md`** (new) — the three lesson-plan paths, grounded in `lesson-plan-router.service.js`. The router returns exactly **two tracks** (gamma_enriched / gamma_standard); pic-to-LP is a separate photo path. Covers the `region_features` gating and the pre-gen-serve-then-Gamma fallback.
- **`docs/features/{quiz,homework,pic-to-lp}.md`** (new) — the three teacher-facing features missing from the library, each citing real handlers/services/workers/tables + the real gate.
- **`docs/features/README.md`** — indexed the three + a utility-flows note + LP_PATHS pointer. (Verified the existing `VIDEO_GENERATION_ENABLED` claim is real — it's read in `video-orchestrator.service.js:42`.)
- **`docs/cost-guide.md`** — rewritten from stale tiers to presence-based (core baseline + per-feature add-ons); added the missing Kie.ai + Mistral lines.

The existing 9 feature docs were audited and found accurate — left as-is.

## Safety / status

- All relative links resolve; leak-clean.
- Full suite green: **83 suites / 1080 tests**.

Next Phase-8 batch: sanitized analyst-DB sample reports (rendered in-memory, never persisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)