### PR TITLE
polish + chore(deps): five honest-output fixes + drop two orphan deps

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -43,7 +43,7 @@ when you want it on. `.env.template` documents every feature's keys under an `EN
 | Spoken replies (TTS) | `ELEVENLABS_API_KEY` (+ `UPLIFT_API_KEY` for Urdu/regional) |
 | Reading pronunciation scoring | `AZURE_SPEECH_KEY` |
 | Lesson-plan generation | `GAMMA_API_KEY` |
-| Educational video | `KIE_API_KEY` + the `R2_*` storage keys |
+| Educational video | `VIDEO_GENERATION_ENABLED=true` + `KIE_API_KEY` |
 
 The single source of truth for what each key enables is
 [bot/shared/config/feature-availability.js](../../../bot/shared/config/feature-availability.js).

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -37,7 +37,6 @@
         "express-session": "^1.18.2",
         "fluent-ffmpeg": "^2.1.3",
         "form-data": "^4.0.4",
-        "html-pdf-node": "^1.0.8",
         "ioredis": "^5.4.1",
         "jsonrepair": "^3.13.1",
         "mammoth": "^1.8.0",
@@ -57,7 +56,6 @@
       },
       "devDependencies": {
         "jest": "^30.2.0",
-        "pdf2pic": "^3.2.0",
         "pino-pretty": "^13.1.3"
       }
     },
@@ -3480,12 +3478,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jonkemp/package-utils": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@jonkemp/package-utils/-/package-utils-1.0.8.tgz",
-      "integrity": "sha512-bIcKnH5YmtTYr7S6J3J86dn/rFiklwRpOqbTOQ9C0WMmR9FKHVb3bxs2UYfqEmNb93O4nbA97sb6rtz33i9SyA==",
-      "license": "MIT"
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -4941,16 +4933,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -5444,20 +5426,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/array-parallel": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
-      "integrity": "sha512-TDPTwSWW5E4oiFiKmz6RGJ/a80Y91GuLgUYuLd49+XBS75tYo8PNgaT2K/OxuQYqkoI852MDGBorg9OcUSTQ8w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/array-series": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
-      "integrity": "sha512-L0XlBwfx9QetHOsbLDrE/vh2t018w9462HM3iaFfxRiK83aJjAt/Ja3NMkOW7FICwWTlQBa3ZbL5FKhuQWkDrg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/async": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
@@ -5670,12 +5638,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/batch": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
-      "license": "MIT"
-    },
     "node_modules/bcryptjs": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
@@ -5778,12 +5740,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -6177,33 +6133,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/cheerio": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-      "integrity": "sha512-8/MzidM6G/TgRelkzDG13y3Y9LxBjCb+8yOEZ9+wwq5gVF2w2pV0wmHvjfT0RvuxGyR7UEuK36r+yYMbT4uKgA==",
-      "license": "MIT",
-      "dependencies": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash.assignin": "^4.0.9",
-        "lodash.bind": "^4.1.4",
-        "lodash.defaults": "^4.0.1",
-        "lodash.filter": "^4.4.0",
-        "lodash.flatten": "^4.2.0",
-        "lodash.foreach": "^4.3.0",
-        "lodash.map": "^4.4.0",
-        "lodash.merge": "^4.4.0",
-        "lodash.pick": "^4.2.1",
-        "lodash.reduce": "^4.4.0",
-        "lodash.reject": "^4.4.0",
-        "lodash.some": "^4.4.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -6496,42 +6425,6 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
-    "node_modules/css-rules": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/css-rules/-/css-rules-1.1.0.tgz",
-      "integrity": "sha512-7L6krLIRwAEVCaVKyCEL6PQjQXUmf8DM9bWYKutlZd0DqOe0SiKIGQOkFb59AjDBb+3If7SDp3X8UlzDAgYSow==",
-      "license": "MIT",
-      "dependencies": {
-        "cssom": "^0.5.0"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-      "integrity": "sha512-dUQOBoqdR7QwV90WysXPLXG5LO7nhYBgiWVfxF80DKPF8zx1t/pUd2FYy73emg3zrjtM6dzmYgbHKfV2rxiHQA==",
-      "license": "BSD-like",
-      "dependencies": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
-        "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "license": "MIT"
-    },
     "node_modules/csv-parser": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.2.0.tgz",
@@ -6732,12 +6625,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.901419",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
-      "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/dfa": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
@@ -6749,40 +6636,6 @@
       "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
       "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -6929,12 +6782,6 @@
       "dependencies": {
         "once": "^1.4.0"
       }
