### PR TITLE
feat(flows): wire Quiz Manager + Registration flows (presence-gated)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -164,6 +164,8 @@ STUDENT_VIDEOS_FLOW_ID=
 HOMEWORK_FLOW_ID=
 # Edit-class roster flow — empty disables the "edit class" command.
 EDIT_CLASS_FLOW_ID=
+# Quiz Manager flow — empty falls back to the plain-text quiz path.
+QUIZ_FLOW_ID=
 # Optional: default country code (digits only, no +) for expanding locally-typed
 # phone numbers with a leading 0 to E.164. Leave empty to require international format.
 DEFAULT_PHONE_COUNTRY_CODE=

--- a/bot/scripts/setup/flow-configs.js
+++ b/bot/scripts/setup/flow-configs.js
@@ -107,6 +107,18 @@ const FLOW_CONFIGS = [
     envVar: 'QUIZ_FLOW_ID',
     categories: ['OTHER'],
   },
+  {
+    // Optional polished registration form. OSS registration also works
+    // conversationally (name capture); this Flow is sent instead only when
+    // REGISTRATION_FLOW_ID is set. The /registration endpoint already handles
+    // its screens (PERSONAL_INFO / REGION_INFO / PROFESSIONAL_INFO / ORG_DETAILS).
+    name: 'Registration',
+    jsonPath: path.join(FLOWS_DIR, 'registration-flow-v3.json'),
+    type: 'endpoint',
+    endpointPath: '/api/flows/registration',
+    envVar: 'REGISTRATION_FLOW_ID',
+    categories: ['OTHER'],
+  },
 ];
 
 /** The flow names that a complete setup must have registered. */

--- a/bot/scripts/setup/flow-configs.js
+++ b/bot/scripts/setup/flow-configs.js
@@ -99,6 +99,14 @@ const FLOW_CONFIGS = [
     envVar: 'PIC_LP_FLOW_ID',
     categories: ['OTHER'],
   },
+  {
+    name: 'Quiz Manager',
+    jsonPath: path.join(FLOWS_DIR, 'quiz-flow.json'),
+    type: 'endpoint',
+    endpointPath: '/api/flows/quiz',
+    envVar: 'QUIZ_FLOW_ID',
+    categories: ['OTHER'],
+  },
 ];
 
 /** The flow names that a complete setup must have registered. */

--- a/bot/shared/routes/flow-endpoint.routes.js
+++ b/bot/shared/routes/flow-endpoint.routes.js
@@ -59,6 +59,11 @@ const {
   handleEditClassDataExchange,
   handleEditClassBack
 } = require('./edit-class-endpoint');
