### PR TITLE
feat(coaching): hero report (PNG+caption) for OECD/HOTS/TEACH/FICO

### DIFF
--- a/bot/shared/services/coaching/coaching-trend.service.js
+++ b/bot/shared/services/coaching/coaching-trend.service.js
@@ -1,0 +1,113 @@
+/**
+ * Coaching Trend Service.
+ *
+ * Loads N most-recent COMPLETED coaching sessions for a user and turns them
+ * into a sparkline-ready trend array. Used by the hero coaching report and
+ * any future framework that wants a trajectory chart.
+ *
+ * Design notes:
+ *   - Returns ALL recent sessions across frameworks, NOT filtered to a single
+ *     framework. A user who switched frameworks mid-history would otherwise see
+ *     an empty sparkline; the template can style differently per framework
+ *     using the `framework` field on each point.
+ *   - Sort ASC (oldest → newest) so the sparkline reads left-to-right.
+ *   - Defensive: returns [] (never null/undefined) on missing user, empty
+ *     data, supabase error, or malformed analysis_data.
+ *   - Each point: { date, pct, framework, label }.
+ */
+
+const supabase = require('../../config/supabase');
+const { logToFile } = require('../../utils/logger');
+
+const DEFAULT_LIMIT = 10;
+
+/**
+ * Short human label for a session date. Used as the x-axis tick label
+ * on the sparkline. Default to Swahili month names for consistency with
+ * the existing MEWAKA template; caller can override via options.locale = 'en'.
+ */
+const SW_MONTHS = ['Jan', 'Feb', 'Mac', 'Apr', 'Mei', 'Jun', 'Jul', 'Ago', 'Sep', 'Okt', 'Nov', 'Des'];
+const EN_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function shortLabel(isoDate, locale = 'sw') {
+  try {
+    const d = new Date(isoDate);
+    if (Number.isNaN(d.getTime())) return '';
+    const months = locale === 'en' ? EN_MONTHS : SW_MONTHS;
+    return `${d.getUTCDate()} ${months[d.getUTCMonth()]}`;
+  } catch {
+    return '';
+  }
+}
+
+function pctFromRow(row) {
+  const ad = row.analysis_data;
+  if (!ad || typeof ad !== 'object') return null;
+  // Prefer scores.overall_percentage (MEWAKA / v2 canonical), then the OECD
+  // shape scores.percentage (every pre-MEWAKA session stores its overall %
+  // here), then any top-level overall_percentage. This keeps the sparkline
+  // framework-agnostic.
+  const cand = ad.scores?.overall_percentage ?? ad.scores?.percentage ?? ad.overall_percentage;
+  const n = Number(cand);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Load the user's recent coaching-score trend.
+ *
+ * @param {string} userId - User UUID
+ * @param {object} [opts]
+ * @param {number} [opts.limit=10] - Max rows to fetch
+ * @param {string} [opts.locale='sw'] - Locale for label formatting (sw|en)
+ * @param {string} [opts.excludeSessionId] - Skip this session (e.g. the
+ *   session currently being reported, to avoid duplicating its data point
+ *   in the sparkline of its own report). Optional.
+ * @returns {Promise<Array<{date:string, pct:number, framework:string, label:string}>>}
+ *   Sorted ascending by date (oldest → newest). Always an array; empty on
+ *   any error or missing data.
+ */
+async function loadTrendData(userId, opts = {}) {
+  const { limit = DEFAULT_LIMIT, locale = 'sw', excludeSessionId = null } = opts;
+  try {
+    if (!userId) return [];
+
+    // Fetch the MOST-RECENT `limit` sessions, not the oldest:
+    // `.order(ascending:true).limit(N)` returns the N OLDEST rows, which for a
+    // teacher with a long history yields a stale, frozen sparkline. Order DESC
+    // so the DB returns the newest N, then reverse() below to get ascending
+    // (oldest→newest) for left-to-right plotting.
+    const { data, error } = await supabase
+      .from('coaching_sessions')
+      .select('id, created_at, analysis_data')
+      .eq('user_id', userId)
+      .eq('status', 'completed')
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      logToFile('[coaching-trend] supabase error', { userId, error: error.message });
+      return [];
+    }
+    if (!Array.isArray(data) || data.length === 0) return [];
+
+    // Reverse the newest-first window into oldest→newest for the sparkline.
+    return [...data].reverse()
+      .filter((row) => !excludeSessionId || row.id !== excludeSessionId)
+      .map((row) => {
+        const pct = pctFromRow(row);
+        if (pct == null) return null;
+        return {
+          date: row.created_at,
+          pct,
+          framework: row.analysis_data?.framework || null,
+          label: shortLabel(row.created_at, locale),
+        };
+      })
+      .filter(Boolean);
+  } catch (err) {
+    logToFile('[coaching-trend] unexpected error', { userId, error: err.message });
+    return [];
+  }
+}
+
+module.exports = { loadTrendData, shortLabel };

--- a/bot/shared/services/coaching/kiswahili-style.js
+++ b/bot/shared/services/coaching/kiswahili-style.js
@@ -1,0 +1,27 @@
+/**
+ * Kiswahili style directive — natural, accurate Kiswahili sanifu for the
+ * teacher-facing coaching text (hero report narrative, voice debrief, MEWAKA analysis,
+ * reflection enhancement).
+ *
+ * Seeded from native-speaker review: the auto-generated Swahili was grammatically
+ * valid but read as over-literal / English-calqued in places, e.g.
+ * "uliwapa watoto taratibu thabiti" (you gave the children procedures) where a
+ * native Tanzanian educator would say the teacher *established* a routine. This is
+ * a living directive — append confirmed corrections to PREFERRED_PHRASINGS as more
+ * Kiswahili reviews come in.
+ *
+ * Inject `KISWAHILI_STYLE` into any prompt branch that emits teacher-facing Kiswahili.
+ */
+
+// Confirmed do/don't corrections from native-speaker review. Append over time.
+const PREFERRED_PHRASINGS = [
+  '• For a teacher\'s systematic routine/orderliness use the abstract noun "utaratibu" and describe what she ESTABLISHED — e.g. "ulianzisha utaratibu thabiti" / "ulikuwa na utaratibu thabiti" (you established / had a firm routine). AVOID "uliwapa watoto taratibu thabiti" (you gave the children procedures) — it reads unnatural and shifts the meaning.',
+];
+
+const KISWAHILI_STYLE = `KISWAHILI QUALITY — write as a Tanzanian educator actually speaks and writes (Kiswahili sanifu reviewed with Tanzanian teachers):
+- NOT a word-for-word translation from English. Avoid English-calque word order and stilted/over-literal constructions. Reread each sentence and ask: "would a Tanzanian teacher really say it this way?"
+- Choose the precise noun form and natural verb collocations; favour describing what the teacher DID or ESTABLISHED in natural Swahili over literal "gave them X" phrasings.
+- Confirmed phrasing corrections (follow these):
+${PREFERRED_PHRASINGS.join('\n')}`;
+
+module.exports = { KISWAHILI_STYLE, PREFERRED_PHRASINGS };