-    },
-    "node_modules/entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -7262,38 +7109,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/extract-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-css/-/extract-css-2.0.1.tgz",
-      "integrity": "sha512-DX3+27l6NIVYNidJjBJ4VU3Z5tk/0aEO/JJ6XEJIRPFum9kyA1PifPjnEa8Ztnv4DHNQg5EF27aypGz6s/fMdw==",
-      "license": "MIT",
-      "dependencies": {
-        "batch": "^0.6.1",
-        "href-content": "^2.0.1",
-        "list-stylesheets": "^1.2.10",
-        "style-data": "^1.4.8"
-      }
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-copy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
@@ -7362,15 +7177,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/fetch-retry": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
@@ -7428,12 +7234,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/flat-util": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/flat-util/-/flat-util-1.1.11.tgz",
-      "integrity": "sha512-h9ho3lHr5hDTQZKLqFDqIliDV/A8yCyP7UoSIBT4U3d7VfA/EeqsC8cxWJGIr5oCxZzMD/3BEx3SLYFX6hD8ng==",
-      "license": "MIT"
     },
     "node_modules/fluent-ffmpeg": {
       "version": "2.1.3",
@@ -7857,33 +7657,6 @@
         "node": "*"
       }
     },
-    "node_modules/gm": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/gm/-/gm-1.25.1.tgz",
-      "integrity": "sha512-jgcs2vKir9hFogGhXIfs0ODhJTfIrbECCehg38tqFgHm8zqXx7kAJyCYAFK4jTjx71AxrkFtkJBawbAxYUPX9A==",
-      "deprecated": "The gm module has been sunset. Please migrate to an alternative. https://github.com/aheckmann/gm?tab=readme-ov-file#2025-02-24-this-project-is-not-maintained",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-parallel": "~0.1.3",
-        "array-series": "~0.1.5",
-        "cross-spawn": "^7.0.5",
-        "debug": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/gm/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7901,27 +7674,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7997,47 +7749,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/href-content": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/href-content/-/href-content-2.0.3.tgz",
-      "integrity": "sha512-ikrAoI1l5ihN5Be2cR9nozFfivVJxPQDpa4+sb6PLt/uaNE/a7A05rHbnJEUduoHddbB3GyT5tdqzXMUmPgJYA==",
-      "license": "MIT",
-      "dependencies": {
-        "remote-content": "^4.0.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/html-pdf-node": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/html-pdf-node/-/html-pdf-node-1.0.8.tgz",
-      "integrity": "sha512-1PXbShoVXy8/86ZBY3xQNd5r2c/CPx/Me2wGtV0Z0Rekko5Tgow2hLms2n+OwA+PV7NyR7OPcTqsnhXIMUJLFw==",
-      "license": "ISC",
-      "dependencies": {
-        "bluebird": "^3.7.2",
-        "handlebars": "^4.7.6",
-        "inline-css": "^3.0.0",
-        "puppeteer": "^10.4.0"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -8163,24 +7880,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
-    },
-    "node_modules/inline-css": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/inline-css/-/inline-css-3.0.0.tgz",
-      "integrity": "sha512-a+IE7oLaQqeVr3hMviekDDk94LA0+oZX8JEfJuXOm20diZAkOFrq/f/QZCEXpMK6qIbYr0nQNpsuioXQN1ZgXA==",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio": "^0.22.0",
-        "css-rules": "^1.0.9",
-        "extract-css": "^2.0.0",
-        "flat-util": "^1.1.6",
-        "pick-util": "^1.1.3",
-        "slick": "^1.12.2",
-        "specificity": "^0.4.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/ioredis": {
       "version": "5.9.2",
@@ -9435,16 +9134,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/list-stylesheets": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/list-stylesheets/-/list-stylesheets-1.2.10.tgz",
-      "integrity": "sha512-F85Yx9GKLJwDr1T9U34FST5m6iIXhPzqD+MRDsljZsdmoEZwllZBDbkAVaa+EpLKrr6de+P4SRGNHwrWv6zMZA==",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio": "^0.22.0",
-        "pick-util": "^1.1.4"
-      }
-    },
     "node_modules/listenercount": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