+const {
+  handleQuizFlowInit,
+  handleQuizFlowDataExchange,
+  handleQuizFlowBack
+} = require('./quiz-flow-endpoint');
 
 /**
  * Handle attendance marking flow data requests
@@ -695,6 +700,46 @@ async function handleStatusFlowRequest(data) {
   if (action === 'BACK')                      return await handleStatusFlowBack(userId, screen, flow_token);
 
   logToFile('Unknown status flow action', { action });
+  return FlowEncryptionService.createErrorResponse('Unknown action');
+}
+
+// ============================================================
+// QUIZ FLOW (Quiz Manager — view/cancel active quizzes, send a new one)
+// ============================================================
+
+router.post('/quiz', async (req, res) => {
+  try {
+    if (!FlowEncryptionService.isConfigured()) {
+      logToFile('Flow encryption not configured', { endpoint: 'quiz' });
+      return res.status(500).json({ error: 'Flow encryption not configured' });
+    }
+    const encryptedResponse = await FlowEncryptionService.processEncryptedRequest(
+      req.body,
+      async (decryptedData) => await handleQuizFlowRequest(decryptedData)
+    );
+    res.set('Content-Type', 'text/plain');
+    res.send(encryptedResponse);
+  } catch (error) {
+    logToFile('Flow endpoint error', { endpoint: 'quiz', error: error.message, stack: error.stack });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+async function handleQuizFlowRequest(data) {
+  const { action, flow_token, screen, data: screenData } = data;
+  logToFile('Handling quiz flow request', {
+    action, screen, hasFlowToken: !!flow_token,
+    screenDataKeys: screenData ? Object.keys(screenData) : []
+  });
+
+  if (action === 'ping') return FlowEncryptionService.handlePing();
+  const userId = (flow_token || '').split(':')[0];
+
+  if (action === 'INIT' || action === 'init') return await handleQuizFlowInit(userId, flow_token);
+  if (action === 'data_exchange')             return await handleQuizFlowDataExchange(userId, screen, screenData, flow_token);
+  if (action === 'BACK')                      return await handleQuizFlowBack(userId, screen, flow_token);
+
+  logToFile('Unknown quiz flow action', { action });
   return FlowEncryptionService.createErrorResponse('Unknown action');
 }
 

--- a/bot/shared/routes/quiz-flow-endpoint.js
+++ b/bot/shared/routes/quiz-flow-endpoint.js
@@ -1,0 +1,427 @@
+'use strict';
+/**
+ * Quiz Flow Endpoint Handler
+ *
+ * /quiz opens this Flow instead of going straight into QuizOrchestrator.
+ * Teacher sees active quizzes with progress, can send a new quiz, or cancel
+ * an active one. State teardown for cancellation handled in
+ * QuizOrchestrator.cancelQuiz.
+ *
+ * Routing (forward-only — Meta requires it):
+ *   MAIN → CONFIRM_CANCEL | NEW_QUIZ_CLASS | SUCCESS
+ *   CONFIRM_CANCEL → SUCCESS
+ *   NEW_QUIZ_CLASS → NEW_QUIZ_LP | NEW_QUIZ_TOPIC | SUCCESS
+ *   NEW_QUIZ_LP → NEW_QUIZ_TOPIC | SUCCESS
+ *   NEW_QUIZ_TOPIC → SUCCESS
+ *
+ * 10-second timeout consideration: quiz generation takes ~30s and CANNOT
+ * happen inside data_exchange. We return SUCCESS immediately and kick off
+ * generation async (setImmediate) — the teacher gets a chat message
+ * "Creating a quiz..." that arrives a few seconds after the flow closes.
+ */
+
+const { logToFile } = require('../utils/logger');
+const supabase = require('../config/supabase');
+
+const ACTIVE_STATUSES = ['ready', 'sent']; // Quizzes that can be cancelled
+
+/**
+ * Flow token format: userId:listIdHint (listIdHint optional, ignored if absent)
+ * Teacher's user.id is used as the flow_token; listIdHint reserved for future.
+ */
+async function handleQuizFlowInit(userId /*, flowToken */) {
+  logToFile('📋 Quiz Flow INIT', { userId });
+  return await buildMainScreen(userId);
+}
+
+async function handleQuizFlowDataExchange(userId, screen, screenData /*, flowToken */) {
+  logToFile('📋 Quiz Flow data_exchange', { userId, screen, screenData });
+
+  if (screen === 'MAIN') {
+    const action = screenData._action;
+    if (action === 'cancel') return await buildConfirmCancelScreen(userId);
+    if (action === 'new')    return await buildNewQuizClassScreen(userId);
+    if (action === 'done')   return buildSuccessScreen('All good — no changes made.', { quizAction: 'done' });
+    return createErrorResponse('Unknown action');
+  }
+
+  if (screen === 'CONFIRM_CANCEL') {
+    return await handleCancelSubmit(userId, screenData._quiz_id);
+  }
+
+  if (screen === 'NEW_QUIZ_CLASS') {
+    return await handleClassPicked(userId, screenData._class_id);
+  }
+
+  if (screen === 'NEW_QUIZ_LP') {
+    return await handleLPPicked(userId, screenData._class_id, screenData._lp_choice);
+  }
+
+  if (screen === 'NEW_QUIZ_TOPIC') {
+    return await handleTopicSubmitted(userId, screenData._class_id, screenData._topic);
+  }
+
+  logToFile('⚠️ Unknown screen in quiz flow', { screen });
+  return createErrorResponse('Unknown screen');
+}
+
+async function handleQuizFlowBack(userId, screen /*, flowToken */) {
+  logToFile('📋 Quiz Flow BACK', { userId, screen });
+  // BACK from any sub-screen → refresh MAIN
+  return await buildMainScreen(userId);
+}
+
+// ─── Builders ──────────────────────────────────────────────────────────────
+
+async function buildMainScreen(userId) {
+  try {
+    const { activeQuizzes, summaryBody, summaryHeading } = await loadActiveQuizSummary(userId);
+
+    const actions = [
+      { id: 'new', title: 'Send a new quiz' }
+    ];
+    if (activeQuizzes.length > 0) {
+      actions.push({ id: 'cancel', title: 'Cancel a quiz' });
+    }
+    actions.push({ id: 'done', title: 'Done' });
+
+    return {
+      screen: 'MAIN',
+      data: {
+        summary_heading: summaryHeading,
+        summary_body: summaryBody,
+        actions
+      }
+    };
+  } catch (err) {
+    logToFile('❌ Error building MAIN', { error: err.message });
+    return createErrorResponse('Could not load quiz menu');
+  }
+}
+
+async function buildConfirmCancelScreen(userId) {
+  const { activeQuizzes } = await loadActiveQuizSummary(userId);
+  if (activeQuizzes.length === 0) {
+    return buildSuccessScreen('No active quizzes to cancel.');
+  }
+  return {
+    screen: 'CONFIRM_CANCEL',
+    data: {
+      active_quizzes: activeQuizzes.map(q => ({
+        id: q.id,
+        title: q.cancelTitle
+      }))
+    }
+  };
+}
+
+async function buildNewQuizClassScreen(userId) {
+  const { data: classes } = await supabase
+    .from('student_lists')
+    .select('id, class_name, section')
+    .eq('user_id', userId)
+    .eq('is_active', true)
+    .order('class_name')
+    .limit(20);
+
+  if (!classes || classes.length === 0) {
+    return buildSuccessScreen('You need to set up a class first. Type "add class" after this.', { quizAction: 'no_class' });
+  }
+
+  return {
+    screen: 'NEW_QUIZ_CLASS',
+    data: {
+      classes: classes.map(c => ({
+        id: c.id,
+        title: c.section ? `${c.class_name} - ${c.section}` : c.class_name
+      }))
+    }
+  };
+}
+
+async function handleClassPicked(userId, classId) {
+  if (!classId) return createErrorResponse('No class selected');
+
+  // Verify ownership
+  const { data: classRow } = await supabase
+    .from('student_lists')
+    .select('id')
+    .eq('id', classId)
+    .eq('user_id', userId)
+    .eq('is_active', true)
+    .single();
+  if (!classRow) return createErrorResponse('Class not found');
+
+  // Recent LPs in last 7 days
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const { data: recentLPs } = await supabase
+    .from('lesson_plans')
+    .select('id, topic, grade, created_at')
+    .eq('user_id', userId)
+    .gte('created_at', sevenDaysAgo)
+    .order('created_at', { ascending: false })
+    .limit(8);
+
+  if (!recentLPs || recentLPs.length === 0) {
+    // No LPs — go straight to topic prompt
+    return {
+      screen: 'NEW_QUIZ_TOPIC',
+      data: { class_id: classId }
+    };
+  }
+
+  const lpOptions = recentLPs.map(lp => ({
+    id: `lp_${lp.id}`,
+    title: trimmed(`${lp.topic} (${humanDate(lp.created_at)})`, 80)
+  }));
+  lpOptions.push({ id: 'new', title: 'New topic (not from a lesson plan)' });
+
+  return {
+    screen: 'NEW_QUIZ_LP',
+    data: {
+      class_id: classId,
+      lp_options: lpOptions
+    }
+  };
+}
+
+async function handleLPPicked(userId, classId, lpChoice) {
+  if (!classId || !lpChoice) return createErrorResponse('Missing class or topic source');
+
+  if (lpChoice === 'new') {
+    return {
+      screen: 'NEW_QUIZ_TOPIC',
+      data: { class_id: classId }
+    };
+  }
+
+  // lpChoice is "lp_<uuid>" — kick off generation async, return SUCCESS
+  const lpId = lpChoice.replace(/^lp_/, '');
+  await kickOffQuizGenerationFromLP(userId, classId, lpId);
+
+  return buildSuccessScreen(
+    "Creating your quiz now. You'll see a confirmation in chat shortly, then your students' parents will receive the quiz invite.",
+    { quizAction: 'new' }
+  );
+}
+
+async function handleTopicSubmitted(userId, classId, topic) {
+  if (!classId || !topic || !topic.trim()) {
+    return createErrorResponse('Topic is required');
+  }
+  await kickOffQuizGenerationFromTopic(userId, classId, topic.trim());
+  return buildSuccessScreen(
+    "Creating your quiz now. You'll see a confirmation in chat shortly, then your students' parents will receive the quiz invite.",
+    { quizAction: 'new', quizTopic: topic.trim() }
+  );
+}
+
+async function handleCancelSubmit(userId, quizId) {
+  if (!quizId) return createErrorResponse('No quiz selected');
+
+  // Defence-in-depth: only allow cancel of OWN quizzes
+  const { data: quiz } = await supabase
+    .from('quizzes')
+    .select('id, teacher_id, status, topic')
+    .eq('id', quizId)
+    .single();
+
+  if (!quiz || quiz.teacher_id !== userId) {
+    return createErrorResponse('Quiz not found');
+  }
+  if (!ACTIVE_STATUSES.includes(quiz.status)) {
+    return buildSuccessScreen(
+      `That quiz is already "${quiz.status}". Nothing to cancel.`,
+      { quizAction: 'cancel_noop', quizTopic: quiz.topic }
+    );
+  }
+
+  try {
+    const QuizOrchestrator = require('../services/quiz/quiz-orchestrator.service');
+    await QuizOrchestrator.cancelQuiz(quizId);
+    return buildSuccessScreen(
+      `Quiz on "${quiz.topic}" cancelled. Parents who hadn't started yet will be told it was cancelled.`,
+      { quizAction: 'cancel', quizTopic: quiz.topic }
+    );
+  } catch (err) {
+    logToFile('❌ Error cancelling quiz', { quizId, error: err.message });
+    return createErrorResponse('Could not cancel the quiz. Please try again.');
+  }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * `quizAction` is surfaced via the flow's extension_message_response.params
+ * so the chat-side handler in whatsapp-bot.js knows what the teacher just
+ * did — and can respond contextually instead of with a generic "Thanks for
+ * your response!" fallback. Detector keys off quiz_action to route to the
+ * Quiz Manager branch.
+ */
+function buildSuccessScreen(message, { quizAction = 'done', quizTopic = null } = {}) {
+  return {
+    screen: 'SUCCESS',
+    data: {
+      success_message: message,
+      extension_message_response: {
+        params: {
+          quiz_action: quizAction,
+          ...(quizTopic ? { quiz_topic: quizTopic } : {})
+        }
+      }
+    }
+  };
+}
+
+function createErrorResponse(message) {
+  return { data: { error: { message } } };
+}
+
+function trimmed(s, max) {
+  if (!s) return '';
+  return s.length > max ? s.slice(0, max - 1) + '…' : s;
+}
+
+function humanDate(iso) {
+  const d = new Date(iso);
+  const now = new Date();
+  const diffH = (now - d) / 3600000;
+  if (diffH < 24) return 'Today';
+  if (diffH < 48) return 'Yesterday';
+  return d.toLocaleDateString('en-PK', { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Pull active quizzes for this teacher, formatted with progress strings.
+ */
+async function loadActiveQuizSummary(userId) {
+  // only quizzes still in flight
+  const { data: quizzes } = await supabase
+    .from('quizzes')
+    .select('id, topic, status, list_id, total_students_sent, created_at')
+    .eq('teacher_id', userId)
+    .in('status', ACTIVE_STATUSES)
+    .order('created_at', { ascending: false })
+    .limit(10);
+
+  const list = quizzes || [];
+
+  if (list.length === 0) {
+    return {
+      activeQuizzes: [],
+      summaryHeading: 'No active quizzes right now.',
+      summaryBody: 'Tap "Send a new quiz" to create one.'
+    };
+  }
+
+  // Pull session progress per quiz in one query
+  const ids = list.map(q => q.id);
+  const { data: sessions } = await supabase
+    .from('quiz_sessions')
+    .select('quiz_id, status')
+    .in('quiz_id', ids);
+
+  // quiz_sessions.status values: invited | active | completed | incomplete |
+  // expired | cancelled. 'active' = in-flight (started, not yet done).
+  const progressByQuiz = {};
+  for (const s of (sessions || [])) {
+    const p = progressByQuiz[s.quiz_id] || { completed: 0, in_progress: 0, invited: 0 };
+    if (s.status === 'completed' || s.status === 'incomplete') p.completed += 1;
+    else if (s.status === 'active') p.in_progress += 1;
+    else if (s.status === 'invited') p.invited += 1;
+    progressByQuiz[s.quiz_id] = p;
+  }
+
+  // Pull class display per list_id
+  const listIds = [...new Set(list.map(q => q.list_id).filter(Boolean))];
+  const { data: classes } = await supabase
+    .from('student_lists')
+    .select('id, class_name, section')
+    .in('id', listIds);
+  const classDisplayById = {};
+  for (const c of (classes || [])) {
+    classDisplayById[c.id] = c.section ? `${c.class_name}-${c.section}` : c.class_name;
+  }
+
+  const enriched = list.map(q => {
+    const cls = classDisplayById[q.list_id] || 'Class';
+    const p = progressByQuiz[q.id] || { completed: 0, in_progress: 0, invited: 0 };
+    // Always derive Sent from the live session count, not the historical
+    // total_students_sent column. The column drifts when delivery skips
+    // happen (queue-skip, session-error fallthrough) without a matching
+    // decrement, and a stale value misleads teachers — the column can run
+    // ahead of the actual session inserts.
+    const sent = p.completed + p.in_progress + p.invited;
+    return {
+      id: q.id,
+      cancelTitle: trimmed(`${q.topic} · ${cls} · Sent ${sent}`, 80),
+      summaryLine: `• ${q.topic} (${cls}) — Sent ${sent} · Done ${p.completed} · Pending ${p.invited}`
+    };
+  });
+
+  return {
+    activeQuizzes: enriched,
+    summaryHeading: `You have ${list.length} active quiz${list.length === 1 ? '' : 'es'}.`,
+    summaryBody: enriched.map(q => q.summaryLine).join('\n')
+  };
+}
+
+/**
+ * Kick off generation+delivery in the background. We can't await this
+ * because the data_exchange has a 10s timeout. setImmediate decouples it.
+ */
+async function kickOffQuizGenerationFromLP(userId, classId, lpId) {
+  setImmediate(async () => {
+    try {
+      const QuizOrchestrator = require('../services/quiz/quiz-orchestrator.service');
+      // Look up user phone from DB
+      const { data: user } = await supabase
+        .from('users')
+        .select('id, phone_number, preferred_language')
+        .eq('id', userId)
+        .single();
+      if (!user) return;
+      const from = user.phone_number.startsWith('+') ? user.phone_number : `+${user.phone_number}`;
+      await QuizOrchestrator.initiateFromLessonPlan(user, from, lpId, user.preferred_language || 'en', classId);
+    } catch (err) {
+      logToFile('❌ Async quiz-from-LP generation failed', { userId, classId, lpId, error: err.message });
+    }
+  });
+}
+
+async function kickOffQuizGenerationFromTopic(userId, classId, topic) {
+  setImmediate(async () => {
+    try {
+      const QuizOrchestrator = require('../services/quiz/quiz-orchestrator.service');
+      const { data: user } = await supabase
+        .from('users')
+        .select('id, phone_number, preferred_language')
+        .eq('id', userId)
+        .single();
+      if (!user) return;
+      const from = user.phone_number.startsWith('+') ? user.phone_number : `+${user.phone_number}`;
+
+      // Resolve class for grade inference
+      const { data: classData } = await supabase
+        .from('student_lists')
+        .select('class_name, section')
+        .eq('id', classId)
+        .single();
+
+      // Re-use the orchestrator's generate-and-deliver via the topic-reply path
+      await QuizOrchestrator.handleTopicReply(user, from, topic, {
+        language: user.preferred_language || 'en',
+        classId
+      });
+    } catch (err) {
+      logToFile('❌ Async quiz-from-topic generation failed', { userId, classId, topic, error: err.message });
+    }
+  });
+}
+
+module.exports = {
+  handleQuizFlowInit,
+  handleQuizFlowDataExchange,
+  handleQuizFlowBack,
+  createErrorResponse
+};

--- a/bot/shared/services/feature-registration.service.js
+++ b/bot/shared/services/feature-registration.service.js
@@ -145,6 +145,30 @@ class FeatureRegistrationService {
    * @param {string} format - 'text' | 'voice'
    */
   static async sendNameQuestion(userId, phoneNumber, language = 'en', format = 'text') {
+    // Presence-gated: if a registration Flow is configured, open the polished
+    // form instead of the conversational name question. Unset (default) → the
+    // conversational path below. The Flow completes via
+    // FlowResponseHandler.handleRegistrationFlow (it does not set
+    // registration_pending_name, which is the text-name path's flag).
+    const REGISTRATION_FLOW_ID = process.env.REGISTRATION_FLOW_ID || '';
+    if (REGISTRATION_FLOW_ID) {
+      try {
+        await WhatsAppService.sendFlow(phoneNumber, {
+          flowId: REGISTRATION_FLOW_ID,
+          flowToken: userId,
+          header: 'Welcome',
+          body: 'Quick setup — tell us a little about you.',
+          footer: 'Powered by Rumi',
+          buttonText: 'Get started',
+        });
+        logToFile('Registration flow sent (presence-gated)', { userId, phoneNumber });
+        return;
+      } catch (error) {
+        logToFile('Registration flow send failed; falling back to name question', { userId, error: error.message });
+        // fall through to the conversational path
+      }
+    }
+
     const messages = {
       en: "By the way, what should I call you?",
       ur: "ویسے، میں آپ کو کیا نام سے بلاؤں؟",

--- a/bot/shared/utils/constants.js
+++ b/bot/shared/utils/constants.js
@@ -45,6 +45,8 @@ const KIE_API_KEY_PIC_LP = process.env.KIE_API_KEY_PIC_LP || process.env.KIE_API
 const RUMI_LOGO_R2_KEY = process.env.RUMI_LOGO_R2_KEY || 'brand/rumi-white-smile-v1.png';
 // WhatsApp Flow ID for the pic-to-LP confirmation form (empty → text fallback).
 const PIC_LP_FLOW_ID = process.env.PIC_LP_FLOW_ID || '';
+// WhatsApp Flow ID for the Quiz Manager form (empty → text fallback / direct path).
+const QUIZ_FLOW_ID = process.env.QUIZ_FLOW_ID || '';
 // Teacher-facing WhatsApp number shown in the lesson-plan Coaching Corner
 // (empty → the contact line is omitted from the rendered LP).
 const COACHING_WHATSAPP_NUMBER = process.env.COACHING_WHATSAPP_NUMBER || '';
@@ -145,6 +147,7 @@ module.exports = {
   KIE_API_KEY_PIC_LP,
   RUMI_LOGO_R2_KEY,
   PIC_LP_FLOW_ID,
+  QUIZ_FLOW_ID,
   COACHING_WHATSAPP_NUMBER,
 
   // Directory Paths

--- a/docs/flows/registration-flow-v3.json
+++ b/docs/flows/registration-flow-v3.json
@@ -1,0 +1,430 @@
+{
+  "version": "6.3",
+  "data_api_version": "3.0",
+  "routing_model": {
+    "PERSONAL_INFO": [
+      "REGION_INFO",
+      "PROFESSIONAL_INFO"
+    ],
+    "REGION_INFO": [
+      "PROFESSIONAL_INFO"
+    ],
+    "PROFESSIONAL_INFO": [
+      "ORG_DETAILS",
+      "SUCCESS"
+    ],
+    "ORG_DETAILS": [
+      "SUCCESS"
+    ],
+    "SUCCESS": []
+  },
+  "screens": [
+    {
+      "id": "PERSONAL_INFO",
+      "title": "Registration",
+      "data": {
+        "countries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          },
+          "__example__": [
+            {
+              "id": "PK",
+              "title": "Pakistan"
+            },
+            {
+              "id": "IN",
+              "title": "India"
+            }
+          ]
+        },
+        "init_full_name": {
+          "type": "string",
+          "__example__": "Ayesha Siddiqa"
+        },
+        "init_country": {
+          "type": "string",
+          "__example__": "PK"
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "personal_form",
+            "init-values": {
+              "full_name": "${data.init_full_name}",
+              "country": "${data.init_country}"
+            },
+            "children": [
+              {
+                "type": "TextHeading",
+                "text": "Welcome to Rumi!"
+              },
+              {
+                "type": "TextBody",
+                "text": "Please register to get started with your AI teaching assistant."
+              },
+              {
+                "type": "TextInput",
+                "name": "full_name",
+                "label": "Full Name",
+                "required": true,
+                "input-type": "text",
+                "helper-text": "Your full name"
+              },
+              {
+                "type": "Dropdown",
+                "name": "country",
+                "label": "Country",
+                "required": true,
+                "data-source": "${data.countries}"
+              },
+              {
+                "type": "Footer",
+                "label": "Next",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "full_name": "${form.full_name}",
+                    "country": "${form.country}"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "REGION_INFO",
+      "title": "Region",
+      "data": {
+        "regions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          },
+          "__example__": [
+            {
+              "id": "punjab",
+              "title": "Punjab"
+            },
+            {
+              "id": "sindh",
+              "title": "Sindh"
+            }
+          ]
+        },
+        "init_region": {
+          "type": "string",
+          "__example__": "punjab"
+        },
+        "init_emis_code": {
+          "type": "string",
+          "__example__": "37330614"
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "region_form",
+            "init-values": {
+              "region": "${data.init_region}",
+              "emis_code": "${data.init_emis_code}"
+            },
+            "children": [
+              {
+                "type": "TextHeading",
+                "text": "Select Your Region"
+              },
+              {
+                "type": "TextBody",
+                "text": "Please select your region or province in Pakistan."
+              },
+              {
+                "type": "Dropdown",
+                "name": "region",
+                "label": "Region / Province",
+                "required": false,
+                "data-source": "${data.regions}"
+              },
+              {
+                "type": "TextInput",
+                "name": "emis_code",
+                "label": "School EMIS Code",
+                "required": false,
+                "input-type": "number",
+                "helper-text": "Your school's unique code from the education department"
+              },
+              {
+                "type": "Footer",
+                "label": "Next",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "region": "${form.region}",
+                    "emis_code": "${form.emis_code}"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "PROFESSIONAL_INFO",
+      "title": "Professional Info",
+      "data": {
+        "init_school_name": {
+          "type": "string",
+          "__example__": "GGES Jail Colony"
+        },
+        "init_organization": {
+          "type": "string",
+          "__example__": "sed_punjab"
+        },
+        "organizations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          },
+          "__example__": [
+            {
+              "id": "example_org",
+              "title": "Example Organization"
+            },
+            {
+              "id": "fde",
+              "title": "FDE"
+            }
+          ]
+        },
+        "grades": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          },
+          "__example__": [
+            {
+              "id": "grade_1",
+              "title": "Grade 1"
+            },
+            {
+              "id": "grade_2",
+              "title": "Grade 2"
+            }
+          ]
+        },
+        "subjects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          },
+          "__example__": [
+            {
+              "id": "maths",
+              "title": "Maths"
+            },
+            {
+              "id": "english",
+              "title": "English"
+            }
+          ]
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "professional_form",
+            "init-values": {
+              "school_name": "${data.init_school_name}",
+              "organization": "${data.init_organization}"
+            },
+            "children": [
+              {
+                "type": "TextHeading",
+                "text": "Professional Details"
+              },
+              {
+                "type": "Dropdown",
+                "name": "organization",
+                "label": "Organization / Partner",
+                "required": true,
+                "data-source": "${data.organizations}"
+              },
+              {
+                "type": "TextInput",
+                "name": "school_name",
+                "label": "School Name",
+                "required": true,
+                "input-type": "text",
+                "helper-text": "Name of your school"
+              },
+              {
+                "type": "CheckboxGroup",
+                "name": "grade",
+                "label": "Grades You Teach",
+                "required": false,
+                "min-selected-items": 0,
+                "max-selected-items": 12,
+                "data-source": "${data.grades}"
+              },
+              {
+                "type": "CheckboxGroup",
+                "name": "subjects",
+                "label": "Subjects You Teach",
+                "required": false,
+                "min-selected-items": 0,
+                "max-selected-items": 11,
+                "data-source": "${data.subjects}"
+              },
+              {
+                "type": "Footer",
+                "label": "Complete Registration",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "organization": "${form.organization}",
+                    "school_name": "${form.school_name}",
+                    "grade": "${form.grade}",
+                    "subjects": "${form.subjects}"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ORG_DETAILS",
+      "title": "Organization Name",
+      "data": {},
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "org_details_form",
+            "children": [
+              {
+                "type": "TextHeading",
+                "text": "Enter Organization Name"
+              },
+              {
+                "type": "TextBody",
+                "text": "Please type your organization or partner name below."
+              },
+              {
+                "type": "TextInput",
+                "name": "organization_other",
+                "label": "Organization Name",
+                "required": true,
+                "input-type": "text",
+                "helper-text": "Enter the name of your organization"
+              },
+              {
+                "type": "Footer",
+                "label": "Complete Registration",
+                "on-click-action": {
+                  "name": "data_exchange",
+                  "payload": {
+                    "organization_other": "${form.organization_other}"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SUCCESS",
+      "title": "Registration Complete",
+      "terminal": true,
+      "data": {
+        "welcome_message": {
+          "type": "string",
+          "__example__": "Welcome, Teacher! Your registration is complete."
+        },
+        "portal_message": {
+          "type": "string",
+          "__example__": "Your portal is ready at your-portal.example.com"
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "TextHeading",
+            "text": "Registration Complete!"
+          },
+          {
+            "type": "TextBody",
+            "text": "${data.welcome_message}"
+          },
+          {
+            "type": "TextBody",
+            "text": "${data.portal_message}"
+          },
+          {
+            "type": "Footer",
+            "label": "Done",
+            "on-click-action": {
+              "name": "complete",
+              "payload": {}
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/quiz/quiz-flow-endpoint.test.js
+++ b/tests/quiz/quiz-flow-endpoint.test.js
@@ -1,0 +1,30 @@
+/**
+ * quiz-flow-endpoint — smoke test.
+ *
+ * `node --check` only syntax-parses; it does not resolve require()s. This test
+ * actually loads the module with bot-only infra deps mocked (the established
+ * pattern — see status-flow.test.js), so a missing/renamed quiz dependency
+ * surfaces here rather than at runtime, and confirms the three Flow handlers
+ * the route dispatcher imports are present.
+ */
+
+describe('quiz-flow-endpoint module', () => {
+  it('loads with infra mocked and exports the three flow handlers', () => {
+    jest.resetModules();
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
+
+    const mod = require('../../bot/shared/routes/quiz-flow-endpoint');
+    expect(typeof mod.handleQuizFlowInit).toBe('function');
+    expect(typeof mod.handleQuizFlowDataExchange).toBe('function');
+    expect(typeof mod.handleQuizFlowBack).toBe('function');
+  });
+
+  it('is wired into flow-configs as the /api/flows/quiz endpoint flow', () => {
+    const { FLOW_CONFIGS } = require('../../bot/scripts/setup/flow-configs');
+    const quiz = FLOW_CONFIGS.find((f) => f.envVar === 'QUIZ_FLOW_ID');
+    expect(quiz).toBeDefined();
+    expect(quiz.type).toBe('endpoint');
+    expect(quiz.endpointPath).toBe('/api/flows/quiz');
+  });
+});

--- a/tests/registration/registration-flow-gate.test.js
+++ b/tests/registration/registration-flow-gate.test.js
@@ -1,0 +1,50 @@
+/**
+ * Registration flow gating — sendNameQuestion opens the WhatsApp registration
+ * Flow when REGISTRATION_FLOW_ID is set, and falls back to the conversational
+ * name question (OSS default) when it is unset. Presence-gated.
+ */
+
+describe('registration flow gating (FeatureRegistrationService.sendNameQuestion)', () => {
+  const ORIG = process.env.REGISTRATION_FLOW_ID;
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env.REGISTRATION_FLOW_ID;
+    else process.env.REGISTRATION_FLOW_ID = ORIG;
+  });
+
+  function load() {
+    jest.resetModules();
+    jest.doMock('uuid', () => ({ v4: () => 'test-uuid' }), { virtual: true });
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    const sendFlow = jest.fn().mockResolvedValue(true);
+    const sendMessage = jest.fn().mockResolvedValue(true);
+    jest.doMock('../../bot/shared/services/whatsapp.service', () => ({
+      sendFlow, sendMessage, sendAudio: jest.fn().mockResolvedValue(true),
+    }));
+    jest.doMock('../../bot/shared/config/supabase', () => ({
+      from: () => ({ update: () => ({ eq: () => Promise.resolve({ error: null }) }) }),
+    }));
+    jest.doMock('../../bot/shared/services/audio.service', () => ({
+      generateSpeechForLanguage: jest.fn().mockResolvedValue(Buffer.from('')),
+    }));
+    jest.doMock('../../bot/shared/utils/constants', () => ({ TEMP_DIR: '/tmp' }));
+    const Svc = require('../../bot/shared/services/feature-registration.service');
+    return { Svc, sendFlow, sendMessage };
+  }
+
+  it('opens the registration Flow when REGISTRATION_FLOW_ID is set', async () => {
+    process.env.REGISTRATION_FLOW_ID = 'flow_reg_test';
+    const { Svc, sendFlow, sendMessage } = load();
+    await Svc.sendNameQuestion('u1', '+100', 'en', 'text');
+    expect(sendFlow).toHaveBeenCalledTimes(1);
+    expect(sendFlow.mock.calls[0][1].flowId).toBe('flow_reg_test');
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the conversational name question when REGISTRATION_FLOW_ID is unset', async () => {
+    delete process.env.REGISTRATION_FLOW_ID;
+    const { Svc, sendFlow, sendMessage } = load();
+    await Svc.sendNameQuestion('u1', '+100', 'en', 'text');
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendFlow).not.toHaveBeenCalled();
+  });
+});

--- a/tests/setup/flow-config-conformance.test.js
+++ b/tests/setup/flow-config-conformance.test.js
@@ -29,8 +29,9 @@ const ORPHAN_JSON_ALLOWLIST = new Set([
 // *_FLOW_ID env vars the bot reads but for which NO Flow JSON ships yet, so they
 // can't be registered. Tracked here so the gap is visible, not silently re-broken.
 const CONSUMER_WITHOUT_ASSET = new Set([
+  // exam-checker reads this but ships no Flow JSON and is intentionally unset on
+  // prod (hardcoded fallback IDs) — optional, documented, not registerable here.
   'EXAM_CHECKER_STUDENTS_FLOW_ID',
-  'REGISTRATION_FLOW_ID',
 ]);
 
 function walk(dir, acc = []) {

--- a/tests/setup/flow-config-conformance.test.js
+++ b/tests/setup/flow-config-conformance.test.js
@@ -22,7 +22,8 @@ const ROUTES_FILE = path.join(BOT_DIR, 'shared/routes/flow-endpoint.routes.js');
 // Flow JSON that ships but is intentionally NOT registered yet (no env consumer
 // / not wired). Keep this list short and justified.
 const ORPHAN_JSON_ALLOWLIST = new Set([
-  'quiz-flow.json', // present as an asset; no QUIZ_FLOW_ID consumer wired yet.
+  // (empty) — quiz-flow.json is now wired: QUIZ_FLOW_ID constant + /api/flows/quiz
+  // endpoint + flow-configs entry.
 ]);
 
 // *_FLOW_ID env vars the bot reads but for which NO Flow JSON ships yet, so they

--- a/tests/setup/register-all-flows.test.js
+++ b/tests/setup/register-all-flows.test.js
@@ -93,9 +93,9 @@ describe('register-all-flows', () => {
   // FLOW_CONFIGS
   // -----------------------------------------------------------------------
   describe('FLOW_CONFIGS', () => {
-    it('exports an array of all 10 registerable flow configurations', () => {
+    it('exports an array of all 11 registerable flow configurations', () => {
       expect(Array.isArray(FLOW_CONFIGS)).toBe(true);
-      expect(FLOW_CONFIGS).toHaveLength(10);
+      expect(FLOW_CONFIGS).toHaveLength(11);
     });
 
     it('includes Reading Assessment as a navigate type with no endpointPath', () => {
@@ -361,10 +361,10 @@ describe('register-all-flows', () => {
       expect(Array.isArray(result.errors)).toBe(true);
     });
 
-    it('registers all 10 flows when none exist and endpointBase is provided', async () => {
+    it('registers all 11 flows when none exist and endpointBase is provided', async () => {
       const result = await registerAllFlows(DEFAULT_OPTS);
 
-      expect(result.registered).toHaveLength(10);
+      expect(result.registered).toHaveLength(11);
       expect(result.skipped).toHaveLength(0);
       expect(result.errors).toHaveLength(0);
     });
@@ -406,7 +406,7 @@ describe('register-all-flows', () => {
 
       expect(result.skipped).toHaveLength(1);
       expect(result.skipped[0].name).toBe('Reading Assessment');
-      expect(result.registered).toHaveLength(9);
+      expect(result.registered).toHaveLength(10);
     });
 
     it('skips all flows when all already exist', async () => {
@@ -417,7 +417,7 @@ describe('register-all-flows', () => {
 
       const result = await registerAllFlows(DEFAULT_OPTS);
 
-      expect(result.skipped).toHaveLength(10);
+      expect(result.skipped).toHaveLength(11);
       expect(result.registered).toHaveLength(0);
       expect(result.errors).toHaveLength(0);
     });
@@ -449,7 +449,7 @@ describe('register-all-flows', () => {
       // Reading Assessment should register, attendance flows should be skipped
       expect(result.registered).toHaveLength(1);
       expect(result.registered[0].name).toBe('Reading Assessment');
-      expect(result.skipped).toHaveLength(9);
+      expect(result.skipped).toHaveLength(10);
       expect(result.skipped.map((s) => s.name)).toContain('Attendance Setup');
       expect(result.skipped.map((s) => s.name)).toContain('Attendance Marking');
     });
@@ -479,7 +479,7 @@ describe('register-all-flows', () => {
 
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0].name).toBe('Reading Assessment');
-      expect(result.registered).toHaveLength(9);
+      expect(result.registered).toHaveLength(10);
     });
 
     it('collects errors with flow name and error message', async () => {
@@ -491,7 +491,7 @@ describe('register-all-flows', () => {
 
       const result = await registerAllFlows(DEFAULT_OPTS);
 
-      expect(result.errors).toHaveLength(10);
+      expect(result.errors).toHaveLength(11);
       for (const err of result.errors) {
         expect(err).toHaveProperty('name');
         expect(err).toHaveProperty('error');
@@ -504,7 +504,7 @@ describe('register-all-flows', () => {
     it('calls state.setFlow for each successfully registered flow', async () => {
       await registerAllFlows(DEFAULT_OPTS);
 
-      expect(mockState.setFlow).toHaveBeenCalledTimes(10);
+      expect(mockState.setFlow).toHaveBeenCalledTimes(11);
     });
 
     it('calls state.setFlow for skipped (existing) flows too', async () => {
@@ -515,7 +515,7 @@ describe('register-all-flows', () => {
 
       await registerAllFlows(DEFAULT_OPTS);
 
-      expect(mockState.setFlow).toHaveBeenCalledTimes(10);
+      expect(mockState.setFlow).toHaveBeenCalledTimes(11);
     });
 
     it('does not call state.setFlow for errored flows', async () => {

--- a/tests/setup/register-all-flows.test.js
+++ b/tests/setup/register-all-flows.test.js
@@ -93,9 +93,9 @@ describe('register-all-flows', () => {
   // FLOW_CONFIGS
   // -----------------------------------------------------------------------
   describe('FLOW_CONFIGS', () => {
-    it('exports an array of all 9 registerable flow configurations', () => {
+    it('exports an array of all 10 registerable flow configurations', () => {
       expect(Array.isArray(FLOW_CONFIGS)).toBe(true);
-      expect(FLOW_CONFIGS).toHaveLength(9);
+      expect(FLOW_CONFIGS).toHaveLength(10);
     });
 
     it('includes Reading Assessment as a navigate type with no endpointPath', () => {
@@ -361,10 +361,10 @@ describe('register-all-flows', () => {
       expect(Array.isArray(result.errors)).toBe(true);
     });
 
-    it('registers all 9 flows when none exist and endpointBase is provided', async () => {
+    it('registers all 10 flows when none exist and endpointBase is provided', async () => {
       const result = await registerAllFlows(DEFAULT_OPTS);
 
-      expect(result.registered).toHaveLength(9);
+      expect(result.registered).toHaveLength(10);
       expect(result.skipped).toHaveLength(0);
       expect(result.errors).toHaveLength(0);
     });
@@ -406,7 +406,7 @@ describe('register-all-flows', () => {
 
       expect(result.skipped).toHaveLength(1);
       expect(result.skipped[0].name).toBe('Reading Assessment');
-      expect(result.registered).toHaveLength(8);
+      expect(result.registered).toHaveLength(9);
     });
 
     it('skips all flows when all already exist', async () => {
@@ -417,7 +417,7 @@ describe('register-all-flows', () => {
 
       const result = await registerAllFlows(DEFAULT_OPTS);
 
-      expect(result.skipped).toHaveLength(9);
+      expect(result.skipped).toHaveLength(10);
       expect(result.registered).toHaveLength(0);
       expect(result.errors).toHaveLength(0);
     });
@@ -449,7 +449,7 @@ describe('register-all-flows', () => {
       // Reading Assessment should register, attendance flows should be skipped
       expect(result.registered).toHaveLength(1);
       expect(result.registered[0].name).toBe('Reading Assessment');
-      expect(result.skipped).toHaveLength(8);
+      expect(result.skipped).toHaveLength(9);
       expect(result.skipped.map((s) => s.name)).toContain('Attendance Setup');
       expect(result.skipped.map((s) => s.name)).toContain('Attendance Marking');
     });
@@ -479,7 +479,7 @@ describe('register-all-flows', () => {
 
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0].name).toBe('Reading Assessment');
-      expect(result.registered).toHaveLength(8);
+      expect(result.registered).toHaveLength(9);
     });
 
     it('collects errors with flow name and error message', async () => {
@@ -491,7 +491,7 @@ describe('register-all-flows', () => {
 
       const result = await registerAllFlows(DEFAULT_OPTS);
 
-      expect(result.errors).toHaveLength(9);
+      expect(result.errors).toHaveLength(10);
       for (const err of result.errors) {
         expect(err).toHaveProperty('name');
         expect(err).toHaveProperty('error');
@@ -504,7 +504,7 @@ describe('register-all-flows', () => {
     it('calls state.setFlow for each successfully registered flow', async () => {
       await registerAllFlows(DEFAULT_OPTS);
 
-      expect(mockState.setFlow).toHaveBeenCalledTimes(9);
+      expect(mockState.setFlow).toHaveBeenCalledTimes(10);
     });
 
     it('calls state.setFlow for skipped (existing) flows too', async () => {
@@ -515,7 +515,7 @@ describe('register-all-flows', () => {
 
       await registerAllFlows(DEFAULT_OPTS);
 
-      expect(mockState.setFlow).toHaveBeenCalledTimes(9);
+      expect(mockState.setFlow).toHaveBeenCalledTimes(10);
     });
 
     it('does not call state.setFlow for errored flows', async () => {

--- a/tests/setup/validate-flows.test.js
+++ b/tests/setup/validate-flows.test.js
@@ -76,6 +76,10 @@ function buildCompleteState(overrides = {}) {
         flowId: 'flow_pl_9', status: 'PUBLISHED', envVar: 'PIC_LP_FLOW_ID',
         type: 'endpoint', endpointPath: '/api/flows/pic-lp', registeredAt: now,
       },
+      'Quiz Manager': {
+        flowId: 'flow_qz_10', status: 'PUBLISHED', envVar: 'QUIZ_FLOW_ID',
+        type: 'endpoint', endpointPath: '/api/flows/quiz', registeredAt: now,
+      },
     },
     templates: {
       welcome_message: { templateId: 'tpl_1', status: 'APPROVED', registeredAt: now },
@@ -176,7 +180,7 @@ describe('validateSetup', () => {
         statePath,
       });
 
-      expect(mockGetFlowDetails).toHaveBeenCalledTimes(9);
+      expect(mockGetFlowDetails).toHaveBeenCalledTimes(10);
       expect(mockGetFlowDetails).toHaveBeenCalledWith('flow_ra_1');
       expect(mockGetFlowDetails).toHaveBeenCalledWith('flow_as_2');
       expect(mockGetFlowDetails).toHaveBeenCalledWith('flow_am_3');

--- a/tests/setup/validate-flows.test.js
+++ b/tests/setup/validate-flows.test.js
@@ -80,6 +80,10 @@ function buildCompleteState(overrides = {}) {
         flowId: 'flow_qz_10', status: 'PUBLISHED', envVar: 'QUIZ_FLOW_ID',
         type: 'endpoint', endpointPath: '/api/flows/quiz', registeredAt: now,
       },
+      'Registration': {
+        flowId: 'flow_reg_11', status: 'PUBLISHED', envVar: 'REGISTRATION_FLOW_ID',
+        type: 'endpoint', endpointPath: '/api/flows/registration', registeredAt: now,
+      },
     },
     templates: {
       welcome_message: { templateId: 'tpl_1', status: 'APPROVED', registeredAt: now },
@@ -180,7 +184,7 @@ describe('validateSetup', () => {
         statePath,
       });
 
-      expect(mockGetFlowDetails).toHaveBeenCalledTimes(10);
+      expect(mockGetFlowDetails).toHaveBeenCalledTimes(11);
       expect(mockGetFlowDetails).toHaveBeenCalledWith('flow_ra_1');
       expect(mockGetFlowDetails).toHaveBeenCalledWith('flow_as_2');
       expect(mockGetFlowDetails).toHaveBeenCalledWith('flow_am_3');


### PR DESCRIPTION
## What
Completes the **Quiz Manager flow**, which was half-ported (a sync-drop regression): `quiz-flow.json` + a gated send trigger (`quiz-intent-router`) shipped, but `QUIZ_FLOW_ID` was imported-but-never-defined (dead path) and there was no `/quiz` endpoint or `flow-configs` entry.

- Define `QUIZ_FLOW_ID` (presence-gated) in `constants.js`.
- Add the `/api/flows/quiz` data-exchange endpoint (`quiz-flow-endpoint.js` — MAIN / CONFIRM_CANCEL / NEW_QUIZ_* screens) + mount in `flow-endpoint.routes.js`.
- Register **Quiz Manager** in `flow-configs.js` → `npm run setup:flows` now registers it.
- Adapt the in-flight progress check to the OSS `quiz_sessions` schema (`'active'`, not prod's `'in_progress'`).
- Document `QUIZ_FLOW_ID` in `.env.template`; conformance guard no longer allowlists `quiz-flow.json`; added an endpoint smoke test.

## Why presence-gated
With `QUIZ_FLOW_ID` unset (the default), the quiz feature keeps its existing plain-text path — **zero behavior change** for current deployments. Set the key + run `setup:flows` to enable the Flow.

## Verified against prod
This was identified by auditing the production bot's actual flow usage (not the OSS repo alone). Quiz's dependencies (`QuizOrchestrator` methods, tables) were confirmed present in OSS; the only schema divergence (`status` value) is handled.

## Tests
`node tests/run.js` → **84 suites / 1097 tests** green (+2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)