### PR TITLE
feat(doctor): show where to get each key + link the onboarding guides

### DIFF
--- a/bot/scripts/setup/doctor.js
+++ b/bot/scripts/setup/doctor.js
@@ -24,6 +24,37 @@
 // Single source of truth: bot/shared/config/feature-availability.js
 const { REQUIRED_VARS, FEATURES, isSet } = require('../../shared/config/feature-availability');
 
+// ── "Where do I get this?" hints ─────────────────────────────────────────────
+// Maps an env var to a short source so a stuck operator (or setup agent) sees
+// the next step inline. Full step-by-step: docs/onboarding/api-keys.md +
+// docs/onboarding/whatsapp.md. Gating stays in feature-availability.js; this is
+// human guidance only.
+const KEY_SOURCES = {
+  SUPABASE_URL: 'supabase.com → Settings → API',
+  SUPABASE_SERVICE_ROLE_KEY: 'supabase.com → Settings → API (service_role)',
+  OPENROUTER_API_KEY: 'openrouter.ai/keys',
+  REDIS_URL: 'Railway Redis plugin or upstash.com',
+  WHATSAPP_TOKEN: 'see docs/onboarding/whatsapp.md',
+  PHONE_NUMBER_ID: 'see docs/onboarding/whatsapp.md',
+  WEBHOOK_VERIFY_TOKEN: 'a string you choose (see docs/onboarding/whatsapp.md)',
+  WABA_ID: 'see docs/onboarding/whatsapp.md',
+  SONIOX_API_KEY: 'console.soniox.com',
+  ELEVENLABS_API_KEY: 'elevenlabs.io → API Keys',
+  UPLIFT_API_KEY: 'platform.upliftai.org',
+  GAMMA_API_KEY: 'gamma.app/settings/api-keys (paid plan)',
+  AZURE_SPEECH_KEY: 'portal.azure.com → Speech resource',
+  AZURE_SPEECH_REGION: 'portal.azure.com → Speech resource',
+  KIE_API_KEY: 'kie.ai → API Key',
+  MISTRAL_API_KEY: 'console.mistral.ai → API Keys',
+  AXIOM_DATASET: 'axiom.co → Datasets',
+  AXIOM_TOKEN: 'axiom.co → Settings → API tokens',
+};
+
+/** Short "get it here" hint for an env var, or '' if none documented. */
+function keySource(varName) {
+  return KEY_SOURCES[varName] || '';
+}
+
 // ── Static analysis (pure, no network) ──────────────────────────────────────
 
 /**
@@ -121,18 +152,20 @@ async function runDoctor({ env = process.env, probes = defaultProbes } = {}) {
   // Feature availability (presence + chromium probe).
   const featureResults = [];
   for (const f of analysis.features) {
+    const keyMeta = { requiredKeys: f.requiredKeys, missingKeys: f.missingKeys };
     if (f.probe && probes[f.probe]) {
       try {
         const { ok, detail } = await probes[f.probe](env);
-        featureResults.push({ name: f.name, status: ok ? 'on' : 'off', detail });
+        featureResults.push({ name: f.name, status: ok ? 'on' : 'off', detail, ...keyMeta });
       } catch (err) {
-        featureResults.push({ name: f.name, status: 'off', detail: err.message });
+        featureResults.push({ name: f.name, status: 'off', detail: err.message, ...keyMeta });
       }
     } else {
       featureResults.push({
         name: f.name,
         status: f.available ? 'on' : 'off',
         detail: f.available ? 'keys present' : `set: ${f.requiredKeys.join(', ')}`,
+        ...keyMeta,
       });
     }
   }
@@ -152,17 +185,31 @@ function formatReport(result) {
   lines.push('');
   if (result.missingRequired.length) {
     lines.push('❌ MISSING REQUIRED variables (the bot will not start):');
-    for (const v of result.missingRequired) lines.push(`   - ${v}`);
+    for (const v of result.missingRequired) {
+      const src = keySource(v);
+      lines.push(`   - ${v}${src ? `  → get it: ${src}` : ''}`);
+    }
     lines.push('');
   }
   lines.push('Required services (live checks):');
   for (const p of result.probeResults) lines.push(`  ${mark(p.status)} ${p.name} — ${p.detail}`);
   lines.push('');
   lines.push('Optional features (on when their keys are set):');
-  for (const f of result.featureResults) lines.push(`  ${mark(f.status)} ${f.name} — ${f.detail}`);
+  for (const f of result.featureResults) {
+    // For an off feature, show where to get the key(s) that would switch it on.
+    let hint = '';
+    if (f.status === 'off') {
+      const srcs = (f.missingKeys && f.missingKeys.length ? f.missingKeys : f.requiredKeys || [])
+        .map((k) => keySource(k)).filter(Boolean);
+      if (srcs.length) hint = `  → get it: ${srcs[0]}`;
+    }
+    lines.push(`  ${mark(f.status)} ${f.name} — ${f.detail}${hint}`);
+  }
   lines.push('');
   lines.push(result.ok ? '✅ All required services are configured and reachable.' :
     '❌ Not ready — fix the items marked ❌ above, then re-run `npm run doctor`.');
+  lines.push('');
+  lines.push('📖 Step-by-step key setup: docs/onboarding/api-keys.md · WhatsApp: docs/onboarding/whatsapp.md');
   return lines.join('\n');
 }
 
@@ -177,4 +224,4 @@ async function main() {
 
 if (require.main === module) main();
 
-module.exports = { analyzeEnv, runDoctor, formatReport, REQUIRED_VARS, FEATURES };
+module.exports = { analyzeEnv, runDoctor, formatReport, keySource, KEY_SOURCES, REQUIRED_VARS, FEATURES };

--- a/tests/setup/doctor.test.js
+++ b/tests/setup/doctor.test.js
@@ -8,7 +8,9 @@
  *   - "key present" is not treated as "service works" (probe still runs)
  */
 