@@ -9462,18 +9151,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash.assignin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-      "integrity": "sha512-yX/rx6d/UTVh7sSVWVSIMjfnz95evAgDFdb1ZozC35I9mSFCkmzptOzevxjgbQUsc78NR44LVHWjsoMQXy9FDg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.bind": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-      "integrity": "sha512-lxdsn7xxlCymgLYo1gGvVrfHmkjDiyqVv62FAeF2i5ta72BipE1SLxw8hPEPLhD4/247Ijw07UQH7Hq/chT5LA==",
-      "license": "MIT"
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -9493,22 +9170,10 @@
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "license": "MIT"
     },
-    "node_modules/lodash.filter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha512-pXYUy7PR8BCLwX5mgJ/aNtyOvuJTdZAo9EQFUvMIYugqmJxnrYaANvTbgndOzHSCSR0wnlBBfRXJL5SbWxo3FQ==",
-      "license": "MIT"
-    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==",
       "license": "MIT"
     },
     "node_modules/lodash.groupby": {
@@ -9558,43 +9223,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
       "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==",
-      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
-      "license": "MIT"
-    },
-    "node_modules/lodash.reduce": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-      "integrity": "sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.reject": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-      "integrity": "sha512-qkTuvgEzYdyhiJBx42YPzPo71R1aEr0z79kAv7Ixg8wPFEjgRgJdUsGMG3Hf3OYSF/kHI79XhNlt+5Ar6OzwxQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.some": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha512-j7MJE+TuT51q9ggt4fSgVqro163BEFjAt3u97IqU+JA2DkWl80nFTrowzLpZ/BnpN7rrl0JA/593NAdd8p/scQ==",
       "license": "MIT"
     },
     "node_modules/lodash.union": {
@@ -9735,15 +9363,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/mediaquery-text": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mediaquery-text/-/mediaquery-text-1.2.0.tgz",
-      "integrity": "sha512-cJyRqgYQi+hsYhRkyd5le0s4LsEPvOB7r+6X3jdEELNqVlM9mRIgyUPg9BzF+PuTqQH1ZekgIjYVOeWSXWq35Q==",
-      "license": "MIT",
-      "dependencies": {
-        "cssom": "^0.5.0"
       }
     },
     "node_modules/merge-descriptors": {
@@ -10012,12 +9631,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT"
-    },
     "node_modules/node-abi": {
       "version": "3.85.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
@@ -10145,15 +9758,6 @@
         "console-control-strings": "^1.1.0",
         "gauge": "^3.0.0",
         "set-blocking": "^2.0.0"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "~1.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -10478,23 +10082,6 @@
         "url": "https://github.com/sponsors/mehmet-kozan"
       }
     },
-    "node_modules/pdf2pic": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pdf2pic/-/pdf2pic-3.2.0.tgz",
-      "integrity": "sha512-p0bp+Mp4iJy2hqSCLvJ521rDaZkzBvDFT9O9Y0BUID3I04/eDaebAFM5t8hoWeo2BCf42cDijLCGJWTOtkJVpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gm": "^1.25.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://www.paypal.me/yakovmeister"
-      }
-    },
     "node_modules/pdfjs-dist": {
       "version": "5.4.530",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.530.tgz",
@@ -10533,21 +10120,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
-    },
-    "node_modules/pick-util": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/pick-util/-/pick-util-1.1.5.tgz",
-      "integrity": "sha512-H0MaM8T7wpQ/azvB12ChZw7kpSFzjsgv3Z+N7fUWnL1McTGSEeroCngcK4eOPiFQq08rAyKX3hadcAB1kUqfXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jonkemp/package-utils": "^1.0.8"
       }
     },
     "node_modules/picocolors": {
@@ -10853,15 +10425,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -10896,97 +10459,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "license": "MIT"
-    },
-    "node_modules/puppeteer": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-10.4.0.tgz",
-      "integrity": "sha512-2cP8mBoqnu5gzAVpbZ0fRaobBWZM8GEUF4I1F6WbgHrKV/rz7SX8PG2wMymZgD0wo0UBlg2FBPNxlF/xlqW6+w==",
-      "deprecated": "< 24.15.0 is no longer supported",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.3.1",
-        "devtools-protocol": "0.0.901419",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
-        "node-fetch": "2.6.1",
-        "pkg-dir": "4.2.0",
-        "progress": "2.0.1",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.0.0",
-        "unbzip2-stream": "1.3.3",
-        "ws": "7.4.6"
-      },
-      "engines": {
-        "node": ">=10.18.1"
-      }
-    },
-    "node_modules/puppeteer/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer/node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/puppeteer/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "license": "MIT"
-    },
-    "node_modules/puppeteer/node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "license": "MIT",
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/puppeteer/node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/pure-rand": {
       "version": "7.0.1",
