### PR TITLE
feat(setup): one-command npm run setup:flows + doctor flow-state

### DIFF
--- a/bot/scripts/setup/doctor.js
+++ b/bot/scripts/setup/doctor.js
@@ -22,7 +22,10 @@
 
 // ── The presence-based contract ─────────────────────────────────────────────
 // Single source of truth: bot/shared/config/feature-availability.js
+const fs = require('fs');
+const path = require('path');
 const { REQUIRED_VARS, FEATURES, isSet } = require('../../shared/config/feature-availability');
+const { FLOW_CONFIGS } = require('./flow-configs');
 
 // ── "Where do I get this?" hints ─────────────────────────────────────────────
 // Maps an env var to a short source so a stuck operator (or setup agent) sees
@@ -53,6 +56,24 @@ const KEY_SOURCES = {
 /** Short "get it here" hint for an env var, or '' if none documented. */
 function keySource(varName) {
   return KEY_SOURCES[varName] || '';
+}
+
+// ── Flow registration state (offline — reads .setup-state.json) ──────────────
+// What `npm run setup:flows` recorded. Informational only: not having flows
+// registered does NOT make the bot un-ready (a minimal deploy may use none, and
+// you can't register them until you have WhatsApp credentials). Run
+// `npm run validate:flows`-style checks against Meta for the live PUBLISHED state.
+function analyzeFlows(state) {
+  const flows = (state && state.flows) || {};
+  return FLOW_CONFIGS.map((c) => {
+    const rec = flows[c.name];
+    return {
+      name: c.name,
+      envVar: c.envVar,
+      registered: !!rec,
+      status: rec ? (rec.status || 'UNKNOWN') : 'not registered',
+    };
+  });
 }
 
 // ── Static analysis (pure, no network) ──────────────────────────────────────
@@ -129,8 +150,20 @@ const REQUIRED_PROBES = [
  * @param {object}   opts.probes  map name->async(env)=>{ok,detail} (default real probes)
  * @returns {Promise<{ ok, missingRequired, probeResults, featureResults }>}
  */
-async function runDoctor({ env = process.env, probes = defaultProbes } = {}) {
+async function runDoctor({
+  env = process.env,
+  probes = defaultProbes,
+  setupState, // inject a parsed .setup-state.json (or null) in tests; otherwise read from disk
+  statePath = path.resolve(process.cwd(), '.setup-state.json'),
+} = {}) {
   const analysis = analyzeEnv(env);
+
+  // Flow registration state (offline). undefined = read from disk; null/object = use as given.
+  let state = setupState;
+  if (state === undefined) {
+    try { state = JSON.parse(fs.readFileSync(statePath, 'utf-8')); } catch { state = null; }
+  }
+  const flowResults = analyzeFlows(state);
 
   // Run REQUIRED probes only for services whose vars are present.
   const probeResults = [];
@@ -173,7 +206,7 @@ async function runDoctor({ env = process.env, probes = defaultProbes } = {}) {
   const probesPassed = probeResults.every((p) => p.status !== 'fail');
   const ok = analysis.missingRequired.length === 0 && probesPassed;
 
-  return { ok, missingRequired: analysis.missingRequired, probeResults, featureResults };
+  return { ok, missingRequired: analysis.missingRequired, probeResults, featureResults, flowResults };
 }
 
 // ── Pretty printer ────────────────────────────────────────────────────────────
@@ -205,6 +238,19 @@ function formatReport(result) {
     }
     lines.push(`  ${mark(f.status)} ${f.name} — ${f.detail}${hint}`);
   }
+  if (result.flowResults && result.flowResults.length) {
+    lines.push('');
+    const anyRegistered = result.flowResults.some((f) => f.registered);
+    lines.push('WhatsApp Flows (registered against your WABA):');
+    if (!anyRegistered) {
+      lines.push('  ➖ none registered yet — run `npm run setup:flows` (after WhatsApp is set up)');
+    } else {
+      for (const f of result.flowResults) {
+        const ok = f.registered && /PUBLISHED|EXISTS/i.test(f.status);
+        lines.push(`  ${ok ? '✅' : '➖'} ${f.name} — ${f.status}`);
+      }
+    }
+  }
   lines.push('');
   lines.push(result.ok ? '✅ All required services are configured and reachable.' :
     '❌ Not ready — fix the items marked ❌ above, then re-run `npm run doctor`.');
@@ -224,4 +270,4 @@ async function main() {
 
 if (require.main === module) main();
 
-module.exports = { analyzeEnv, runDoctor, formatReport, keySource, KEY_SOURCES, REQUIRED_VARS, FEATURES };
+module.exports = { analyzeEnv, analyzeFlows, runDoctor, formatReport, keySource, KEY_SOURCES, REQUIRED_VARS, FEATURES };

--- a/bot/scripts/setup/run-full-setup.js
+++ b/bot/scripts/setup/run-full-setup.js
@@ -2,13 +2,18 @@
 /**
  * Rumi Full Setup Orchestrator
  *
- * Runs all WhatsApp Flow & Template registration steps in order:
+ * Runs all WhatsApp Flow & Template registration steps in order, idempotently
+ * (already-registered flows/templates are skipped):
  *   1. Setup encryption (RSA keypair + Meta registration)
- *   2. Register all 3 flows (Reading Assessment, Attendance Setup, Attendance Marking)
- *   3. Register all 2 templates (Video Style Selection, Feature Menu Carousel)
+ *   2. Register every Flow in flow-configs.js (see FLOW_CONFIGS — the single
+ *      source of truth; endpoint flows need --endpoint-base)
+ *   3. Register the message templates
  *   4. Validate setup (verify flows are PUBLISHED, templates submitted)
  *
- * Usage:
+ * Usage (either form):
+ *   npm run setup:flows -- --waba-id=YOUR_WABA_ID --token=YOUR_TOKEN \
+ *     --phone-number-id=YOUR_PHONE_NUMBER_ID --endpoint-base=https://your-app.up.railway.app
+ *
  *   node bot/scripts/setup/run-full-setup.js \
  *     --waba-id=YOUR_WABA_ID \
  *     --token=YOUR_TOKEN \

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "validate:connections": "node infrastructure/scripts/test-connections.js",
     "bootstrap:db": "node infrastructure/scripts/bootstrap-db.js",
     "doctor": "node bot/scripts/setup/doctor.js",
+    "setup:flows": "node bot/scripts/setup/run-full-setup.js",
     "simulate": "node bot/scripts/simulate.js",
     "setup": "echo 'Use /setup in Claude Code or follow SETUP.md for manual instructions'"
   },

--- a/tests/setup/doctor.test.js
+++ b/tests/setup/doctor.test.js
@@ -9,7 +9,7 @@
  */
 
 const {
-  analyzeEnv, runDoctor, formatReport, keySource, REQUIRED_VARS,
+  analyzeEnv, analyzeFlows, runDoctor, formatReport, keySource, REQUIRED_VARS,
 } = require('../../bot/scripts/setup/doctor');
 
 const FULL_ENV = {
@@ -136,5 +136,33 @@ describe('key sourcing ("get it here" guidance)', () => {
     const report = formatReport(result);
     // Soniox is off in FULL_ENV (no SONIOX_API_KEY) → hint should appear.
     expect(report).toMatch(/get it: .*soniox/i);
+  });
+});
+
+describe('flow registration state (analyzeFlows + doctor reporting)', () => {
+  it('reports every configured flow as not-registered when there is no setup state', () => {
+    const flows = analyzeFlows(null);
+    expect(flows.length).toBeGreaterThan(0);
+    expect(flows.every((f) => f.registered === false)).toBe(true);
+    expect(flows.every((f) => f.status === 'not registered')).toBe(true);
+  });
+
+  it('reflects recorded status for registered flows', () => {
+    const state = { flows: { 'Settings': { flowId: 'f', status: 'PUBLISHED', envVar: 'SETTINGS_FLOW_ID' } } };
+    const flows = analyzeFlows(state);
+    const settings = flows.find((f) => f.envVar === 'SETTINGS_FLOW_ID');
+    expect(settings.registered).toBe(true);
+    expect(settings.status).toBe('PUBLISHED');
+  });
+
+  it('flow state is informational — unregistered flows do NOT make doctor not-ok', async () => {
+    const r = await runDoctor({ env: FULL_ENV, probes: allPassProbes, setupState: null });
+    expect(r.ok).toBe(true); // required present + probes pass; flows don't gate readiness
+    expect(r.flowResults.every((f) => !f.registered)).toBe(true);
+  });
+
+  it('formatReport tells the user to run setup:flows when no flows are registered', async () => {
+    const r = await runDoctor({ env: FULL_ENV, probes: allPassProbes, setupState: null });
+    expect(formatReport(r)).toMatch(/npm run setup:flows/);
   });
 });


### PR DESCRIPTION
## What
Finishes the "smooth sailing after WhatsApp" onboarding step.

1. **`npm run setup:flows`** — wires the existing full-setup orchestrator (encryption → flows → templates → validate, idempotent) to a discoverable npm script:
   ```
   npm run setup:flows -- --waba-id=… --token=… --phone-number-id=… --endpoint-base=https://your-app…
   ```
   Because it drives `flow-configs.js`, it registers **all** configured flows automatically (the header comment was stale at "3 flows / 2 templates").

2. **`npm run doctor` now reports Flow registration state** per configured flow — read offline from `.setup-state.json`:
   ```
   WhatsApp Flows (registered against your WABA):
     ➖ none registered yet — run `npm run setup:flows` (after WhatsApp is set up)
   ```
   …or per-flow `✅ Settings — PUBLISHED` once registered. **Informational only** — flow state does not gate `doctor` readiness (a minimal deploy may use none; flows can't be registered before WhatsApp creds exist).

## How
- `package.json`: add `setup:flows`.
- `run-full-setup.js`: corrected docstring + npm-run usage.
- `doctor.js`: `analyzeFlows()` + a Flows section (state injectable for tests).
- Tests: `analyzeFlows`, informational-not-gating guarantee, the setup:flows hint.

## Tests
`node tests/run.js` → **84 suites / 1095 tests green** (+4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)