-const { analyzeEnv, runDoctor, REQUIRED_VARS } = require('../../bot/scripts/setup/doctor');
+const {
+  analyzeEnv, runDoctor, formatReport, keySource, REQUIRED_VARS,
+} = require('../../bot/scripts/setup/doctor');
 
 const FULL_ENV = {
   SUPABASE_URL: 'https://x.supabase.co',
@@ -105,5 +107,34 @@ describe('runDoctor', () => {
     expect(off.featureResults.find((f) => f.name.includes('Exam')).status).toBe('off');
     const on = await runDoctor({ env: { ...FULL_ENV, MISTRAL_API_KEY: 'k' }, probes: allPassProbes });
     expect(on.featureResults.find((f) => f.name.includes('Exam')).status).toBe('on');
+  });
+});
+
+describe('key sourcing ("get it here" guidance)', () => {
+  it('returns a source hint for a known env var and empty string for unknown', () => {
+    expect(keySource('OPENROUTER_API_KEY')).toMatch(/openrouter/i);
+    expect(keySource('NOT_A_REAL_VAR')).toBe('');
+  });
+
+  it('every REQUIRED var has a documented "get it here" source', () => {
+    const undocumented = REQUIRED_VARS.filter((v) => !keySource(v));
+    expect(undocumented).toEqual([]);
+  });
+
+  it('formatReport shows the source next to a missing required var + points at the guides', async () => {
+    const env = { ...FULL_ENV };
+    delete env.OPENROUTER_API_KEY;
+    const result = await runDoctor({ env, probes: allPassProbes });
+    const report = formatReport(result);
+    expect(report).toMatch(/OPENROUTER_API_KEY.*get it: .*openrouter/i);
+    expect(report).toContain('docs/onboarding/api-keys.md');
+    expect(report).toContain('docs/onboarding/whatsapp.md');
+  });
+
+  it('formatReport shows where to get the key for an OFF optional feature', async () => {
+    const result = await runDoctor({ env: FULL_ENV, probes: allPassProbes });
+    const report = formatReport(result);
+    // Soniox is off in FULL_ENV (no SONIOX_API_KEY) → hint should appear.
+    expect(report).toMatch(/get it: .*soniox/i);
   });
 });


### PR DESCRIPTION
## What
`npm run doctor` already reports which required vars are missing and which optional features are on/off. This makes it a **live, actionable checklist**:

- Each **missing required var** now prints where to get it inline — e.g. `OPENROUTER_API_KEY  → get it: openrouter.ai/keys`.
- Each **off optional feature** shows where to get the key that would switch it on.
- A footer points at the step-by-step guides: `docs/onboarding/api-keys.md` and `docs/onboarding/whatsapp.md`.

Sample:
```
❌ MISSING REQUIRED variables (the bot will not start):
   - OPENROUTER_API_KEY  → get it: openrouter.ai/keys
   - WABA_ID  → get it: see docs/onboarding/whatsapp.md

Optional features (on when their keys are set):
  ➖ Reading pronunciation scoring (Azure) — set: AZURE_SPEECH_KEY, AZURE_SPEECH_REGION  → get it: portal.azure.com → Speech resource

📖 Step-by-step key setup: docs/onboarding/api-keys.md · WhatsApp: docs/onboarding/whatsapp.md
```

## How
- New `KEY_SOURCES` map + `keySource()` helper (human guidance only — gating stays in `feature-availability.js`).
- `formatReport` surfaces the hint next to missing required vars + off features.
- `runDoctor` carries `requiredKeys`/`missingKeys` through to `featureResults`.
- Tests: `keySource` lookup, **every REQUIRED var has a documented source** (completeness guard), and the rendered report shows hints + guide links.

## Tests
`node tests/run.js` → **84 suites / 1091 tests green** (+4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)