@@ -11186,16 +10658,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/remote-content": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remote-content/-/remote-content-4.0.1.tgz",
-      "integrity": "sha512-W2lDnjK4k1vAJg7UZArH/rkNYJqZuteHkX1jS7tO9TJUiLhDcu2Ejvj97gK/XbZNDhzld0sn11OW8vihin4cAg==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.7.9",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/require-directory": {
@@ -11658,15 +11120,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/slick": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
-      "integrity": "sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A==",
-      "license": "MIT (http://mootools.net/license.txt)",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/sonic-boom": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
@@ -11694,15 +11147,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/specificity": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
-      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
-      "license": "MIT",
-      "bin": {
-        "specificity": "bin/specificity"
       }
     },
     "node_modules/split2": {
@@ -11872,17 +11316,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/style-data": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/style-data/-/style-data-1.4.8.tgz",
-      "integrity": "sha512-RBJD+YQef4PzYKqC4PQEjDvyX709mwEClYg9u0A5EPXqdSkN2BtMnF/tW7EtS9Q0FnBF+lrWsK5+bEKqA+++Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio": "^0.22.0",
-        "mediaquery-text": "^1.2.0",
-        "pick-util": "^1.1.4"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12023,12 +11456,6 @@
         "real-require": "^0.2.0"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "license": "MIT"
-    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -12143,19 +11570,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -12166,40 +11580,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/unbzip2-stream": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
-    "node_modules/unbzip2-stream/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/underscore": {
@@ -12508,12 +11888,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "license": "MIT"
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -12694,16 +12068,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/bot/package.json
+++ b/bot/package.json
@@ -55,7 +55,6 @@
     "express-session": "^1.18.2",
     "fluent-ffmpeg": "^2.1.3",
     "form-data": "^4.0.4",
-    "html-pdf-node": "^1.0.8",
     "ioredis": "^5.4.1",
     "jsonrepair": "^3.13.1",
     "mammoth": "^1.8.0",
@@ -75,7 +74,6 @@
   },
   "devDependencies": {
     "jest": "^30.2.0",
-    "pdf2pic": "^3.2.0",
     "pino-pretty": "^13.1.3"
   },
   "optionalDependencies": {

--- a/bot/scripts/setup/doctor.js
+++ b/bot/scripts/setup/doctor.js
@@ -90,7 +90,7 @@ function analyzeEnv(env) {
     // A feature with no env keys (e.g. Chromium) is keyed off its probe, not env.
     const missingKeys = f.keys.filter((k) => !isSet(env[k]));
     const available = f.keys.length > 0 ? missingKeys.length === 0 : null; // null = "ask the probe"
-    return { name: f.name, requiredKeys: f.keys, missingKeys, available, probe: f.probe || null };
+    return { name: f.name, requiredKeys: f.keys, missingKeys, available, probe: f.probe || null, notes: f.notes || null };
   });
 
   return { requiredPresent, missingRequired, features };
@@ -185,7 +185,7 @@ async function runDoctor({
   // Feature availability (presence + chromium probe).
   const featureResults = [];
   for (const f of analysis.features) {
-    const keyMeta = { requiredKeys: f.requiredKeys, missingKeys: f.missingKeys };
+    const keyMeta = { requiredKeys: f.requiredKeys, missingKeys: f.missingKeys, notes: f.notes };
     if (f.probe && probes[f.probe]) {
       try {
         const { ok, detail } = await probes[f.probe](env);
@@ -217,7 +217,7 @@ function formatReport(result) {
   lines.push('Rumi doctor — deployment preflight');
   lines.push('');
   if (result.missingRequired.length) {
-    lines.push('❌ MISSING REQUIRED variables (the bot will not start):');
+    lines.push('❌ MISSING REQUIRED variables — the bot will boot but features needing these will be OFF until you set them:');
     for (const v of result.missingRequired) {
       const src = keySource(v);
       lines.push(`   - ${v}${src ? `  → get it: ${src}` : ''}`);
@@ -237,6 +237,7 @@ function formatReport(result) {
       if (srcs.length) hint = `  → get it: ${srcs[0]}`;
     }
     lines.push(`  ${mark(f.status)} ${f.name} — ${f.detail}${hint}`);
+    if (f.notes) lines.push(`        note: ${f.notes}`);
   }
   if (result.flowResults && result.flowResults.length) {
     lines.push('');

--- a/bot/shared/config/feature-availability.js
+++ b/bot/shared/config/feature-availability.js
@@ -30,7 +30,13 @@ const FEATURES = [
   { name: 'Urdu / regional voices (Uplift)', keys: ['UPLIFT_API_KEY'] },
   { name: 'Lesson-plan generation (Gamma)', keys: ['GAMMA_API_KEY'] },
   { name: 'Reading pronunciation scoring (Azure)', keys: ['AZURE_SPEECH_KEY', 'AZURE_SPEECH_REGION'] },
-  { name: 'Video generation (Kie.ai)', keys: ['KIE_API_KEY'] },
+  // Video generation has TWO gates: KIE_API_KEY (creds, presence-checked here)
+  // AND VIDEO_GENERATION_ENABLED=true at the orchestrator (a master kill-switch
+  // checked in bot/shared/services/video/video-orchestrator.service.js). The
+  // flag intentionally stays out of `keys` because `keys` drives the presence
+  // gate — adding it would mark the feature OFF whenever the env var is unset,
+  // which is the wrong semantics (you can set the key and gate it independently).
+  { name: 'Video generation (Kie.ai)', keys: ['KIE_API_KEY'], notes: 'Also requires VIDEO_GENERATION_ENABLED=true at runtime.' },
   { name: 'Exam-checker OCR (Mistral vision)', keys: ['MISTRAL_API_KEY'] },
   { name: 'Observability (Axiom)', keys: ['AXIOM_DATASET', 'AXIOM_TOKEN'] },
 ];

--- a/bot/shared/services/cache/railway-redis.service.js
+++ b/bot/shared/services/cache/railway-redis.service.js
@@ -64,10 +64,17 @@ class RailwayRedisService {
         logToFile('✅ Railway Redis ready');
       });
 
+      // Throttle error logs: ioredis fires 'error' on every reconnect attempt
+      // (every ~0.7s during outages), and error.message can be empty string when
+      // the socket dies. Log at most once per 10s and always include a useful
+      // identifier (code or stringified error) so logs don't fill with blanks.
+      this._lastRedisErrorLoggedAt = 0;
       this.redis.on('error', (error) => {
-        logToFile('❌ Railway Redis error', {
-          error: error.message
-        });
+        const now = Date.now();
+        if (now - this._lastRedisErrorLoggedAt < 10_000) return;
+        this._lastRedisErrorLoggedAt = now;
+        const msg = (error && error.message) || (error && error.code) || String(error) || 'unknown';
+        logToFile('❌ Railway Redis error', { error: msg, code: error && error.code });
       });
 
       this.redis.on('close', () => {

--- a/bot/shared/services/coaching/report-generator.service.js
+++ b/bot/shared/services/coaching/report-generator.service.js
@@ -151,7 +151,7 @@ class ReportGeneratorService {
           .eq('id', coachingSessionId);
       }
 
-      // Generate PDF report directly using wkhtmltopdf
+      // Generate PDF report via the per-framework transformer + PDFReportService
       const pdfBuffer = await this.generatePDFReport(session, teacherName, enhancedAnalysis);
 
       // Upload PDF to R2 for portal access
@@ -524,7 +524,7 @@ class ReportGeneratorService {
   }
 
   /**
-   * Generate PDF report using wkhtmltopdf
+   * Generate PDF report via the per-framework transformer + PDFReportService
    * @param {object} session - Session data
    * @param {string} teacherName - Teacher's full name
    * @param {object} enhancedAnalysis - Enhanced analysis data

--- a/infrastructure/scripts/test-connections.js
+++ b/infrastructure/scripts/test-connections.js
@@ -95,7 +95,15 @@ async function runTests() {
 
   console.log('');
   if (allPassed) {
-    console.log('  All connections successful (or skipped).\n');
+    const okCount = results.filter(r => r.status === 'OK').length;
+    const skippedCount = results.filter(r => r.status === 'SKIP').length;
+    if (okCount === 0 && skippedCount === results.length) {
+      console.log('  Nothing was tested - no services configured. Set credentials in .env and re-run.\n');
+    } else if (okCount > 0 && skippedCount > 0) {
+      console.log(`  ${okCount} connection(s) OK; ${skippedCount} skipped (not configured).\n`);
+    } else {
+      console.log(`  All ${okCount} configured connection(s) OK.\n`);
+    }
   } else {
     console.log('  Some connections failed. Check your .env configuration.\n');
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "doctor": "node bot/scripts/setup/doctor.js",
     "setup:flows": "node bot/scripts/setup/run-full-setup.js",
     "simulate": "node bot/scripts/simulate.js",
-    "setup": "echo 'Use /setup in Claude Code or follow SETUP.md for manual instructions'"
+    "setup": "node bot/scripts/setup/doctor.js"
   },
   "keywords": [
     "whatsapp",

--- a/tests/cache/redis-error-throttle.test.js
+++ b/tests/cache/redis-error-throttle.test.js
@@ -1,0 +1,57 @@
+/**
+ * §D-2 guard — Railway Redis 'error' event handler must throttle to ≤1 log per 10s.
+ *
+ * ioredis fires 'error' on every reconnect attempt (every ~0.7s during a real
+ * outage). Without throttling the log file fills with hundreds of identical
+ * lines that drown out everything else. This guard fires 50 events in <1s and
+ * asserts logToFile was called exactly once.
+ *
+ * The service exports a SINGLETON (`module.exports = new RailwayRedisService()`),
+ * so each test does its own resetModules() + doMock() + require() to start fresh.
+ */
+
+const path = require('path');
+const SERVICE = path.resolve(__dirname, '../../bot/shared/services/cache/railway-redis.service');
+const LOGGER = path.resolve(__dirname, '../../bot/shared/utils/logger');
+const CONSTANTS = path.resolve(__dirname, '../../bot/shared/utils/constants');
+
+function loadFreshService() {
+  jest.resetModules();
+  jest.doMock('ioredis', () => {
+    return class MockRedis {
+      constructor() { this.handlers = {}; this.status = 'connecting'; }
+      on(event, fn) { this.handlers[event] = fn; }
+      fire(event, payload) { if (this.handlers[event]) this.handlers[event](payload); }
+    };
+  });
+  const mockLog = jest.fn();
+  jest.doMock(LOGGER, () => ({ logToFile: mockLog }));
+  jest.doMock(CONSTANTS, () => ({ RATE_LIMIT_MAX: 30, RATE_LIMIT_WINDOW_SECONDS: 60 }));
+  process.env.REDIS_URL = 'redis://localhost:6379';
+  const svc = require(SERVICE);
+  return { svc, mockLog };
+}
+
+describe('railway-redis error spam throttle', () => {
+  it('logs at most once when 50 error events fire in <1s', () => {
+    const { svc, mockLog } = loadFreshService();
+    for (let i = 0; i < 50; i++) {
+      svc.redis.fire('error', { message: 'ECONNREFUSED', code: 'ECONNREFUSED' });
+    }
+    const errorLogCalls = mockLog.mock.calls.filter(
+      ([msg]) => typeof msg === 'string' && msg.includes('Railway Redis error')
+    );
+    expect(errorLogCalls).toHaveLength(1);
+  });
+
+  it('handles empty error.message gracefully (prints code or fallback)', () => {
+    const { svc, mockLog } = loadFreshService();
+    svc.redis.fire('error', { message: '', code: 'ENOTFOUND' });
+    const errorLogCalls = mockLog.mock.calls.filter(
+      ([msg]) => typeof msg === 'string' && msg.includes('Railway Redis error')
+    );
+    expect(errorLogCalls).toHaveLength(1);
+    const [, payload] = errorLogCalls[0];
+    expect(payload.error || payload.code).toBeTruthy();
+  });
+});

--- a/tests/setup/doctor-wording.test.js
+++ b/tests/setup/doctor-wording.test.js
@@ -1,0 +1,76 @@
+/**
+ * §D-3 + §D-4 guards — `npm run doctor` must:
+ *   - NOT claim "the bot will not start" for missing optional vars (§D-3).
+ *     The bot DOES boot with placeholders thanks to presence-gating; the
+ *     missing-variable copy now matches that reality.
+ *   - Surface the `notes` field for features that have a dual-gate (e.g. Video
+ *     needs KIE_API_KEY AND VIDEO_GENERATION_ENABLED=true at runtime — §D-4).
+ */
+
+const path = require('path');
+
+const DOCTOR = path.resolve(__dirname, '../../bot/scripts/setup/doctor.js');
+const FEATURE_AVAILABILITY = path.resolve(
+  __dirname,
+  '../../bot/shared/config/feature-availability.js'
+);
+
+describe('doctor — honest wording', () => {
+  let originalEnv;
+  beforeEach(() => { originalEnv = { ...process.env }; jest.resetModules(); });
+  afterEach(() => { process.env = originalEnv; });
+
+  it('missing-required line no longer says "the bot will not start"', () => {
+    // Force at least one REQUIRED_VAR to be absent.
+    delete process.env.SUPABASE_URL;
+    delete process.env.WHATSAPP_TOKEN;
+
+    const { analyzeEnv, formatReport } = require(DOCTOR);
+    const analysis = analyzeEnv(process.env);
+    // Construct a minimal result the formatter accepts.
+    const result = {
+      ok: false,
+      missingRequired: analysis.missingRequired,
+      probeResults: [],
+      featureResults: [],
+      flowResults: [],
+    };
+    const out = formatReport(result);
+
+    expect(out).not.toMatch(/the bot will not start/i);
+    expect(out).toMatch(/MISSING REQUIRED variables/);
+    // The new copy promises "features needing these will be OFF" — the truth.
+    expect(out).toMatch(/will be OFF/i);
+  });
+
+  it('Video feature carries a "VIDEO_GENERATION_ENABLED" note', () => {
+    const { FEATURES } = require(FEATURE_AVAILABILITY);
+    const video = FEATURES.find((f) => /video/i.test(f.name));
+    expect(video).toBeTruthy();
+    expect(video.keys).toContain('KIE_API_KEY');
+    expect(video.notes).toBeTruthy();
+    expect(video.notes).toMatch(/VIDEO_GENERATION_ENABLED/);
+  });
+
+  it('doctor surfaces the feature note in formatted output', () => {
+    const { formatReport } = require(DOCTOR);
+    const result = {
+      ok: true,
+      missingRequired: [],
+      probeResults: [],
+      featureResults: [
+        {
+          name: 'Video generation (Kie.ai)',
+          status: 'off',
+          detail: 'set: KIE_API_KEY',
+          requiredKeys: ['KIE_API_KEY'],
+          missingKeys: ['KIE_API_KEY'],
+          notes: 'Also requires VIDEO_GENERATION_ENABLED=true at runtime.',
+        },
+      ],
+      flowResults: [],
+    };
+    const out = formatReport(result);
+    expect(out).toMatch(/note: Also requires VIDEO_GENERATION_ENABLED/);
+  });
+});

--- a/tests/setup/skill-md-video-claims.test.js
+++ b/tests/setup/skill-md-video-claims.test.js
@@ -1,0 +1,35 @@
+/**
+ * §D-4 guard — the setup SKILL.md must not claim R2_* keys are required for
+ * the video feature. The real video service (bot/shared/services/video/) reads
+ * KIE_API_KEY and is gated by VIDEO_GENERATION_ENABLED=true. R2_* is not
+ * consulted anywhere in the video chain.
+ *
+ * This test is the structural lock — if a future doc-pass re-adds R2_* to the
+ * Video row, CI catches it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SKILL_MD = path.resolve(__dirname, '../../.claude/skills/setup/SKILL.md');
+const README = path.resolve(__dirname, '../../README.md');
+
+describe('SKILL.md video-key claims match reality', () => {
+  it('does NOT mention R2_* in the Educational video row', () => {
+    const content = fs.readFileSync(SKILL_MD, 'utf8');
+    // Find the Educational-video row in the feature table.
+    const m = content.match(/\| Educational video \| ([^|]+) \|/);
+    expect(m).toBeTruthy();
+    const cell = m[1];
+    expect(cell).not.toMatch(/R2_/);
+    expect(cell).toMatch(/KIE_API_KEY/);
+    expect(cell).toMatch(/VIDEO_GENERATION_ENABLED/);
+  });
+
+  it('README and SKILL.md both name VIDEO_GENERATION_ENABLED for video', () => {
+    const skill = fs.readFileSync(SKILL_MD, 'utf8');
+    const readme = fs.readFileSync(README, 'utf8');
+    expect(skill).toMatch(/VIDEO_GENERATION_ENABLED/);
+    expect(readme).toMatch(/VIDEO_GENERATION_ENABLED/);
+  });
+});

--- a/tests/setup/test-connections-output.test.js
+++ b/tests/setup/test-connections-output.test.js
@@ -1,0 +1,44 @@
+/**
+ * §D-1 guard — `validate:connections` must not print a misleading
+ * "All connections successful" line when nothing was actually tested.
+ *
+ * Before this fix, an adopter with no credentials in `.env` saw a green
+ * success message even though every check had been SKIPped. The fix counts
+ * OK vs SKIP and emits one of three honest messages.
+ */
+
+const path = require('path');
+
+const SCRIPT = path.resolve(__dirname, '../../infrastructure/scripts/test-connections.js');
+
+describe('validate:connections honest output', () => {
+  let originalEnv;
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    // Wipe all the keys the script reads.
+    for (const k of ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'REDIS_URL',
+      'OPENAI_API_KEY', 'OPENROUTER_API_KEY', 'LLM_PROVIDER']) {
+      delete process.env[k];
+    }
+    jest.resetModules();
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('prints the "Nothing was tested" message when no services are configured', async () => {
+    const { runTests } = require(SCRIPT);
+    const logs = [];
+    const orig = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try {
+      const results = await runTests();
+      expect(results.every((r) => r.status === 'SKIP')).toBe(true);
+    } finally {
+      console.log = orig;
+    }
+    const all = logs.join('\n');
+    expect(all).toMatch(/Nothing was tested/);
+    expect(all).not.toMatch(/All connections successful/);
+  });
+});


### PR DESCRIPTION
## Wave 2 first PR — `§D` polish + `bd-1835` orphan-dep cleanup

Two commits, separately reviewable:

### 1. `polish: five honest-output fixes for setup, doctor, redis, and connections` (d6335f2)

Five adopter-facing fixes pulled from the Wave 1 readiness audit:

| # | What was wrong | What it says now |
|---|----------------|------------------|
| 1 | `npm run validate:connections` printed *'All connections successful'* when every check had been SKIPped | Counts OKs vs SKIPs and prints one of three honest messages |
| 2 | Railway-Redis 'error' handler fired every ~0.7s during reconnect storms with empty `error.message` | Throttled to ≤1 log per 10s; always includes `code` or fallback so log line is never blank |
| 3 | `npm run doctor` said *'the bot will not start'* for missing required vars | *'features needing these will be OFF until you set them'* — matches actual presence-gated boot behaviour |
| 4 | SKILL.md said the video feature needed `KIE_API_KEY + R2_*`. Three docs, three answers | Removed `R2_*` (video service doesn't read it); added a runtime-gate note for `VIDEO_GENERATION_ENABLED` |
| 5 | `npm run setup` echoed *'go elsewhere'* | Invokes `doctor` — adopters see the real preflight matrix |

**Tests:** 4 new smoke tests guard each behaviour:
- `tests/setup/test-connections-output.test.js` — empty-config branch prints 'Nothing was tested'
- `tests/cache/redis-error-throttle.test.js` — 50 errors → 1 log, empty-message handled
- `tests/setup/doctor-wording.test.js` — missing-var line + feature notes surfaced
- `tests/setup/skill-md-video-claims.test.js` — structural lock against `R2_*` re-appearing

### 2. `chore(deps): drop html-pdf-node + pdf2pic (orphans)` (166e22c)

Both deps had **zero callers** in the bot codebase (verified by full-repo grep). Removing them slims `bot/package-lock.json` by ~700 lines as the transitive chains collapse.

**Honest accounting:**
- The Wave 1 readiness doc projected 2 critical + 2 high CVEs would disappear. They don't — the remaining critical (`fast-xml-parser`) comes from `@aws-sdk/xml-builder` v3, not the removed orphans. The audit numbers don't move at the top tier.
- Net win is still real: smaller install (~50 fewer packages), removed future-CVE surface (e.g. `puppeteer@10` sunset that was pulled in by html-pdf-node), and the lockfile is clean.
- Also fixed two stale 'wkhtmltopdf' comments in `report-generator.service.js` — the function actually delegates to `PDFReportService`, not wkhtmltopdf.

**Deferred from this PR:**
- `aws-sdk` v2 → v3 SQS migration. Readiness doc projected zero callers; **two real callers exist** (`sqs-queue.service.js` and `requeue-lesson-plan.js`). A v2→v3 migration touches critical queue infrastructure with real breakage risk — wrong shape for a polish PR. Tracked for a follow-up.
- `wkhtmltopdf-selfcontained` — likely orphan too (only stale-comment mentions, no `require`). Flagged for the same follow-up.

### Test status

- **Local:** 97 suites / 1169 tests green (was 96 / 1161 before this PR)
- **CI-condition smoke** (`mv bot/node_modules /tmp/_nm && node tests/run.js`): green
- **Source-hygiene + customization-doc-accuracy guards:** green
- **Leak-grep on changed files:** clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)