### PR TITLE
docs: repo-wide accuracy audit — purge deleted tier system, fix actors/counts/tables

### DIFF
--- a/.claude/skills/coaching/SKILL.md
+++ b/.claude/skills/coaching/SKILL.md
@@ -41,6 +41,11 @@ uses. The default `oecd` framework scores 5 goals across 19 classroom criteria +
 criteria (23 total). To add a region's own rubric, drop a new `*-framework.js` module and register its key
 — no orchestrator changes needed.
 
+Beyond the four registry frameworks, the bot also ships a **MEWAKA** report path (a Tanzania teacher-CPD
+format): when a session's framework is `mewaka`, the report is rendered by a dedicated transformer +
+template rather than the standard renderer — see the `framework === 'mewaka'` branch in
+[bot/shared/services/pdf-report.service.js](../../../bot/shared/services/pdf-report.service.js).
+
 > The framework used for a given session is recorded inside `coaching_sessions.analysis_data.framework`
 > (there is no dedicated column). Each framework writes a different `analysis_data` shape, so always read
 > the `framework` field first before parsing scores.

--- a/.claude/skills/feature-tracer/SKILL.md
+++ b/.claude/skills/feature-tracer/SKILL.md
@@ -44,7 +44,7 @@ table)? The hop where the trace goes quiet is the failure point.
 | Lesson plans | `lesson-plan-v2.handler.js`, `image-message.handler.js` | `lesson-planning` / router services | `lesson-plan-generation.worker.js`, `lesson-plan-extraction.worker.js`, `pic-lp-kieai.worker.js` | `lesson_plans`, `lesson_plan_requests` | — (see [debugging](../debugging/SKILL.md)) |
 | Registration | `text-message.handler.js`, `flow-response.handler.js` | `feature-registration.service.js` | — | `users` | [registration](../registration/SKILL.md) |
 | Video | (video orchestrator) | `video/video-orchestrator.service.js` | `video-generation.worker.js` | `video_requests`, `video_tasks` | [video-generation](../video-generation/SKILL.md) |
-| Quiz | `text-message.handler.js` (`/quiz`) | `quiz/*` services | `quiz-job-handler.js` | `quizzes`, `quiz_sessions`, `quiz_answers` | — |
+| Quiz (teacher → class; students answer) | `text-message.handler.js` (`/quiz`) | `quiz/*` services | `quiz-job-handler.js` | `quizzes`, `quiz_questions`, `quiz_sessions`, `quiz_answers` | — |
 | Exam checker | `exam-checker.handler.js` | exam services | `exam-grading.worker.js` | `exam_grades` | — |
 | Homework | `homework-trigger.js` | `homework-lookup` service | `homework-bundle.worker.js` | `homework_chapters` | — |
 | Text chat | `text-message.handler.js` | chat / context services | — | `conversations` | — |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,14 +24,14 @@ rumi-platform/
 ├── bot/                    # WhatsApp Bot (main application)
 │   ├── whatsapp-bot.js     # Entry point (webhook, message routing)
 │   ├── shared/config/      # Branding, presence-based feature gating, region config
-│   ├── shared/services/    # 39+ service modules
+│   ├── shared/services/    # 49 service modules
 │   ├── shared/handlers/    # Message handlers (text, voice, image, flow)
-│   ├── workers/            # 8 background workers
+│   ├── workers/            # 10 background workers / job processors
 │   └── scripts/            # CLI simulator, validators
 ├── infrastructure/
 │   ├── supabase/           # SQL schema, RLS policies, seed data
 │   └── railway/            # Deployment configs
-├── tests/                  # Jest suites (82 suites / 1075 tests)
+├── tests/                  # Jest suites (83 suites / 1080 tests)
 ├── docs/                   # Architecture, customization, monitoring
 └── .claude/                # Claude Code config + /setup skill
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,5 +48,5 @@ CLAUDE.md (this file)  →  <folder>/CLAUDE.md (router)  →  .claude/skills/<sk
 ## Repo map
 
 `bot/` WhatsApp bot (Node/Express; entry `bot/whatsapp-bot.js`; 10 handlers, 49 services, 10 workers) ·