--- a/bot/shared/services/coaching/report-generator.service.js
+++ b/bot/shared/services/coaching/report-generator.service.js
@@ -572,8 +572,25 @@ class ReportGeneratorService {
     logToFile('Report transformer dispatched', { frameworkKey, hasPriorSessions });
     const reportData = transformer(session, teacherName, analysisForTransformer, hasPriorSessions);
 
-    // Generate PDF using our new service
-    const pdfBuffer = await PDFReportService.generateClassroomObservationReport(reportData);
+    // Attach the inputs the hero renderer needs so it can reach them off
+    // reportData (the PDFKit / HTML renderers ignore these). Kept as
+    // underscored fields to make the side-channel intent explicit.
+    reportData._heroInput = {
+      session,
+      analysis: analysisForTransformer,
+      opts: {
+        teacherName,
+        language: enhancedAnalysis.language || session.transcript_language || 'en',
+        commitmentAction: '', // commitment-card action is sent separately; the hero
+                              // template tolerates an empty tryNext gracefully.
+      },
+    };
+
+    // Generate report through the renderer registry. The hero renderer returns
+    // { png, caption } (image+caption delivery via WhatsAppService); the PDFKit
+    // and HTML renderers return Buffer. The caller normalises both shapes.
+    const rendered = await PDFReportService.generateClassroomObservationReport(reportData);
+    const pdfBuffer = Buffer.isBuffer(rendered) ? rendered : (rendered && rendered.png);
 
     logToFile('PDF report generated', {
       coachingSessionId: session.id,

--- a/bot/shared/services/coaching/report-renderers/renderer-registry.js
+++ b/bot/shared/services/coaching/report-renderers/renderer-registry.js
@@ -2,18 +2,27 @@
  * Report Renderer Registry
  *
  * Routes framework key → the renderer that produces its coaching report.
- * A renderer is `{ render(reportData) -> Promise<Buffer> }`.
+ * A renderer is `{ render(input) -> Promise<Buffer | {png, caption}> }`.
  *
- * Today there are two renderers:
- *   - pdfkit : the hardcoded ~1100-line PDFKit layout shared by
- *              OECD / HOTS / TEACH / FICO (the default).
+ * Three renderers ship:
+ *   - hero   : the unified celebration design (Playwright HTML → PNG +
+ *              caption). DEFAULT for OECD / HOTS / TEACH / FICO; consumes
+ *              an input of shape `{ session, analysis, opts }` and returns
+ *              `{ png, caption }`.
+ *   - pdfkit : the hardcoded PDFKit layout. Kept as the fallback for
+ *              unknown frameworks (so a clone that adds a new framework
+ *              key still renders something), and as the safety net the
+ *              report-generator falls back to if the hero render rejects.
  *   - html   : MEWAKA's Playwright HTML→PDF path (hero focus area +
- *              6-domain Swahili scorecard + inline SVG sparkline), which
- *              doesn't fit the PDFKit layout.
+ *              6-domain Swahili scorecard + inline SVG sparkline). Kept
+ *              as the active MEWAKA renderer in OSS — MEWAKA does not yet
+ *              ship a `mewaka-framework.js` module, so the hero renderer's
+ *              score adapter cannot produce groups for it. Add the
+ *              framework module + a `mewaka-adapter.js` to flip mewaka
+ *              onto `heroRenderer` in a follow-up.
  *
- * Adding a new framework's report design is now "register one line" here
+ * Adding a new framework's report design is "register one line" here
  * (point a key at a renderer), not "edit an `if` in pdf-report.service.js".
- * Unknown frameworks fall back to the default PDFKit renderer.
  *
  * Mirrors the report-transformers/report-transformer-dispatch.js pattern:
  * an object map + lazy require so callers never pull a renderer they don't
@@ -25,8 +34,25 @@ const { logToFile } = require('../../../utils/logger');
 // ─── Renderers (lazy require so unused renderers stay unloaded) ──────────
 
 /**
- * Default renderer: the existing PDFKit layout. Wraps the PDFKit-only entry
- * on PDFReportService so output is byte-identical to the pre-registry path.
+ * Hero renderer: the unified celebration design. Returns { png, caption }.
+ *
+ * Accepts either a hero-shaped input `{ session, analysis, opts }` directly,
+ * OR a legacy `reportData` object with the hero input attached at
+ * `reportData._heroInput` (the side-channel used by report-generator so the
+ * PDFKit / HTML renderers can keep their reportData contract unchanged).
+ */
+const heroRenderer = {
+  key: 'hero',
+  render(input) {
+    const { generateHeroReport } = require('../report-v2/hero-report.service');
+    const hero = (input && input._heroInput) || input;
+    return generateHeroReport(hero.session, hero.analysis, hero.opts || {});
+  },
+};
+
+/**
+ * Default renderer (fallback): the existing PDFKit layout. Wraps the PDFKit-only
+ * entry on PDFReportService so output is byte-identical to the pre-registry path.
  */
 const pdfkitRenderer = {
   key: 'pdfkit',
@@ -51,11 +77,12 @@ const htmlRenderer = {
 // ─── Registry: framework key → renderer ──────────────────────────────────
 
 const renderers = {
-  oecd: pdfkitRenderer,
-  hots: pdfkitRenderer,
-  teach: pdfkitRenderer,
-  fico: pdfkitRenderer,
-  mewaka: htmlRenderer,   // Tanzania CPD — Playwright HTML→PDF report
+  oecd:  heroRenderer,
+  hots:  heroRenderer,
+  teach: heroRenderer,
+  fico:  heroRenderer,
+  mewaka: htmlRenderer, // see file-header note; flip in a follow-up after
+                        // adding `mewaka-framework.js` + a `mewaka-adapter.js`
 };
 
 const DEFAULT_RENDERER = pdfkitRenderer;
@@ -63,7 +90,7 @@ const DEFAULT_RENDERER = pdfkitRenderer;
 /**
  * Get the report renderer for a given framework key.
  * @param {string} frameworkKey - Framework key (oecd, hots, teach, fico, mewaka)
- * @returns {{ render: (reportData: object) => Promise<Buffer> }} Renderer
+ * @returns {{ key:string, render:(input:object) => Promise<Buffer|{png,caption}> }}
  */
 function getReportRenderer(frameworkKey) {
   const renderer = renderers[frameworkKey];

--- a/bot/shared/services/coaching/report-v2/hero-report.service.js
+++ b/bot/shared/services/coaching/report-v2/hero-report.service.js
@@ -1,0 +1,69 @@
+/**
+ * Coaching Report v2 — Hero report service.
+ *
+ * Orchestrates the unified celebration renderer for a completed session:
+ *   score adapter → narrative pass → (caller-supplied commitment action) → trend →
+ *   hero template → htmlToImage → { png, caption }.
+ *
+ * The report's "one thing to try next" is the commitment-card action passed in
+ * by the caller (single source of next-step truth).
+ */
+
+const { buildScoreViewModel } = require('./score-adapter.service');
+const { generateReportNarrative } = require('./narrative.service');
+const { buildHeroReportHtml, buildReportCaption } = require('./hero-report.template');
+const { loadTrendData } = require('../coaching-trend.service');
+const { htmlToImage } = require('../../../utils/html-to-pdf');
+const { logToFile } = require('../../../utils/logger');
+
+/**
+ * @param {object} session - coaching_sessions row (transcript_text, user_id, created_at, classroom_photos)
+ * @param {object} analysis - enhancedAnalysis (framework, scores, domains, reflective_corpus, …)
+ * @param {object} opts - { teacherName, commitmentAction, language }
+ * @returns {Promise<{png:Buffer, caption:string}>}
+ */
+async function generateHeroReport(session, analysis, opts = {}) {
+  const { teacherName = 'Teacher', commitmentAction = '', language } = opts;
+  const lang = language || analysis.language || session.transcript_language || 'en';
+  const framework = (analysis.framework || 'oecd').toLowerCase();
+
+  const score = buildScoreViewModel(analysis, { framework, language: lang });
+
+  // Cross-framework journey trend. Non-fatal if it fails: a freshly-cloned bot
+  // with no coaching_sessions yet will return [] and the template renders the
+  // hero without the sparkline.
+  let trend = [];
+  try {
+    const raw = await loadTrendData(session.user_id, { limit: 12, locale: 'en' });
+    trend = raw
+      .map((t) => ({ date: String(t.date || '').slice(0, 10), pct: Math.round(parseFloat(t.pct || 0)) }))
+      .filter((t) => t.pct > 0);
+  } catch (e) {
+    logToFile('hero-report: trend load failed (non-fatal)', { error: e.message });
+  }
+
+  const narrative = await generateReportNarrative(analysis, {
+    transcript: session.transcript_text,
+    trend,
+    language: lang,
+    teacherName,
+  });
+
+  const vm = {
+    language: lang,
+    teacherName,
+    topic: (narrative && narrative.topic) || analysis.topic || '',
+    date: String(session.created_at || '').slice(0, 10),
+    score: { overall: score.overall, marks: score.marks, max: score.max },
+    groups: score.groups,
+    narrative: narrative || {},
+    tryNext: commitmentAction || '',
+    trend,
+    photoB64: '', // classroom-photo embedding = follow-up; solid-navy hero is the default
+  };
+
+  const png = await htmlToImage(buildHeroReportHtml(vm), { selector: '.report', width: 794, deviceScaleFactor: 2 });
+  return { png, caption: buildReportCaption(vm) };
+}
+
+module.exports = { generateHeroReport };

--- a/bot/shared/services/coaching/report-v2/narrative.service.js
+++ b/bot/shared/services/coaching/report-v2/narrative.service.js
@@ -1,0 +1,154 @@
+/**
+ * Coaching Report v2 — Celebration Narrative pass.
+ *
+ * The ONE new generation step the hero report needs. Reads the transcript (source of
+ * truth) + scores + the v12 reflective_corpus + the teacher's strengths/growth, and
+ * emits the celebration copy that makes a teacher feel SEEN. Modeled on
+ * `extractReflectiveCorpus` — a separate, purpose-built pass; the SCORING prompt
+ * (analyzePedagogy) is NOT touched.
+ *
+ * Deliberately does NOT produce `try_next` — the report's "one thing to try next" is
+ * the COMMITMENT-CARD action (single source of next-step truth).
+ *
+ * Output (stored at analysis_data.report_narrative):
+ *   { topic, affirmation, identity, moments:[{title,quote,why}×3],
+ *     strength_name, strength_note, horizon_title, horizon_note,
+ *     journey_note, score_framing }
+ *
+ * Language: en/sw LTR, ur/ar RTL. Gender-neutral + code-switch pedagogical terms to
+ * English inline (same rules as the commitment card), plus a deterministic
+ * transliteration normalizer for RTL. Quotes are kept verbatim in the spoken language.
+ */
+
+const GPT5MiniService = require('../../gpt5-mini.service');
+const { logToFile } = require('../../../utils/logger');
+const { KISWAHILI_STYLE } = require('../kiswahili-style');
+
+const LANG_NAME = { en: 'English', ur: 'Urdu', ar: 'Arabic', sw: 'Kiswahili' };
+const RTL_LANGS = new Set(['ur', 'ar']);
+
+function langRules(language) {
+  if (language === 'ur') {
+    return `WRITE every string value in URDU (Nastaliq), warm and natural — EXCEPT keep her real quotes verbatim in the language actually spoken, and EXCEPT the code-switched English terms below.
+
+GENDER-NEUTRAL (teachers are men AND women — mandatory):
+- Describe what she DID in PAST TENSE with نے (gender-neutral): "آپ نے جوڑا / آپ نے ماڈل کیا".
+- NEVER feminine present-habitual stems ("کرتی ہیں / دیتی ہیں").
+- Instructions use the RESPECTFUL آپ-imperative (کریں، دیں، پوچھیں) — never the intimate تم (کرو، دو).
+
+CODE-SWITCH: keep pedagogical/technical/subject terms in ENGLISH (Latin letters) inline — never transliterate into Nastaliq (write "open-ended questions" not "کھلے سوال"; "scaffolding" not "اسکفولڈنگ"; "phonics", "context", "model" stay English).`;
+  }
+  if (language === 'ar') {
+    return `WRITE every string value in MODERN STANDARD ARABIC, warm and natural — EXCEPT keep her real quotes verbatim in the language actually spoken, and keep pedagogical/technical terms in ENGLISH (Latin letters) inline (open-ended questions, scaffolding, phonics). Use gender-neutral phrasing (verbal nouns / impersonal constructions) rather than gendered second-person verb forms.`;
+  }
+  if (language === 'sw') {
+    return `WRITE every string value in warm, natural KISWAHILI — EXCEPT keep her real quotes VERBATIM in the language actually spoken (Kiswahili stays Kiswahili, English stays English; never translate a quote).
+
+Kiswahili is naturally gender-neutral — address her as "wewe"/"u-". Keep it warm and specific, never clinical.
+
+CODE-SWITCH like a real Tanzanian teacher: keep pedagogical/technical terms in ENGLISH (Latin letters) inline rather than inventing Swahili calques — "formative assessment", "open-ended questions", "scaffolding", "think-pair-share", "group work", "gallery walk", "feedback". The connecting Kiswahili words stay Kiswahili.
+
+${KISWAHILI_STYLE}`;
+  }
+  return 'Write every string value in warm, specific English.';
+}
+
+// Deterministic code-switch safety net for RTL (LLMs are ~90% consistent). Maps known
+// Urdu transliterations of pedagogical terms back to English. Mirrors the explorer +
+// commitment-card normalizers.
+const TRANSLIT_FIX = [
+  [/سائلنٹ\s*لیٹرز?/g, 'silent letters'],
+  [/کنٹیکسٹ/g, 'context'],
+  [/اسکی?فولڈنگ/g, 'scaffolding'],
+  [/فونکس/g, 'phonics'],
+  [/کھلے\s*سوالات?|اوپن\s*اینڈڈ\s*سوالات?/g, 'open-ended questions'],
+  [/گائیڈڈ\s*پریکٹس/g, 'guided practice'],
+];
+
+function fixCodeswitch(s) {
+  if (typeof s !== 'string') return s;
+  return TRANSLIT_FIX.reduce((acc, [re, en]) => acc.replace(re, en), s);
+}
+
+function normalize(c, language) {
+  if (!RTL_LANGS.has(language)) return c;
+  for (const k of ['affirmation', 'identity', 'strength_name', 'strength_note', 'horizon_title', 'horizon_note', 'journey_note', 'score_framing', 'topic']) {
+    if (c[k]) c[k] = fixCodeswitch(c[k]);
+  }
+  (c.moments || []).forEach((m) => { m.title = fixCodeswitch(m.title); m.why = fixCodeswitch(m.why); });
+  return c;
+}
+
+function buildPrompt(analysis, { transcript, trend = [], language, teacherName }) {
+  const a = analysis || {};
+  const fw = (a.framework || 'hots').toUpperCase();
+  const pct = Math.round(parseFloat(a.scores?.overall_percentage || 0));
+  const sessionCount = trend.length || 1;
+  const peak = trend.length ? Math.max(...trend.map((t) => Math.round(parseFloat(t.pct || 0)))) : pct;
+  const corpus = a.reflective_corpus || {};
+  const throughline = corpus.lesson_throughline_en || '';
+  const corpusMoments = (corpus.significant_moments || []).slice(0, 5)
+    .map((m) => `- ${m.what_happened || ''} (${m.significance_reason_en || ''})`).join('\n');
+
+  return `You are Rumi, a warm, perceptive instructional coach. Below is the FULL TRANSCRIPT of a real lesson by ${teacherName} plus its ${fw} rubric analysis. Write the words for a CELEBRATION report that makes this teacher feel truly SEEN — not graded like a medical report.
+
+Use the TRANSCRIPT as source of truth. Find what is UNIQUELY hers — a signature move, how she talks to children, how she connects ideas — and ground every claim in something she actually did. Tie it to the ${fw} lens (clarity, student involvement, questioning, classroom management) honestly, but lead with humanity. Address her as "you".
+
+${langRules(language)}
+
+Return STRICT JSON:
+{
+ "topic":"the lesson's topic in 2-4 words (in the report language)",
+ "affirmation":"ONE short, true, specific hero sentence — what she did beautifully today. Not generic. Max 14 words.",
+ "identity":"2-3 sentences: the signature of HER teaching, grounded in the transcript. Make her see herself.",
+ "moments":[{"title":"3-5 word title","quote":"a SHORT real quote kept VERBATIM in the language actually spoken","why":"one warm sentence on why it mattered"}],
+ "strength_name":"her #1 ${fw} strength, 2-4 warm words",
+ "strength_note":"one sentence celebrating it, grounded in what she did",
+ "horizon_title":"her growth edge framed as an exciting next horizon, 2-5 words",
+ "horizon_note":"one warm sentence naming the growth area without making her feel deficient",
+ "journey_note":"one sentence on her ${sessionCount}-session arc (peaked at ${peak}%, keeps showing up). Honest + encouraging.",
+ "score_framing":"one warm sentence framing overall ${pct}% as a stage in a journey, not a verdict."
+}
+moments: EXACTLY 3, the best real moments. Do NOT invent quotes — use real lines from the transcript.
+
+${throughline ? `THIS LESSON'S THROUGHLINE (from prior analysis): ${throughline}\n` : ''}${corpusMoments ? `MOMENTS ALREADY SURFACED (hints — prefer these, but pull the verbatim quote from the transcript):\n${corpusMoments}\n` : ''}LESSON TOPIC: ${a.topic || ''}
+${fw} summary: ${(a.executive_summary_sw || a.executive_summary || '').slice(0, 700)}
+Strengths: ${(a.strengths || []).map((s) => s.title_sw || s.title || s).filter(Boolean).join('; ')}
+Growth: ${a.growth_opportunities?.[0]?.area_sw || a.growth_opportunities?.[0]?.area || ''} — ${(a.growth_opportunities?.[0]?.rationale_sw || a.growth_opportunities?.[0]?.rationale || '').slice(0, 250)}
+TRANSCRIPT:
+${String(transcript || '').slice(0, 11000)}`;
+}
+
+/**
+ * Generate the celebration narrative.
+ * @param {object} analysis - analysis_data (framework, scores, strengths, growth_opportunities, reflective_corpus, …)
+ * @param {object} opts - { transcript, trend, language, teacherName }
+ * @returns {Promise<object|null>} celebration JSON (no try_next), normalized; null on failure.
+ */
+async function generateReportNarrative(analysis, opts = {}) {
+  const { transcript = '', trend = [], language = 'en', teacherName = 'Teacher' } = opts;
+  try {
+    const prompt = buildPrompt(analysis, { transcript, trend, language, teacherName });
+    const response = await GPT5MiniService.openai.chat.completions.create({
+      model: 'gpt-5-mini-2025-08-07',
+      messages: [{ role: 'user', content: prompt }],
+      response_format: { type: 'json_object' },
+    });
+    const parsed = JSON.parse(response.choices[0].message.content);
+    const narrative = normalize(parsed, language);
+    // The report's next-step is the COMMITMENT-CARD action, not a field of this pass.
+    // Strip any try_next the model volunteered so there's one source of next-step truth.
+    delete narrative.try_next;
+    // Guard: exactly 3 moments, each with the fields the template reads.
+    narrative.moments = (narrative.moments || []).slice(0, 3).map((m) => ({
+      title: m.title || '', quote: m.quote || '', why: m.why || '',
+    }));
+    narrative._language = language;
+    return narrative;
+  } catch (err) {
+    logToFile('❌ generateReportNarrative failed', { error: err.message, framework: analysis?.framework, language });
+    return null;
+  }
+}
+
+module.exports = { generateReportNarrative, buildPrompt, LANG_NAME };

--- a/bot/shared/services/coaching/report-v2/score-adapter.service.js
+++ b/bot/shared/services/coaching/report-v2/score-adapter.service.js
@@ -1,0 +1,51 @@
+/**
+ * Coaching Report v2 — Score Adapter.
+ *
+ * Turns a framework's `analysis_data` into ONE normalized ScoreViewModel that
+ * the unified celebration ("hero") renderer consumes — so the template never
+ * has to know each framework's bespoke score shape.
+ *
+ * ScoreViewModel:
+ *   {
+ *     framework, language,
+ *     overall,            // rounded overall %
+ *     marks, max,         // overall marks / max (null if absent)
+ *     groups: [           // the scorecard rows
+ *       { key, name, score, max, pct }
+ *     ]
+ *   }
+ *
+ * Per-framework `groups` are produced by adapters under
+ * `./score-adapters/`. The dispatcher maps a framework key to its adapter
+ * with an empty-groups fallback for unknown frameworks.
+ */
+
+const { getScoreAdapter } = require('./score-adapters/dispatch');
+
+function round(n) {
+  const v = parseFloat(n);
+  return Number.isFinite(v) ? Math.round(v) : 0;
+}
+
+/**
+ * @param {object} analysisData - coaching_sessions.analysis_data
+ * @param {object} [opts]
+ * @param {string} [opts.framework] - override analysisData.framework
+ * @param {string} [opts.language]  - 'sw' | 'en' | 'ur' | 'ar' (display language)
+ * @returns {{framework:string, language:string, overall:number, marks:?number, max:?number, groups:Array}}
+ */
+function buildScoreViewModel(analysisData, opts = {}) {
+  const a = analysisData || {};
+  const framework = String(opts.framework || a.framework || 'oecd').toLowerCase();
+  const language = opts.language || a.language || 'en';
+
+  const overall = round(a.scores?.overall_percentage);
+  const marks = a.scores?.overall_marks ?? null;
+  const max = a.scores?.overall_max_marks ?? null;
+
+  const groups = getScoreAdapter(framework)(a, language);
+
+  return { framework, language, overall, marks, max, groups };
+}
+
+module.exports = { buildScoreViewModel };

--- a/bot/shared/services/coaching/report-v2/score-adapters/dispatch.js
+++ b/bot/shared/services/coaching/report-v2/score-adapters/dispatch.js
@@ -1,0 +1,35 @@
+/**
+ * Score-adapter dispatch.
+ *
+ * Routes a framework key → its per-framework adapter function with the standard
+ * dispatch contract: lazy require + an empty-groups fallback for unknown
+ * frameworks (so an unknown framework renders an empty scorecard instead of
+ * crashing the hero report).
+ *
+ * Adding a new framework's score adapter = one line here.
+ */
+
+const { logToFile } = require('../../../../utils/logger');
+
+const ADAPTERS = {
+  oecd:  () => require('./oecd-adapter').buildOecdGroups,
+  hots:  () => require('./hots-adapter').buildHotsGroups,
+  teach: () => require('./teach-adapter').buildTeachGroups,
+  fico:  () => require('./fico-adapter').buildFicoGroups,
+};
+
+/**
+ * @param {string} framework  oecd | hots | teach | fico
+ * @returns {(analysis:object) => Array<{key,name,score,max,pct}>}
+ */
+function getScoreAdapter(framework) {
+  const key = String(framework || '').toLowerCase();
+  const factory = ADAPTERS[key];
+  if (!factory) {
+    logToFile(`[score-adapter-dispatch] Unknown framework "${framework}", returning empty-groups`);
+    return () => [];
+  }
+  return factory();
+}
+
+module.exports = { getScoreAdapter };

--- a/bot/shared/services/coaching/report-v2/score-adapters/fico-adapter.js
+++ b/bot/shared/services/coaching/report-v2/score-adapters/fico-adapter.js
@@ -1,0 +1,30 @@
+/**
+ * FICO score adapter — 5 domains.
+ *
+ * Structurally similar to MEWAKA — `analysis.domains[domainKey]` carries
+ * `{ domain_score, domain_max, indicators[] }` on a 1-4 scale. Falls back to
+ * `area_score`/`area_max` if a session was scored with the legacy area shape.
+ */
+
+const ficoFramework = require('../../frameworks/fico-framework');
+
+const SCALE_MAX = 4;
+
+function buildFicoGroups(a) {
+  const DOMAINS = ficoFramework.getScoringConstants().domains;
+  const container = (a && (a.domains || a.areas)) || {};
+  return Object.entries(DOMAINS).map(([domainKey, def], i) => {
+    const d = container[domainKey] || {};
+    const score = d.domain_score ?? d.area_score ?? 0;
+    const max = d.domain_max ?? d.area_max ?? def.indicatorCount * SCALE_MAX;
+    return {
+      key: `D${i + 1}`,
+      name: def.displayName,
+      score,
+      max,
+      pct: max > 0 ? Math.round((score / max) * 100) : 0,
+    };
+  });
+}
+
+module.exports = { buildFicoGroups };

--- a/bot/shared/services/coaching/report-v2/score-adapters/hots-adapter.js
+++ b/bot/shared/services/coaching/report-v2/score-adapters/hots-adapter.js
@@ -1,0 +1,30 @@
+/**
+ * HOTS score adapter — area altitude (5 groups).
+ *
+ * `analysis.areas[areaKey]` carries `{ area_score, area_max, indicators[] }` on
+ * a 1-3 scale. Display name is read from the framework module so the rubric is
+ * the single source of truth.
+ */
+
+const hotsFramework = require('../../frameworks/hots-framework');
+
+const SCALE_MAX = 3;
+
+function buildHotsGroups(a) {
+  const AREAS = hotsFramework.getScoringConstants().areas;
+  const container = (a && a.areas) || {};
+  return Object.entries(AREAS).map(([areaKey, def], i) => {
+    const ar = container[areaKey] || {};
+    const score = ar.area_score ?? 0;
+    const max = ar.area_max ?? def.indicatorCount * SCALE_MAX;
+    return {
+      key: `A${i + 1}`,
+      name: def.displayName,
+      score,
+      max,
+      pct: max > 0 ? Math.round((score / max) * 100) : 0,
+    };
+  });
+}
+
+module.exports = { buildHotsGroups };

--- a/bot/shared/services/coaching/report-v2/score-adapters/oecd-adapter.js
+++ b/bot/shared/services/coaching/report-v2/score-adapters/oecd-adapter.js
@@ -1,0 +1,34 @@
+/**
+ * OECD score adapter — goal altitude (5 groups).
+ *
+ * Mirrors the hero report's 6-row grid; goal-altitude is the cleanest fit
+ * (criterion altitude is 17 rows, too dense for a mobile hero). The
+ * pre-rolled `analysis.scores.goalN_total` marks are the source of truth;
+ * each goal's max = sum of criterion `max_marks` from the rubric.
+ */
+
+const oecdFramework = require('../../frameworks/oecd-framework');
+
+const GOAL_DISPLAY = {
+  goal1_formative_assessment: { key: 'G1', name: 'Formative Assessment & Feedback' },
+  goal2_student_engagement:   { key: 'G2', name: 'Student Engagement' },
+  goal3_quality_content:      { key: 'G3', name: 'Quality Subject Content' },
+  goal4_classroom_interaction: { key: 'G4', name: 'Classroom Interaction' },
+  goal5_classroom_management: { key: 'G5', name: 'Classroom Management' },
+};
+
+function buildOecdGroups(a) {
+  const RUBRIC = oecdFramework.getScoringConstants().areas;
+  const scores = (a && a.scores) || {};
+  return Object.entries(GOAL_DISPLAY).map(([goalKey, def]) => {
+    const criteria = RUBRIC[goalKey] || {};
+    const max = Object.values(criteria).reduce((s, c) => s + (c.max_marks || 0), 0);
+    // goal_key looks like `goal1_formative_assessment`; the persisted score key is
+    // `goal1_total` (i.e. the prefix before the first underscore + `_total`).
+    const shortKey = goalKey.split('_')[0]; // 'goal1'
+    const score = Number(scores[`${shortKey}_total`]) || 0;
+    return { key: def.key, name: def.name, score, max, pct: max > 0 ? Math.round((score / max) * 100) : 0 };
+  });
+}
+
+module.exports = { buildOecdGroups };

--- a/bot/shared/services/coaching/report-v2/score-adapters/teach-adapter.js
+++ b/bot/shared/services/coaching/report-v2/score-adapters/teach-adapter.js
@@ -1,0 +1,42 @@
+/**
+ * TEACH score adapter — 3 areas + Time on Task = 4 groups total.
+ *
+ * Element scoring is holistic 1-5 (not mathematical). Each area's max =
+ * elementCount × 5. Time on Task is a SEPARATE single score on a 1-5 scale,
+ * surfaced as a 4th group at position T1 (matches the existing PDFKit-side
+ * transformer's group order during the rollout).
+ */
+
+const teachFramework = require('../../frameworks/teach-framework');
+
+const ELEMENT_MAX = 5;
+
+function buildTeachGroups(a) {
+  const AREAS = teachFramework.getScoringConstants().areas;
+  const container = (a && a.areas) || {};
+
+  // Time on Task is group 1 (matches the legacy transformer for visual
+  // continuity during rollout). Then the 3 areas T2..T4.
+  const tot = (a && a.time_on_task) || {};
+  const totScore = Number(tot.score) || 0;
+  const groups = [
+    { key: 'T1', name: 'Time on Task', score: totScore, max: ELEMENT_MAX, pct: Math.round((totScore / ELEMENT_MAX) * 100) },
+  ];
+
+  Object.entries(AREAS).forEach(([areaKey, def], i) => {
+    const ar = container[areaKey] || {};
+    const score = ar.area_score ?? 0;
+    const max = ar.area_max ?? def.elementCount * ELEMENT_MAX;
+    groups.push({
+      key: `T${i + 2}`,
+      name: def.displayName,
+      score,
+      max,
+      pct: max > 0 ? Math.round((score / max) * 100) : 0,
+    });
+  });
+
+  return groups;
+}
+
+module.exports = { buildTeachGroups };

--- a/tests/coaching/hero-narrative-corpus.test.js
+++ b/tests/coaching/hero-narrative-corpus.test.js
@@ -1,0 +1,128 @@
+/**
+ * Hero Narrative — reflective_corpus propagation (bd-1842 → bd-1843 regression).
+ *
+ * The corpus extracted at session-completion (bd-1842) is the bridge between the
+ * v12 reflective chain and the celebration narrative. If the narrative ever stops
+ * pulling `lesson_throughline_en` + `significant_moments[]` off `analysis.reflective_corpus`,
+ * the hero report regresses to generic celebration copy. These tests lock the seam:
+ * the prompt builder must read corpus fields, and the celebration LLM must produce
+ * the exact downstream contract the hero template consumes.
+ */
+
+jest.mock('jsonrepair', () => ({ jsonrepair: (s) => s }), { virtual: true });
+jest.mock('dotenv', () => ({ config: () => ({}) }), { virtual: true });
+jest.mock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+
+// Mock GPT5MiniService.openai so the narrative call never touches the network.
+// We can't preconfigure a single canned response here — different tests need
+// different responses — so we expose a per-test setter on the mock module.
+const mockOpenAI = { chat: { completions: { create: jest.fn() } } };
+jest.mock('../../bot/shared/services/gpt5-mini.service', () => ({ openai: mockOpenAI }));
+
+const { buildPrompt, generateReportNarrative } = require('../../bot/shared/services/coaching/report-v2/narrative.service');
+
+const ANALYSIS_WITH_CORPUS = {
+  framework: 'hots',
+  topic: 'Place Value',
+  scores: { overall_percentage: 64 },
+  strengths: [{ title: 'Warm tone' }],
+  growth_opportunities: [{ area: 'Wait time', rationale: 'Asha rephrased before children had time' }],
+  reflective_corpus: {
+    lesson_throughline_en: 'children give confident wrong answers and the teacher re-explains herself',
+    significant_moments: [
+      { what_happened: 'class went silent on the tens-vs-ones distinction', significance_reason_en: 'collective confusion not addressed' },
+      { what_happened: 'a child answered 23 for 32', significance_reason_en: 'reversal misconception not surfaced' },
+      { what_happened: 'group whispered the answer for a struggling student', significance_reason_en: 'peer scaffolding teacher could amplify' },
+    ],
+  },
+};
+
+describe('buildPrompt() — corpus pull-through', () => {
+  it('throughline appears in the prompt verbatim', () => {
+    const prompt = buildPrompt(ANALYSIS_WITH_CORPUS, {
+      transcript: 'T', trend: [], language: 'en', teacherName: 'Asha',
+    });
+    expect(prompt).toContain("THIS LESSON'S THROUGHLINE");
+    expect(prompt).toContain('children give confident wrong answers');
+  });
+
+  it('first 5 significant_moments are formatted as "- what (reason)" lines', () => {
+    const prompt = buildPrompt(ANALYSIS_WITH_CORPUS, {
+      transcript: 'T', trend: [], language: 'en', teacherName: 'Asha',
+    });
+    expect(prompt).toContain('MOMENTS ALREADY SURFACED');
+    expect(prompt).toContain('- class went silent on the tens-vs-ones distinction (collective confusion not addressed)');
+    expect(prompt).toContain('- a child answered 23 for 32 (reversal misconception not surfaced)');
+  });
+
+  it('no reflective_corpus → "MOMENTS ALREADY SURFACED" omitted', () => {
+    const noCorpus = { ...ANALYSIS_WITH_CORPUS, reflective_corpus: undefined };
+    const prompt = buildPrompt(noCorpus, { transcript: 'T', trend: [], language: 'en', teacherName: 'Asha' });
+    expect(prompt).not.toContain('MOMENTS ALREADY SURFACED');
+    expect(prompt).not.toContain("THIS LESSON'S THROUGHLINE");
+  });
+
+  it('framework label tracks analysis.framework (HOTS here)', () => {
+    const prompt = buildPrompt(ANALYSIS_WITH_CORPUS, { transcript: 'T', trend: [], language: 'en', teacherName: 'Asha' });
+    expect(prompt).toContain('HOTS rubric analysis');
+    expect(prompt).toContain('HOTS lens');
+  });
+});
+
+describe('generateReportNarrative() — output guards', () => {
+  beforeEach(() => mockOpenAI.chat.completions.create.mockReset());
+
+  function mockResponse(payload) {
+    mockOpenAI.chat.completions.create.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify(payload) } }],
+    });
+  }
+
+  it('valid JSON → moments is exactly 3 with {title, quote, why}', async () => {
+    mockResponse({
+      topic: 'Place Value', affirmation: 'A clear opening',
+      identity: 'You ground children with calm framing.',
+      moments: [
+        { title: 'A', quote: 'q1', why: 'w1' },
+        { title: 'B', quote: 'q2', why: 'w2' },
+        { title: 'C', quote: 'q3', why: 'w3' },
+      ],
+      strength_name: 'Warmth', strength_note: 's',
+      horizon_title: 'Wait Time', horizon_note: 'h',
+      journey_note: 'j', score_framing: 'sf',
+    });
+    const out = await generateReportNarrative(ANALYSIS_WITH_CORPUS, { transcript: 'T', language: 'en', teacherName: 'Asha' });
+    expect(out.moments).toHaveLength(3);
+    expect(out.moments[0]).toEqual({ title: 'A', quote: 'q1', why: 'w1' });
+  });
+
+  it('5-moment payload → sliced to exactly 3', async () => {
+    mockResponse({
+      moments: [1, 2, 3, 4, 5].map((i) => ({ title: `T${i}`, quote: `Q${i}`, why: `W${i}` })),
+    });
+    const out = await generateReportNarrative(ANALYSIS_WITH_CORPUS, { transcript: 'T', language: 'en', teacherName: 'Asha' });
+    expect(out.moments).toHaveLength(3);
+    expect(out.moments.map((m) => m.title)).toEqual(['T1', 'T2', 'T3']);
+  });
+
+  it('try_next stripped from return value', async () => {
+    mockResponse({
+      topic: 't', moments: [], try_next: 'should be removed',
+    });
+    const out = await generateReportNarrative(ANALYSIS_WITH_CORPUS, { transcript: 'T', language: 'en', teacherName: 'Asha' });
+    expect(out.try_next).toBeUndefined();
+  });
+
+  it('LLM throws → returns null', async () => {
+    mockOpenAI.chat.completions.create.mockRejectedValue(new Error('boom'));
+    const out = await generateReportNarrative(ANALYSIS_WITH_CORPUS, { transcript: 'T', language: 'en', teacherName: 'Asha' });
+    expect(out).toBeNull();
+  });
+
+  it('output _language === opts.language', async () => {
+    mockResponse({ moments: [] });
+    const out = await generateReportNarrative(ANALYSIS_WITH_CORPUS, { transcript: 'T', language: 'sw', teacherName: 'Asha' });
+    expect(out._language).toBe('sw');
+  });
+});

--- a/tests/coaching/report-renderer-registry.test.js
+++ b/tests/coaching/report-renderer-registry.test.js
@@ -3,10 +3,12 @@
  *
  * The coaching report renderer is pluggable per framework via
  * bot/shared/services/coaching/report-renderers/renderer-registry.js.
- * Today: OECD/HOTS/TEACH/FICO render via the shared PDFKit layout and
- * MEWAKA renders via the Playwright HTML→PDF path. Adding a framework's
- * report design should be "register one line" in the registry, NOT editing
- * a hardcoded `if (framework === 'x')` branch in pdf-report.service.js.
+ *
+ * Default: OECD/HOTS/TEACH/FICO render via the unified celebration ("hero")
+ * design; MEWAKA renders via the legacy Playwright HTML→PDF path (it does not
+ * yet ship a `mewaka-framework.js` module, so the hero score adapter cannot
+ * produce groups for it — flipped in a follow-up). Unknown frameworks fall
+ * back to PDFKit.
  *
  * These tests lock the seam in place: if someone reintroduces a hardcoded
  * framework equality check in pdf-report.service.js, the grep assertion
@@ -36,15 +38,15 @@ describe('Report Renderer Registry — getReportRenderer()', () => {
     expect(typeof renderer.render).toBe('function');
   });
 
-  describe('PDFKit renderer for the pdfkit-layout frameworks', () => {
+  describe('Hero renderer is the default for OECD/HOTS/TEACH/FICO', () => {
     for (const framework of ['oecd', 'hots', 'teach', 'fico']) {
-      test(`"${framework}" maps to the PDFKit renderer`, () => {
+      test(`"${framework}" maps to the hero renderer`, () => {
         const renderer = getReportRenderer(framework);
-        expect(renderer.key).toBe('pdfkit');
+        expect(renderer.key).toBe('hero');
       });
     }
 
-    test('oecd/hots/teach/fico all share ONE PDFKit renderer instance', () => {
+    test('oecd/hots/teach/fico all share ONE hero renderer instance', () => {
       const oecd = getReportRenderer('oecd');
       expect(getReportRenderer('hots')).toBe(oecd);
       expect(getReportRenderer('teach')).toBe(oecd);
@@ -52,26 +54,29 @@ describe('Report Renderer Registry — getReportRenderer()', () => {
     });
   });
 
-  describe('HTML renderer for MEWAKA', () => {
+  describe('HTML renderer for MEWAKA (legacy — until a mewaka-framework lands)', () => {
     test('"mewaka" maps to the HTML (Playwright) renderer', () => {
       const renderer = getReportRenderer('mewaka');
       expect(renderer.key).toBe('html');
     });
 
-    test('the MEWAKA renderer is NOT the PDFKit renderer', () => {
+    test('the MEWAKA renderer is NOT the hero renderer', () => {
       expect(getReportRenderer('mewaka')).not.toBe(getReportRenderer('oecd'));
     });
   });
 
-  describe('Unknown frameworks fall back to the default', () => {
+  describe('Unknown frameworks fall back to the PDFKit default', () => {
     test('an unknown framework falls back to the PDFKit (default) renderer', () => {
       const fallback = getReportRenderer('does-not-exist');
       expect(fallback.key).toBe('pdfkit');
-      expect(fallback).toBe(getReportRenderer('oecd'));
     });
 
     test('undefined framework falls back to the PDFKit (default) renderer', () => {
       expect(getReportRenderer(undefined).key).toBe('pdfkit');
+    });
+
+    test('the PDFKit fallback is NOT the hero renderer', () => {
+      expect(getReportRenderer('does-not-exist')).not.toBe(getReportRenderer('oecd'));
     });
   });
 

--- a/tests/coaching/score-adapters.test.js
+++ b/tests/coaching/score-adapters.test.js
@@ -1,0 +1,186 @@
+/**
+ * Per-framework score adapter conformance.
+ *
+ * Each adapter takes a framework's `analysis_data` and produces the normalized
+ * `{ key, name, score, max, pct }[]` rows that the hero template renders. These
+ * tests lock the expected shape, group counts, display names sourced from the
+ * framework module, and the canonical-input → expected-groups mapping per
+ * framework. They also confirm the dispatcher's unknown-framework safety net.
+ */
+
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+
+const { buildScoreViewModel } = require('../../bot/shared/services/coaching/report-v2/score-adapter.service');
+const { getScoreAdapter } = require('../../bot/shared/services/coaching/report-v2/score-adapters/dispatch');
+
+describe('Score Adapter — buildScoreViewModel() per framework', () => {
+  describe('OECD — 5 goals at goal altitude', () => {
+    const a = {
+      framework: 'oecd',
+      scores: {
+        overall_percentage: 75,
+        goal1_total: 18,
+        goal2_total: 16,
+        goal3_total: 28,
+        goal4_total: 4,
+        goal5_total: 20,
+      },
+    };
+
+    it('returns 5 groups in canonical order G1..G5', () => {
+      const vm = buildScoreViewModel(a);
+      expect(vm.groups).toHaveLength(5);
+      expect(vm.groups.map((g) => g.key)).toEqual(['G1', 'G2', 'G3', 'G4', 'G5']);
+    });
+
+    it('G1 = Formative Assessment & Feedback, 18 / 22 / 82%', () => {
+      const vm = buildScoreViewModel(a);
+      const g1 = vm.groups[0];
+      expect(g1.name).toBe('Formative Assessment & Feedback');
+      expect(g1.score).toBe(18);
+      expect(g1.max).toBe(22);
+      expect(g1.pct).toBe(82);
+    });
+
+    it('G3 = Quality Subject Content, 28 / 34 / 82%', () => {
+      const vm = buildScoreViewModel(a);
+      const g3 = vm.groups[2];
+      expect(g3.name).toBe('Quality Subject Content');
+      expect(g3.score).toBe(28);
+      expect(g3.max).toBe(34);
+      expect(g3.pct).toBe(82);
+    });
+
+    it('missing goalN_total → score 0, full max, pct 0', () => {
+      const vm = buildScoreViewModel({ framework: 'oecd', scores: { overall_percentage: 0 } });
+      // G1 still shows its full rubric max even though score is 0.
+      expect(vm.groups[0].score).toBe(0);
+      expect(vm.groups[0].max).toBe(22);
+      expect(vm.groups[0].pct).toBe(0);
+    });
+
+    it('overall, marks, max pull from analysis.scores', () => {
+      const vm = buildScoreViewModel({ framework: 'oecd', scores: { overall_percentage: 75, overall_marks: 86, overall_max_marks: 115 } });
+      expect(vm.overall).toBe(75);
+      expect(vm.marks).toBe(86);
+      expect(vm.max).toBe(115);
+    });
+  });
+
+  describe('HOTS — 5 areas', () => {
+    const a = {
+      framework: 'hots',
+      areas: {
+        classroom_environment: { area_score: 7, area_max: 9 },
+        lesson_planning: { area_score: 5, area_max: 9 },
+        instructional_strategies: { area_score: 8, area_max: 12 },
+        student_engagement: { area_score: 6, area_max: 9 },
+        assessment_feedback: { area_score: 4, area_max: 9 },
+      },
+      scores: { overall_percentage: 62 },
+    };
+
+    it('returns 5 groups A1..A5 with displayName from rubric', () => {
+      const vm = buildScoreViewModel(a);
+      expect(vm.groups).toHaveLength(5);
+      expect(vm.groups.map((g) => g.key)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5']);
+      expect(vm.groups[0].name).toBe('Classroom Environment');
+      expect(vm.groups[3].name).toBe('Student Engagement');
+    });
+
+    it('A1 score/max land at 7 / 9 / 78%', () => {
+      const vm = buildScoreViewModel(a);
+      expect(vm.groups[0].score).toBe(7);
+      expect(vm.groups[0].max).toBe(9);
+      expect(vm.groups[0].pct).toBe(78);
+    });
+
+    it('missing areas → 0 score, indicatorCount × 3 max', () => {
+      const vm = buildScoreViewModel({ framework: 'hots', areas: {}, scores: {} });
+      // classroom_environment: 3 indicators × 3 = 9
+      expect(vm.groups[0].score).toBe(0);
+      expect(vm.groups[0].max).toBe(9);
+    });
+  });
+
+  describe('TEACH — 3 areas + Time on Task = 4 groups', () => {
+    const a = {
+      framework: 'teach',
+      areas: {
+        classroom_culture: { area_score: 8, area_max: 10 },
+        instruction: { area_score: 14, area_max: 20 },
+        socioemotional: { area_score: 10, area_max: 15 },
+      },
+      time_on_task: { score: 4 },
+      scores: { overall_percentage: 72 },
+    };
+
+    it('returns 4 groups T1..T4 with Time on Task first', () => {
+      const vm = buildScoreViewModel(a);
+      expect(vm.groups).toHaveLength(4);
+      expect(vm.groups.map((g) => g.key)).toEqual(['T1', 'T2', 'T3', 'T4']);
+      expect(vm.groups[0].name).toBe('Time on Task');
+    });
+
+    it('T1 = Time on Task, max 5, score 4, pct 80', () => {
+      const vm = buildScoreViewModel(a);
+      expect(vm.groups[0].score).toBe(4);
+      expect(vm.groups[0].max).toBe(5);
+      expect(vm.groups[0].pct).toBe(80);
+    });
+
+    it('missing time_on_task → T1 score 0', () => {
+      const vm = buildScoreViewModel({ framework: 'teach', areas: {}, scores: {} });
+      expect(vm.groups[0].score).toBe(0);
+      expect(vm.groups[0].max).toBe(5);
+    });
+  });
+
+  describe('FICO — 5 domains', () => {
+    const a = {
+      framework: 'fico',
+      domains: {
+        lesson_structure: { domain_score: 12, domain_max: 16 },
+        instructional_quality: { domain_score: 14, domain_max: 20 },
+        classroom_climate: { domain_score: 13, domain_max: 16 },
+        student_engagement: { domain_score: 11, domain_max: 16 },
+        assessment_feedback: { domain_score: 10, domain_max: 16 },
+      },
+      scores: { overall_percentage: 71 },
+    };
+
+    it('returns 5 groups D1..D5 from domain_score/domain_max', () => {
+      const vm = buildScoreViewModel(a);
+      expect(vm.groups).toHaveLength(5);
+      expect(vm.groups.map((g) => g.key)).toEqual(['D1', 'D2', 'D3', 'D4', 'D5']);
+      expect(vm.groups[0].name).toBe('Lesson Structure');
+      expect(vm.groups[0].score).toBe(12);
+      expect(vm.groups[0].max).toBe(16);
+      expect(vm.groups[0].pct).toBe(75);
+    });
+
+    it('falls back to area_score/area_max when domain_* missing', () => {
+      const a2 = {
+        framework: 'fico',
+        areas: { lesson_structure: { area_score: 9, area_max: 16 } },
+      };
+      const vm = buildScoreViewModel(a2);
+      expect(vm.groups[0].score).toBe(9);
+      expect(vm.groups[0].max).toBe(16);
+    });
+  });
+
+  describe('Unknown framework — empty groups (safety net)', () => {
+    it('framework="unknown" returns groups: []', () => {
+      const vm = buildScoreViewModel({ framework: 'unknown' });
+      expect(vm.framework).toBe('unknown');
+      expect(vm.groups).toEqual([]);
+    });
+
+    it('getScoreAdapter returns a function for any input (never throws)', () => {
+      const fn = getScoreAdapter('completely-made-up');
+      expect(typeof fn).toBe('function');
+      expect(fn({})).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## What this changes

The coaching report for the four PDFKit-rendered frameworks is currently a clinical scorecard. **This PR replaces it with the unified celebration design (PNG + caption)** — the same shape MEWAKA already ships, now generalised across frameworks.

The hero report:
- Frames overall % as a stage in a journey, not a verdict.
- Lifts the teacher's signature move + names her growth horizon.
- Reads the v12 reflective_corpus from PR #40 (lesson_throughline_en + first 5 significant_moments) so the celebration narrative is grounded in real moments, not generic copy.
- Renders as **inline image + caption** (image-friendly delivery) rather than a PDF document.
- Ends with a placeholder for the commitment-card action (single source of next-step truth — bd-1844 wires it).

## What's in the PR

### 6 new files at `bot/shared/services/coaching/report-v2/`

| File | Role |
|---|---|
| `score-adapter.service.js` | `buildScoreViewModel(analysis, opts)` — normalised `{ framework, language, overall, marks, max, groups[] }` |
| `score-adapters/dispatch.js` | Framework key → adapter, lazy require + empty-groups safety net |
| `score-adapters/oecd-adapter.js` | 5 groups G1..G5 at goal altitude (matches hero's 6-row grid) |
| `score-adapters/hots-adapter.js` | 5 groups A1..A5; display names from `hots-framework.getScoringConstants().areas` |
| `score-adapters/teach-adapter.js` | 4 groups T1..T4 (Time on Task **first** for visual continuity with legacy transformer) |
| `score-adapters/fico-adapter.js` | 5 groups D1..D5; `domain_score`/`domain_max` w/ `area_*` legacy fallback |
| `narrative.service.js` | Celebration LLM pass. Per-language gender + code-switch rules, RTL transliteration normalizer. Does NOT produce `try_next` |
| `hero-report.service.js` | `generateHeroReport(session, analysis, opts) → { png, caption }` — score adapter → narrative → trend → template → htmlToImage |

### Two supporting ports

- `coaching-trend.service.js` — `loadTrendData(userId)` for the hero sparkline. Defensive: always returns `[]`.
- `kiswahili-style.js` — `KISWAHILI_STYLE` directive for any prompt branch that emits teacher-facing Kiswahili.

### Wiring

- **`renderer-registry.js`** — flipped OECD / HOTS / TEACH / FICO from `pdfkitRenderer` to `heroRenderer`. **MEWAKA stays on `htmlRenderer`** because OSS does not yet ship a `mewaka-framework.js` module, so the hero score adapter cannot produce groups for it. Unknown frameworks still fall back to `pdfkitRenderer`.
- **`report-generator.service.js`** — attaches `_heroInput = { session, analysis, opts }` onto `reportData` before dispatch. The post-renderer line normalises return shape (heroRenderer returns `{png, caption}`; pdfkit/html return `Buffer`).

## Scoping decision

- **MEWAKA stays on `htmlRenderer`** in OSS. The readiness pack scoped a 5th `mewaka-adapter.js`, but OSS doesn't have `mewaka-framework.js` (only the legacy transformer + template). Adding the framework module + adapter is a clean follow-up. The renderer-registry header documents the lift.
- **Commitment-card action is not wired here** (`tryNext` defaults to `''` in the hero VM). bd-1844 wires it as the next PR; the hero template tolerates an empty `tryNext` gracefully.
- **No env-gated rollout flag.** The readiness pack listed `HERO_REPORT_FRAMEWORKS=oecd,hots,...` as an option, but OSS adopters change defaults via code, not env. The renderer-registry literal is the rollout lever.

## Test status

- **101 suites / 1211 tests green** (was 99 / 1186 → +2 suites, +25 tests)
- **CI-condition smoke** (`mv bot/node_modules /tmp/_nm && node tests/run.js`): green
- **Source-hygiene + leak-grep:** clean

Three test files:

- `tests/coaching/score-adapters.test.js` (15 tests) — per-framework canned-input → expected-groups assertions; unknown framework → empty groups.
- `tests/coaching/hero-narrative-corpus.test.js` (9 tests) — the bd-1842 → bd-1843 regression. Locks the seam: the narrative reads `lesson_throughline_en` + first 5 `significant_moments` off `analysis.reflective_corpus`, slices moments to exactly 3, strips `try_next`.
- `tests/coaching/report-renderer-registry.test.js` (UPDATED, 14 tests) — flipped expected default to hero for OECD/HOTS/TEACH/FICO. MEWAKA → html. Unknown → pdfkit. The no-hardcoded-fork grep stays as the seam guard.

## Wave 2 sequence

This is PR 3 of 4 in Wave 2:
- PR #39 (merged) — §D polish + bd-1835 partial
- PR #40 (merged) — bd-1842 v12 reflective chain
- **PR this — bd-1843 hero report for 4 frameworks**
- **Next: bd-1844 commitment card** — wires the teacher's Q3 verbatim + LLM lesson action into the hero `tryNext` slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)