### PR TITLE
docs(onboarding): step-by-step API-key + WhatsApp setup guides

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -11,6 +11,10 @@
 | OpenRouter API key | [openrouter.ai/keys](https://openrouter.ai/keys) (for LLM access) |
 | WhatsApp Business credentials | [Meta Business Manager](https://business.facebook.com) |
 
+> **New to any of these?** Two step-by-step guides walk you through the slow parts:
+> - **[docs/onboarding/whatsapp.md](docs/onboarding/whatsapp.md)** — get a working WhatsApp connection in ~10 minutes (free test number), then go to production.
+> - **[docs/onboarding/api-keys.md](docs/onboarding/api-keys.md)** — how to get every API key, what each unlocks, and which 8 you actually need to start.
+
 ## Step 1: Fork, Clone, and Install
 
 **First, fork the repo** on GitHub — click the **Fork** button at [github.com/Orenda-Project/rumi-platform](https://github.com/Orenda-Project/rumi-platform). This creates your own independent copy.

--- a/docs/onboarding/api-keys.md
+++ b/docs/onboarding/api-keys.md
@@ -1,0 +1,124 @@
+# Getting your API keys
+
+Rumi turns features on by **presence**: set a feature's key(s) and it switches on; leave them blank and it stays off (the bot never crashes over a missing optional key). So you only need a handful to start, then add more as you go.
+
+**You need 8 keys to boot.** Everything else is optional. Run `npm run doctor` any time to see what's on, what's off, and which key unlocks each off feature.
+
+> Steps were verified against each provider's signup as of May 2026; provider dashboards change, so the exact menu labels may drift. Env-var names match `bot/shared/config/feature-availability.js` and `.env.template`.
+
+---
+
+## Tier 0 — required to start (8 keys)
+
+Without all of these the bot won't start.
+
+### Supabase → `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`
+The database. **Free tier: yes (no card).**
+1. Go to **supabase.com** → **Start your project** → sign in with GitHub.
+2. **New project** → name it, set a DB password + region → **Create** (~2 min to provision).
+3. **Settings** (gear, bottom-left) → **API**: copy the **Project URL** → `SUPABASE_URL`.
+4. Same page → **Project API keys** → copy the **`service_role`** secret (NOT `anon`) → `SUPABASE_SERVICE_ROLE_KEY`. Server-side only — never ship it to a client.
+> Supabase is rolling out new `sb_secret_…` keys; the legacy `service_role` key works through end-2026 and is what Rumi expects. Use the legacy key if both are shown.
+
+### OpenRouter → `OPENROUTER_API_KEY`
+The LLM gateway behind every AI feature (one key → many models). **Free tier: yes, free models at $0 (no card to start).**
+1. **openrouter.ai** → **Sign in** (Google/GitHub/email).
+2. Open **Keys** (account menu → Keys).
+3. **Create Key** → name it → copy it now (shown once).
+4. Add funds under **Credits** when you want paid models; free `:free` models work at $0 balance.
+
+### Redis → `REDIS_URL`
+Session state + the job queue. Two easy options:
+
+**Upstash (free, no card):**
+1. **upstash.com** → Console → **Redis** tab → **+ Create Database**.
+2. Name it, pick a region, **Free** tier → **Create**.
+3. **Connect to your database** → copy the TLS connection string (`rediss://default:…`) → `REDIS_URL`.
+
+**Railway plugin (if you deploy on Railway):**
+1. In your Railway project: **+ New** → **Database** → **Add Redis**.
+2. Open the Redis service → **Variables** → copy `REDIS_URL` (or `REDIS_PRIVATE_URL` for same-project service-to-service).
+> Railway has no permanent free tier (Hobby ≈ $5/mo); confirm current terms at railway.com/pricing.
+
+### Meta WhatsApp → `WHATSAPP_TOKEN`, `PHONE_NUMBER_ID`, `WEBHOOK_VERIFY_TOKEN`, `WABA_ID`
+The messaging layer — the one step with eligibility rules, so it has **its own guide:** **[whatsapp.md](whatsapp.md)**. You can get a free test number + all four values in ~10 minutes, no verification.
+
+---
+
+## Tier 1 — optional features (add a key → the feature turns on)
+
+### Soniox → `SONIOX_API_KEY` — *voice notes (speech-to-text, multilingual incl. Urdu/Swahili)*
+Usage-priced (~$0.10/hr).
+1. **console.soniox.com/signup** → create account → verify email.
+2. Console → **API Keys** → **Create** → copy (shown once).
+> Free-credit amount + whether a card is needed at signup aren't stated publicly — check on first login.
+
+### ElevenLabs → `ELEVENLABS_API_KEY` (+ `ELEVENLABS_VOICE_ID`) — *spoken replies (text-to-speech)*
+**Free tier: ~10k chars/month, no card.**
+1. **elevenlabs.io** → **Sign up**.
+2. Profile icon (bottom-left) → **API Keys** → **Create API Key** → copy (shown once) → `ELEVENLABS_API_KEY`.
+3. **Voices** → on a voice, **⋮ → Copy voice ID** → `ELEVENLABS_VOICE_ID`.
+
+### Uplift AI → `UPLIFT_API_KEY` — *Urdu / regional-language voices*
+Only needed for South-Asian regional TTS.
+1. **platform.upliftai.org** → **Sign in to get started**.
+2. In the studio, find **generate your API key** → create + copy (`sk_api_…`).
+> Pricing/free-tier/access-gating isn't documented publicly — verify after signing in.
+
+### Gamma → `GAMMA_API_KEY` — *polished lesson-plan/deck generation*
+Optional (the Kie.ai image lesson-plan path is a cheaper alternative). **API key requires a PAID Gamma plan (Pro+); card required.**
+1. **gamma.app** → sign in (upgrade to Pro or higher — keys are gated to paid tiers).
+2. **Account Settings → API Keys** (gamma.app/settings/api-keys) → **generate** → copy (`sk-gamma-…`).
+
+### Microsoft Azure → `AZURE_SPEECH_KEY`, `AZURE_SPEECH_REGION` — *reading pronunciation scoring*
+**Free tier: F0 (5 hrs STT + 500k chars TTS/month). Card required to create the Azure account (F0 itself isn't billed).**
+1. **portal.azure.com** → sign up (identity + card verification).
+2. **Create a resource** → search **Speech** → **Create**.
+3. Set subscription, resource group, **Region** (note it → `AZURE_SPEECH_REGION`, e.g. `eastus`), name, **Pricing tier = Free F0** → **Create**.
+4. Open the resource → **Keys and Endpoint** → copy **KEY 1** → `AZURE_SPEECH_KEY`.
+
+### Kie.ai → `KIE_API_KEY` — *AI video generation + image lesson plans*
+**Free: 80 credits on signup, no card** (credits ~$0.005 each after).
+1. **kie.ai** → sign up (Google).
+2. Dashboard → **API Key** section → generate + copy.
+
+### Mistral → `MISTRAL_API_KEY` — *exam-checker OCR (vision)*
+**Free tier: yes, no card — but phone/SMS verification required.**
+1. **console.mistral.ai** → create account → verify phone via SMS.
+2. Sidebar → **API Keys** → **Create new key** → copy (shown once).
+> On the free plan, requests may be used to train Mistral's models.
+
+### Axiom → `AXIOM_DATASET`, `AXIOM_TOKEN` — *optional structured logging*
+The bot logs to console + correlation IDs without it. **Free tier: 500 GB/mo ingest, no card.**
+1. **axiom.co** → sign up.
+2. **Datasets → New Dataset** → the name is your `AXIOM_DATASET`.
+3. **Settings → API tokens → New API token** (type **Basic**, scoped to that dataset) → copy → `AXIOM_TOKEN`.
+
+---
+
+## Tier 2 — infrastructure & feature support
+
+### Cloudflare R2 → `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_R2_ACCESS_KEY_ID`, `CLOUDFLARE_R2_SECRET_ACCESS_KEY`, `CLOUDFLARE_R2_BUCKET_NAME`
+Object storage for coaching audio, reading recordings, and generated PDFs/videos — needed by any feature that produces or reads media. **Free: 10 GB + zero egress fees; card required to enable R2 (usage still $0 within limits).**
+1. **dash.cloudflare.com** → **Storage & databases → R2 → Overview** → enable R2 (add a payment method).
+2. **Create bucket** → name it → `CLOUDFLARE_R2_BUCKET_NAME`. The S3 endpoint is `https://<ACCOUNT_ID>.r2.cloudflarestorage.com`.
+3. Note your **Account ID** (top of the R2 page) → `CLOUDFLARE_ACCOUNT_ID`.
+4. **Manage API Tokens → Create API token** → permission **Object Read & Write** → copy the **Access Key ID** → `CLOUDFLARE_R2_ACCESS_KEY_ID` and **Secret Access Key** (shown once) → `CLOUDFLARE_R2_SECRET_ACCESS_KEY`.
+
+### WhatsApp Flow encryption & Flow IDs
+The `FLOW_PRIVATE_KEY` / `FLOW_PUBLIC_KEY` pair is **not a third-party signup** — it's an RSA keypair generated locally by the setup script and registered with Meta (needed for endpoint-type Flows). The various `*_FLOW_ID` values are **written back automatically** when you register your Flows against your WABA — you don't fetch them by hand. See [SETUP.md](../../SETUP.md) for flow registration.
+
+### Job queue (only if `QUEUE_DRIVER=sqs`) → `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`
+Default `QUEUE_DRIVER=bullmq` uses Redis (no AWS needed). Only set these if you opt into SQS.
+
+### Advanced / niche (most adopters skip)
+`GEMINI_API_KEY`, Mistral vision, `CHANDRA_*`, `DATALAB_API_KEY`, `MMS_SERVICE_URL`/`_API_KEY` (Modal), `ANTHROPIC_API_KEY` (dashboard only) — advanced; not needed for a standard deployment.
+
+---
+
+## After you have your keys
+1. `cp .env.template .env` and paste them in.
+2. `npm run validate:env` — checks the 8 required are present.
+3. `npm run doctor` — shows every feature's on/off state and the exact key for each off feature.
+
+For what each deployment costs to run, see the [cost guide](../cost-guide.md).

--- a/docs/onboarding/whatsapp.md
+++ b/docs/onboarding/whatsapp.md
@@ -1,0 +1,88 @@
+# Connecting WhatsApp
+
+WhatsApp is the only setup step with eligibility rules, so it's where people get stuck. Good news: **you can have a working bot in ~10 minutes, for free, with no business verification** — using Meta's free *test number*. Do that first. Move to a production number when you're ready to message real teachers.
+
+This produces the four values the bot needs: `WHATSAPP_TOKEN`, `PHONE_NUMBER_ID`, `WEBHOOK_VERIFY_TOKEN`, `WABA_ID`.
+
+> Verified against Meta's docs as of May 2026. Meta's console wording shifts — re-check the menu labels as you go.
+
+---
+
+## Part 1 — Try it in ~10 minutes (free test number)
+
+No cost, no verification, you can message up to 5 of your own numbers.
+
+1. Go to **developers.facebook.com** → log in → **My Apps** → **Create App**.
+2. Choose the **Business** type → name the app → create.
+3. On the app dashboard, find **WhatsApp** → **Set up**. Meta automatically creates a **WhatsApp Business Account (WABA)** and a **free test phone number**.
+4. Open **WhatsApp → API Setup**. You'll see:
+   - **Phone number ID** → `PHONE_NUMBER_ID`
+   - **WhatsApp Business Account ID** → `WABA_ID`
+   - a **temporary access token** (valid 24h) → use as `WHATSAPP_TOKEN` for now (replace with a permanent one in Part 2).
+5. Under **To**, add your own phone number(s) as recipients (up to 5) — each confirms via a code in WhatsApp.
+6. **App Secret:** app dashboard → **App Settings → Basic** → reveal **App Secret** (the bot uses it to validate incoming webhooks).
+7. **Choose your Verify Token:** make up any random string (e.g. a UUID). You'll paste the *same* string into Meta's webhook config and into the bot's `WEBHOOK_VERIFY_TOKEN`.
+
+### Wire the webhook
+8. Deploy the bot so it has a public URL (e.g. on Railway), or use a tunnel (ngrok) for local testing.
+9. In **WhatsApp → Configuration → Webhook**, click **Edit**:
+   - **Callback URL** = `https://<your-bot-domain>/webhook` (check the bot's route).
+   - **Verify token** = the string from step 7.
+   - Click **Verify and save** — Meta GET-pings your URL with the token; the bot echoes the challenge back.
+10. Click **Manage** and **subscribe** to the **`messages`** field.
+11. Send "Hi" from one of your added recipient numbers → the bot should reply. ✅
+
+> The temporary token expires in 24h. Before it does, mint a permanent one (Part 2, step C) so the bot doesn't go dark.
+
+---
+
+## Part 2 — Go to production (real number, real teachers)
+
+When you're ready to message anyone (not just your 5 test recipients):
+
+**A. Add your own phone number**
+- In **WhatsApp → API Setup → Add phone number**, register a number you control.
+- **It must NOT currently be active on regular WhatsApp or the WhatsApp Business app.** Use a fresh SIM or a VoIP/landline number that can receive an SMS or voice code. (If the number was in use, delete its WhatsApp account first.)
+- Verify it via the SMS/voice code, and set a **display name** (Meta reviews it — avoid generic words / mismatches or it gets rejected).
+
+**B. Complete Business Verification**
+- In **Meta Business Settings → Security Center / Business Verification**, submit legal-entity documents (incorporation / utility bill / tax certificate; NGOs use registration/charity docs) that **match** your Business Manager's legal name + address.
+- No fixed SLA — hours to several days; it stalls on document mismatches. Verification lifts the test caps and raises your messaging limits.
+
+**C. Mint a permanent access token** (replaces the 24h token)
+- **Business Settings → Users → System Users** → **Add** a system user (Admin).
+- **Add Assets** → assign your **WABA** with **Manage** permission.
+- **Generate new token** → select the app → scopes **`whatsapp_business_messaging`** + **`whatsapp_business_management`** → generate → copy → this is your permanent `WHATSAPP_TOKEN`.
+
+You now have all four production values. Update `.env` and redeploy.
+
+---
+
+## What to know before you scale (gotchas)
+
+- **24-hour service window:** when a teacher messages you, a 24h window opens during which the bot's **free-form replies are free**. Outside it you must send an **approved template** (billed). Rumi is built around this — most teacher-initiated conversations cost nothing.
+- **Messaging limits:** new numbers start at **250 business-initiated conversations / 24h**, auto-raising to 1k → 10k → 100k → unlimited as you verify + keep a good quality rating + sustain volume.
+- **Quality rating** (green/yellow/red): driven by user blocks/reports + template quality. A low rating throttles you and blocks limit upgrades.
+- **Pricing (2026):** per-message, by category (marketing / utility / authentication / service) × country, billed on delivery. **Service replies in the 24h window are free.** A bot that mostly answers within the window is cheap; broadcasts (templates) are where cost grows. See the [cost guide](../cost-guide.md).
+
+---
+
+## Can't pass Business Verification? Use a BSP (360dialog)
+
+If verification is a blocker, or you'd rather not run your own number, a Business Solution Provider can host the WABA while you keep your own webhook:
+
+- **360dialog** — flat ~€49/$50 per number/month, **no per-message markup**, bring-your-own-number (incl. migrating a number already on the WhatsApp Business app), and you point the **webhook at your own server**. No lock-in.
+- Its API differs slightly from raw Cloud API, so the bot may need a thin adapter (not included yet — open an issue if you need it).
+- Avoid per-message-markup BSPs (e.g. Twilio production) for a self-hosted bot unless you're already on them. Twilio's *sandbox* is, however, a fast way to demo without any approval.
+
+---
+
+## Quick reference — the four values
+| Value | Where it comes from |
+|-------|---------------------|
+| `WABA_ID` | WhatsApp → API Setup → WhatsApp Business Account ID |
+| `PHONE_NUMBER_ID` | WhatsApp → API Setup → Phone number ID |
+| `WHATSAPP_TOKEN` | API Setup (temp 24h) → then a System User permanent token (Part 2C) |
+| `WEBHOOK_VERIFY_TOKEN` | A random string you invent, pasted into both Meta's webhook config and `.env` |
+
+Next: get the rest of your [API keys](api-keys.md), then register your interactive Flows + message templates against the WABA (see [SETUP.md](../../SETUP.md)).


### PR DESCRIPTION
## What
Two new onboarding guides + links from SETUP.md, covering the two slowest parts of cloning the platform:

- **`docs/onboarding/api-keys.md`** — every API key, which **8 are required to boot**, how to get each (numbered click-paths), and free-tier/card notes. Organized Tier 0 (required) → Tier 1 (optional features) → Tier 2 (infra).
- **`docs/onboarding/whatsapp.md`** — a two-speed guide: a free **test number working in ~10 minutes** (no business verification), then the production path (own number, verification, permanent token), plus a 360dialog fallback and the scaling gotchas (24h window, messaging limits, pricing).

## Why
WhatsApp credentials and per-provider API keys are where new adopters stall. These turn "figure it out" into a checklist.

## Notes
- Presence-based framing throughout (a feature is on iff its key is set; only 8 keys to start).
- Steps verified against each provider's signup as of May 2026.
- Guard tests pass locally: `source-hygiene` (no secrets/PII in markdown), `link-integrity`, `docs-completeness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)