-`infrastructure/` Supabase schema (73 tables) + deploy configs · `tests/` Jest suites (82 suites / 1075
+`infrastructure/` Supabase schema (73 tables) + deploy configs · `tests/` Jest suites (83 suites / 1080
 tests) · `docs/` architecture & customization · `dashboard/` + `portal/` observability/teacher UIs.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Every feature lives on WhatsApp. Click any feature for its own page — what it 
 | 📋 **[Lesson Plans](docs/features/lesson-plans.md)** | A topic + grade → a full lesson-plan PDF | `GAMMA_API_KEY` |
 | 📸 **[Pic-to-LP](docs/features/pic-to-lp.md)** | A photo of a textbook page → an illustrated 2-page lesson plan | `KIE_API_KEY` |
 | 📚 **[Homework](docs/features/homework.md)** | Pick a class + chapters → a curriculum homework bundle PDF | `HOMEWORK_FLOW_ID` |
-| 🧠 **[Quiz](docs/features/quiz.md)** | A topic → an interactive multiple-choice quiz, scored in the chat | _core (uses `OPENROUTER_API_KEY`)_ |
+| 🧠 **[Quiz](docs/features/quiz.md)** | Teacher sends a topic quiz to a class; students answer on their parents' WhatsApp, teacher gets a results report | _core (uses `OPENROUTER_API_KEY`)_ |
 | 🗣️ **[Voice Messages](docs/features/voice.md)** | Full spoken interaction in many languages | `SONIOX_API_KEY` + `ELEVENLABS_API_KEY` |
 | 🎬 **[Video Generation](docs/features/video.md)** | A topic → a short narrated educational video | `VIDEO_GENERATION_ENABLED` + `KIE_API_KEY` |
 | ✅ **[Attendance](docs/features/attendance.md)** | Voice- or tap-based attendance via WhatsApp Flows | _always on (core)_ |

--- a/SETUP.md
+++ b/SETUP.md
@@ -35,7 +35,7 @@ cd bot && npm install && cd ..
 1. **Create account** at [supabase.com](https://supabase.com) (free tier is sufficient)
 2. **Create a new project** — choose a region closest to your users
 3. **Run the schema** in SQL Editor (Settings > SQL Editor):
-   - Copy and paste the contents of `infrastructure/supabase/00_complete-schema.sql` — this creates all 60 tables, 38 functions, 27 triggers, and 186+ indexes
+   - Copy and paste the contents of `infrastructure/supabase/00_complete-schema.sql` — this creates all 73 tables, 40 functions, 29 triggers, and 200+ indexes (or just run `npm run bootstrap:db`, which applies all three SQL files in order)
    - Then run `infrastructure/supabase/01_rls-policies.sql` — enables Row Level Security on all tables
    - Then run `infrastructure/supabase/02_seed-data.sql` — adds reading assessment benchmarks
 4. **Verify** by running `infrastructure/supabase/verify-schema.sql` — all checks should show PASS
@@ -149,7 +149,6 @@ Fill in the required values:
 # Core
 NODE_ENV=production
 PORT=3000
-RUMI_TIER=minimal
 
 # Database (from Step 2)
 SUPABASE_URL=https://your-project.supabase.co
@@ -275,19 +274,21 @@ node bot/workers/stale-session.worker.js
 
 ---
 
-## Upgrading Tiers
+## Adding Features
 
-### Minimal to Recommended
+There are **no tiers** — each feature turns on the moment its key(s) are present in your environment, and
+`npm run doctor` shows you which are live. To add one, set its key(s) and redeploy. For example:
+
+### Add voice transcription (coaching, reading, voice notes)
 
 1. Get a Soniox API key at [soniox.com](https://soniox.com)
 2. Add to your environment: `SONIOX_API_KEY=your-key`
-3. Update: `RUMI_TIER=recommended`
-4. Set up the stale session cron job (Step 11)
-5. Redeploy
+3. Set up the stale session cron job (Step 11)
+4. Redeploy
 
-### Recommended to Full (Regional Language Support)
+### Add regional-language speech-to-text (optional)
 
-The full tier adds speech-to-text for regional Pakistani languages (Balochi, Sindhi, Pashto) using Meta's MMS-ASR model deployed on [Modal.com](https://modal.com).
+Speech-to-text for regional Pakistani languages (Balochi, Sindhi, Pashto) uses Meta's MMS-ASR model deployed on [Modal.com](https://modal.com).
 
 **Prerequisites:** Python 3.10+, a Modal.com account
 
@@ -302,7 +303,6 @@ Set environment variables:
 ```env
 MMS_SERVICE_URL=https://your-workspace--mms-asr-service-web-app.modal.run
 MMS_API_KEY=your-secret-key-here
-RUMI_TIER=full
 ```
 
 ---

--- a/docs/agent-customization.md
+++ b/docs/agent-customization.md
@@ -80,7 +80,7 @@ CONVERSATIONAL FRAMEWORK: [YOUR CONVERSATION APPROACH]
 }
 ```
 
-**Key constraint**: The LLM expects the response in a specific JSON structure. Find `_buildAnalysisPrompt()` in the same file (~line 680) and update the JSON schema to match your framework's domains.
+**Key constraint**: The LLM expects the response in a specific JSON structure. Find `_buildAnalysisPrompt()` in the same file (~line 636) and update the JSON schema to match your framework's domains.
 
 #### Step 2: Update Scoring Constants
 
@@ -386,24 +386,25 @@ Every feature in the bot follows this pattern:
 }
 ```
 
-#### Step 2: Add Feature Flag
+#### Step 2: Register its key (only if it needs one)
+
+Gating is **presence-based** — there are no tiers. If your feature needs its own API key, add it to the
+`FEATURES` map so `doctor` and the runtime gate know about it:
 
 ```javascript
-// bot/shared/config/feature-tiers.js
-// Add to each tier's features object:
-features: {
-  // ... existing
-  homeworkChecker: true,  // or false for lower tiers
-}
+// bot/shared/config/feature-availability.js — add to the FEATURES array:
+{ name: 'Homework checker (Acme OCR)', keys: ['ACME_OCR_API_KEY'] },
 ```
+
+If your feature only uses already-required services (e.g. the LLM), skip this step.
 
 #### Step 3: Gate in Handler
 
 ```javascript
 // bot/shared/handlers/text-message.handler.js (or image handler)
-const { isFeatureEnabled } = require('../config/feature-tiers');
+const { isFeatureAvailable } = require('../config/feature-availability');
 
-if (isFeatureEnabled('homeworkChecker') && isHomeworkRequest(messageBody)) {
+if (isFeatureAvailable('Homework checker (Acme OCR)') && isHomeworkRequest(messageBody)) {
   await handleHomeworkCheck(userId, messageBody);
   return;
 }
@@ -523,7 +524,7 @@ This changes: welcome messages, system prompts, error messages, and all user-fac
 |------|---------------|
 | `bot/workers/sqs-worker.js` | Add `case` for your new job type |
 | `bot/shared/services/queue/sqs-queue.service.js` | Queue job submission |
-| `bot/shared/config/feature-tiers.js` | Gate behind feature flag |
+| `bot/shared/config/feature-availability.js` | Register the feature's API key (presence-based gating) |
 
 ### Pattern
 
@@ -563,7 +564,7 @@ WhatsApp Webhook
 | Want to change... | Edit this file |
 |-------------------|---------------|
 | Bot name/branding | `bot/shared/config/branding.js` |
-| Which features are on/off | `bot/shared/config/feature-tiers.js` |
+| Which features are on/off | `.env` (presence of each feature's keys); the map is `bot/shared/config/feature-availability.js` |
 | Feature descriptions (help text) | `bot/shared/config/capabilities.config.js` |
 | System messages (all languages) | `bot/shared/config/system-messages.js` |
 | Language list | `bot/shared/config/branding.js` + `language-config.js` |
@@ -571,7 +572,7 @@ WhatsApp Webhook
 | TTS voices | `bot/shared/config/tts-voices.js` |
 | Coaching framework | `bot/shared/services/gpt5-mini.service.js` → `getCachedFrameworkPrompt()` |
 | Scoring rubric | `bot/shared/constants/scoring.constants.js` |
-| Reading benchmarks | `bot/shared/services/reading/fluency.service.js` |
+| Reading benchmarks | `bot/shared/services/reading/analysis.service.js` (`compareToBenchmarks` → `check_benchmark_status` RPC) |
 | Database schema | `infrastructure/supabase/00_complete-schema.sql` |
 
 ### Database Tables by Feature
@@ -580,12 +581,15 @@ WhatsApp Webhook
 |---------|--------------|----------------|
 | Registration | `users` | - |
 | AI Chat | `conversations` | `chat_sessions` |
-| Coaching | `coaching_sessions` | `coaching_jobs` |
-| Reading | `reading_sessions` | `reading_results`, `reading_passages` |
-| Lesson Plans | `lesson_plan_requests` | - |
-| Video | `video_requests` | `video_sessions` |
-| Attendance | `attendance_classes` | `attendance_records`, `attendance_setup` |
-| Exam Checker | `exam_sessions` | `exam_papers`, `exam_grades` |
+| Coaching | `coaching_sessions` | `coaching_jobs`, `coaching_quality_metrics` |
+| Reading | `reading_assessments` | `wcpm_percentiles` (benchmarks) |
+| Lesson Plans | `lesson_plan_requests` | `lesson_plans`, `pre_generated_lps`, `textbook_toc` |
+| Pic-to-LP | `pic_lp_sessions` | `lesson_plans` |
+| Quiz | `quiz_sessions` | `quizzes`, `quiz_questions`, `quiz_answers` |
+| Homework | `homework_chapters` | `student_lists` |
+| Video | `video_requests` | `video_tasks` |
+| Attendance | `attendance_sessions` | `attendance_records`, `student_lists` |
+| Exam Checker | `exam_check_sessions` | `exam_grades`, `image_analysis_requests` |
 
 ---
 
@@ -595,5 +599,5 @@ WhatsApp Webhook
 2. **Read before editing** - Always have the AI read the target file first to understand the current implementation
 3. **Test after each change** - Run `npm test` after every file change
 4. **Use the simulator** - `cd bot && npm run simulate` lets you test without WhatsApp
-5. **Check feature tiers** - Make sure your feature is enabled in the right tier
-6. **Follow the pattern** - Every feature follows: capability config → feature tier → handler gate → service → worker (if async)
+5. **Check feature availability** - Make sure your feature's API key is set (gating is presence-based; `npm run doctor` shows what's live)
+6. **Follow the pattern** - Every feature follows: capability config → (optional) key in feature-availability → handler gate → service → worker (if async)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,10 +45,10 @@ Meta WhatsApp API
 | Service | File | Purpose |
 |---------|------|---------|
 | LLM Client | `bot/shared/services/llm-client.js` | AI chat via OpenRouter |
-| Queue | `bot/shared/services/queue/sqs-queue.service.js` | Job queue for async tasks |
+| Queue | `bot/shared/services/queue/` (`index.js` selects the driver) | Pluggable job queue — `QUEUE_DRIVER=sqs` (default) or `bullmq` |
 | Worker | `bot/workers/sqs-worker.js` | Background job processing |
 | Branding | `bot/shared/config/branding.js` | Customizable bot identity |
-| Feature Tiers | `bot/shared/config/feature-tiers.js` | Feature gating by tier |
+| Feature gating | `bot/shared/config/feature-availability.js` | Presence-based feature availability (no tiers) |
 
 ## Message Flow
 
@@ -68,7 +68,7 @@ Meta WhatsApp API
 
 ## Job Queue
 
-- **BullMQ** (Redis-based) replaces AWS SQS
-- 7 job types: transcription, analysis, report, lesson plan extraction, lesson plan generation, video generation, exam grading
-- Configurable concurrency (default: 3)
+- **Pluggable driver** via `QUEUE_DRIVER`: AWS SQS (default) or BullMQ/Redis — both expose the same surface (`bot/shared/services/queue/index.js` selects it)
+- ~15 job types dispatched by the worker, including: transcription, analysis, report generation, lesson-plan extraction, lesson-plan generation, pic-to-LP rendering, video generation, exam grading, homework-bundle generation, and the quiz jobs (quiz, quiz_report, quiz_nudge, quiz_reminder, quiz_expire)
+- Configurable concurrency
 - Automatic retry with exponential backoff

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -20,20 +20,19 @@ const supportedLanguages = [
 ];
 ```
 
-## Feature Tiers
+## Feature Availability (presence-based)
 
-Control which features are enabled via `RUMI_TIER` environment variable:
+There is **no tier system**. A feature turns on when the env key(s) it needs are present — set them and it
+works, leave them blank and it stays off cleanly. The single source of truth is the `FEATURES` map in
+`bot/shared/config/feature-availability.js` (each feature → the env key that switches it on). Run
+`npm run doctor` to see which features are live for your current `.env`.
 
-- `minimal` - AI Chat + Registration
-- `recommended` - + Coaching + Reading Assessment
-- `full` - All features
-
-Check features in code:
+Check availability in code:
 
 ```javascript
-const { isFeatureEnabled } = require('./config/feature-tiers');
-if (isFeatureEnabled('coaching')) {
-  // Enable coaching flow
+const { isFeatureAvailable } = require('./config/feature-availability');
+if (isFeatureAvailable('Voice notes (speech-to-text, Soniox)')) {
+  // ... transcription path
 }
 ```
 
@@ -57,8 +56,8 @@ LLM_MODEL=anthropic/claude-sonnet-4
 ## Adding New Features
 
 1. Add capability to `bot/shared/config/capabilities.config.js`
-2. Add feature flag to `bot/shared/config/feature-tiers.js`
-3. Gate with `isFeatureEnabled('your_feature')` in handlers
+2. If the feature needs its own API key, add it to the `FEATURES` map in `bot/shared/config/feature-availability.js`
+3. Gate with `isFeatureAvailable(...)` in handlers (or just let a missing key degrade gracefully)
 4. Add job type to `bot/workers/sqs-worker.js` if async
 
 ## File Zones
@@ -71,9 +70,9 @@ These files are yours. Upstream updates rarely touch them, so merge conflicts ar
 
 | File | Purpose |
 |------|---------|
-| `.env` | Your credentials and config |
+| `.env` | Your credentials and config — **this is where you switch features on** (presence of keys) |
 | `bot/shared/config/branding.js` | Bot name, org name, languages |
-| `bot/shared/config/feature-tiers.js` | Which features are enabled |
+| `bot/shared/config/feature-availability.js` | The feature → env-key map (rarely edited) |
 | `bot/shared/config/capabilities.config.js` | Feature capabilities |
 | `bot/shared/config/system-messages.js` | Custom system prompts |
 | `bot/shared/services/llm-client.js` | LLM provider config |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -13,7 +13,7 @@ Run **`npm run doctor`** at any time to see which features are live for your cur
 | 📋 [Lesson Plans](lesson-plans.md) | Topic + grade → full lesson-plan PDF | `GAMMA_API_KEY` |
 | 📸 [Pic-to-LP](pic-to-lp.md) | Photo of a textbook page → illustrated 2-page LP | `KIE_API_KEY` |
 | 📚 [Homework](homework.md) | Pick class + chapters → curriculum homework bundle PDF | `HOMEWORK_FLOW_ID` |
-| 🧠 [Quiz](quiz.md) | Topic → interactive multiple-choice quiz in chat | _core — powered by `OPENROUTER_API_KEY`_ |
+| 🧠 [Quiz](quiz.md) | Teacher sends a topic quiz to a class → students answer, teacher gets results | _core — powered by `OPENROUTER_API_KEY`_ |
 | 🗣️ [Voice Messages](voice.md) | Full spoken interaction in many languages | `SONIOX_API_KEY` + `ELEVENLABS_API_KEY` |
 | 🎬 [Video Generation](video.md) | Topic → short narrated educational video | `VIDEO_GENERATION_ENABLED` + `KIE_API_KEY` |
 | ✅ [Attendance](attendance.md) | Tap-based attendance via WhatsApp Flows | _core — always on_ |

--- a/docs/features/coaching.md
+++ b/docs/features/coaching.md
@@ -20,7 +20,7 @@ A teacher records part of a lesson as **audio** on their phone and sends the voi
    - **TEACH** — the World Bank's TEACH observation tool
    - **FICO** — a domain-based observation framework
 
-   (These four ship with the OSS bot. MEWAKA and other production-only frameworks are not included here.)
+   (These four are the selectable scoring frameworks, registered in `framework-registry.js`.) The OSS bot also includes a **MEWAKA** report path (a Tanzania teacher-CPD format) — when a session's framework is `mewaka`, the report is rendered by a dedicated transformer + template (`pdf-report.service.js`, `framework === 'mewaka'`).
 4. **Optional classroom photo analysis** — if the teacher also sends a photo, Rumi uses vision AI to score things only a picture can show (seating, materials, board use).
 5. **Reflective conversation** — Rumi asks a few voice-delivered questions that prompt the teacher to think about specific moments in their own lesson.
 6. **PDF report** — scores per goal, evidence quoted from the transcript, growth areas, prioritised recommendations, and charts. It ends with a coaching card naming the single highest-leverage next action.

--- a/docs/features/quiz.md
+++ b/docs/features/quiz.md
@@ -2,38 +2,43 @@
 
 ![Quiz](../images/features/quiz.jpg)
 
-> Turn any topic into a short, interactive quiz the teacher (or their students) can take right in the chat — with instant scoring and a follow-up report.
+> A teacher turns any topic into a short multiple-choice quiz and **sends it to a whole class** — students answer on their parents' WhatsApp, and the teacher gets a results report.
 
 ## What it is
 
-A teacher asks Rumi for a quiz on a topic and answers multiple-choice questions one at a time in WhatsApp.
-Rumi generates the questions with the LLM, tracks the session, scores the answers, and follows up with a
-short report. It's a fast way to check understanding without leaving the chat.
+The teacher asks Rumi for a quiz on a topic and picks one of their classes. Rumi generates the questions
+with the LLM and delivers the quiz to **every student in that class** via their parent's WhatsApp number.
+Each student answers the multiple-choice questions one at a time; Rumi scores them and sends the **teacher**
+a class results report. It's a fast way to check a whole class's understanding without printing anything.
 
 ## How it works
 
-1. **Trigger** — the teacher sends `/quiz <topic>` (or asks for a quiz in conversation). Entry point: [bot/shared/handlers/text-message.handler.js](../../bot/shared/handlers/text-message.handler.js).
-2. **Generation** — [bot/shared/services/quiz/quiz-generation.service.js](../../bot/shared/services/quiz/quiz-generation.service.js) produces multiple-choice questions with the LLM; the orchestrator ([quiz-orchestrator.service.js](../../bot/shared/services/quiz/quiz-orchestrator.service.js)) drives generation + delivery.
-3. **Delivery** — questions are sent one at a time; the teacher answers by tapping a button or typing `A` / `B` / `C`. The active-quiz reply is intercepted early in the text handler so a bare `A`/`B`/`C` is scored, not treated as chat.
-4. **Session state** — [quiz-session.service.js](../../bot/shared/services/quiz/quiz-session.service.js) keeps the question list, answers, and progress in the `quiz_sessions` table.
-5. **Report** — when the quiz ends, [quiz-report.service.js](../../bot/shared/services/quiz/quiz-report.service.js) summarises the score and which concepts need work. Long-running pieces run on the worker [bot/workers/quiz-job-handler.js](../../bot/workers/quiz-job-handler.js).
+1. **Trigger** — the teacher sends `/quiz <topic>` (or asks for a quiz in conversation), then picks which **class** receives it from a list. Entry point: [bot/shared/handlers/text-message.handler.js](../../bot/shared/handlers/text-message.handler.js); class selection + the gate (a class with student **parent phone numbers** is required) live in [quiz-orchestrator.service.js](../../bot/shared/services/quiz/quiz-orchestrator.service.js).
+2. **Generation** — [quiz-generation.service.js](../../bot/shared/services/quiz/quiz-generation.service.js) produces the multiple-choice questions with the LLM.
+3. **Delivery to students** — [quiz-delivery.service.js](../../bot/shared/services/quiz/quiz-delivery.service.js) sends the quiz to **each student's parent phone**, creating a `quiz_session` per student. Students answer by tapping a button or typing `A` / `B` / `C` — that reply is intercepted early in the text handler (before the registration gate) so an unregistered parent/student can play without onboarding.
+4. **Session state** — per-student progress (questions, answers) is tracked in `quiz_sessions` against each parent phone.
+5. **Report back to the teacher** — once students finish (or a ~12-hour window closes), [quiz-report.service.js](../../bot/shared/services/quiz/quiz-report.service.js) compiles a class results summary and sends it to the teacher. The report/expiry/nudge/reminder jobs run via the queue worker ([quiz-job-handler.js](../../bot/workers/quiz-job-handler.js)).
+
+A teacher can have only one active quiz per class at a time, and can cancel an in-flight quiz (which tears down the per-student state and the pending report).
 
 ## What the teacher experiences
 
-`/quiz photosynthesis` → a question with options → tap an answer → immediate next question → a friendly
-score summary at the end. They can cancel mid-quiz, and a scheduled follow-up can nudge them later.
+`/quiz photosynthesis` → pick a class → "sent to your class" confirmation → students answer on their own
+phones over the next while → the teacher receives a results report showing how the class did and which
+concepts need reteaching.
 
 ## Enable it
 
 Core feature — it rides on the required `OPENROUTER_API_KEY` (the LLM that writes the questions). No extra
-key needed. Optional Flow-based management can be wired via a quiz Flow id if configured.
+key needed. It does require a class set up with student **parent phone numbers** (see the edit-class /
+attendance setup), since that's who the quiz is delivered to.
 
 ## Data
 
-`quizzes`, `quiz_sessions`, `quiz_questions`, and `quiz_answers` (see
+`quizzes`, `quiz_questions`, `quiz_sessions` (one per student), and `quiz_answers` (see
 [infrastructure/supabase/00_complete-schema.sql](../../infrastructure/supabase/00_complete-schema.sql)).
 
 ## Related
 
 - [A/B testing](../../.claude/skills/ab-testing/SKILL.md) — quiz copy/variants can be optimised with the bandit.
-- [feature-tracer](../../.claude/skills/feature-tracer/SKILL.md) — trace a quiz session end to end.
+- [feature-tracer](../../.claude/skills/feature-tracer/SKILL.md) — trace a quiz from send to per-student answers to the teacher's report.

--- a/docs/pulling-updates.md
+++ b/docs/pulling-updates.md
@@ -112,7 +112,7 @@ If conflicts appear in these files, keep your version (`--ours`):
 
 - `.env`
 - `bot/shared/config/branding.js`
-- `bot/shared/config/feature-tiers.js`
+- `bot/shared/config/feature-availability.js`
 - `bot/shared/config/capabilities.config.js`
 
 ### Accept Upstream Version

--- a/docs/railway-operations.md
+++ b/docs/railway-operations.md
@@ -149,7 +149,7 @@ railway variables --service bot --set KEY1=value1 --set KEY2=value2
 | `WHATSAPP_TOKEN` | Token rotated by admin |
 | `OPENROUTER_API_KEY` | Key expired or changed |
 | `SONIOX_API_KEY` | New Soniox account |
-| `RUMI_TIER` | Upgrading tier |
+| a feature's key (e.g. `KIE_API_KEY`, `GAMMA_API_KEY`) | Turning that feature on — gating is presence-based, there are no tiers |
 
 After changing variables, the bot restarts automatically.
 


### PR DESCRIPTION
## What

A page-by-page accuracy review of every doc + agent skill against the **actual shipped code** (three parallel read-only audit passes, every finding then verified by hand against `bot/` and the schema — which also caught the audit agents' own hallucinations). Triggered by a real bug spotted in the wild: the quiz doc said the *teacher* takes the quiz.

## Fixes

**Actors (who does what)**
- **Quiz** — corrected the core error: the **teacher sends** a quiz to a **class**, **students answer** on their parents' WhatsApp, and the teacher gets a results report. Fixed `quiz.md`, the README + features-index one-liners, and the feature-tracer row.

**The deleted tier system** (`RUMI_TIER` / `feature-tiers.js` / `isFeatureEnabled` — removed in Phase 2; gating is presence-based, but six docs never caught up). Purged + reframed to presence-based in `customization.md`, `agent-customization.md`, `SETUP.md`, `railway-operations.md`, `architecture.md`, `pulling-updates.md`. (The two `there is no RUMI_TIER` mentions in CLAUDE.md/AGENTS.md are intentional and kept.)

**Wrong table names** in agent-customization's "Database Tables by Feature" (cited tables that don't exist): `reading_sessions`→`reading_assessments`, `video_sessions`→`video_tasks`, `attendance_classes`→`attendance_sessions`, `exam_sessions`→`exam_check_sessions`, etc. — all verified against `00_complete-schema.sql`; added the missing Pic-to-LP/Quiz/Homework rows.

**Stale counts** — SETUP.md schema (60/38/27/186 → **73/40/29/200+**), architecture.md ("BullMQ replaces SQS" → pluggable `QUEUE_DRIVER`; "7 job types" → **~15**), CLAUDE.md/AGENTS.md (82 suites/1075 → **83/1080**; services 39+ → **49**).

**Other** — coaching "MEWAKA not included" corrected (the MEWAKA report path **is** in OSS); a stale line ref and the reading-benchmark file pointer fixed.

The existing 9 feature docs were re-audited and found accurate.

## Status

All links resolve; leak-clean; suite green (**83 suites / 1080 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)