### PR TITLE
feat(audit): platform-audit infrastructure — 4 conformance guards + allowlists (Wave 3 PR α)

### DIFF
--- a/tests/setup/_audit-helpers/require-graph.js
+++ b/tests/setup/_audit-helpers/require-graph.js
@@ -1,0 +1,404 @@
+/**
+ * Static require-graph helper for the Wave-3 platform audit guards.
+ *
+ * Builds the directed reachability graph rooted at the bot's entry points
+ * (web + workers + scripts + tests) and surfaces three derived properties
+ * the audit guards consume:
+ *
+ *   - reachable(): set of files reachable from any entry
+ *   - unresolvedRequires(): literal require('./x') that doesn't resolve
+ *   - findCycles(): Tarjan SCCs of size > 1
+ *
+ * Design notes:
+ *   - Strips `//` line comments and `/* * /` block comments before regex so
+ *     a `require(...)` mentioned inside a comment or string assertion doesn't
+ *     count.
+ *   - Distinguishes "literal" requires (`require('./x')`) from "lazy/optional"
+ *     requires (the same call wrapped in a `try { … }` block — the OSS-strip
+ *     pattern). Optionals that don't resolve are reported separately so the
+ *     guard can allowlist them by file:spec.
+ *   - Captures the path.resolve(VAR, 'X') / path.join(__dirname, 'X')
+ *     dynamic-require pattern so a test referenced via `require(path.resolve(
+ *     MONOREPO_ROOT, 'bot/.../x.js'))` doesn't false-orphan its target.
+ *   - Skips bare module specs (npm packages) — they're not in the audit's scope.
+ *   - Skips /node_modules/ subtree.
+ *
+ * Performance: this runs once per Jest run, memoised by an in-module cache, so
+ * the 4 guards share one graph. Empirically <2s on the OSS codebase (≈400 JS
+ * files reachable).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const BOT_ROOT = path.join(ROOT, 'bot');
+
+// ─── Comment stripping ──────────────────────────────────────────────────────
+
+const BLOCK_COMMENT_RE = /\/\*[\s\S]*?\*\//g;
+const LINE_COMMENT_RE = /\/\/[^\n]*/g;
+
+function stripComments(src) {
+  return src.replace(BLOCK_COMMENT_RE, '').replace(LINE_COMMENT_RE, '');
+}
+
+// ─── Require extraction ─────────────────────────────────────────────────────
+
+// Literal require: require('./x') or require("../x").
+// Negative look-behind on `"` / `'` skips `require(...)` literals that are
+// themselves inside a JS string (e.g. `toContain("require('./x')")` in a test
+// file — that's a string assertion, not a real require).
+const REQUIRE_LIT_RE = /(?<!["'])require\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+// Dynamic require with path.resolve(VAR, 'X') or path.join(VAR, 'X') —
+// captures the literal X (the file-path-like argument). Same look-behind guard.
+const PATH_RESOLVE_REQUIRE_RE =
+  /(?<!["'])require\(\s*path\.(?:resolve|join)\([^)]*?,\s*['"]([^'"]+)['"]\s*\)\s*\)/g;
+
+// Detect whether the position is inside a try { } block by counting brace depth
+// since the last `try {`. Cheap heuristic — sufficient for the audit.
+function isInTryCatch(src, pos) {
+  const prefix = src.slice(0, pos);
+  const lastTry = prefix.lastIndexOf('try {');
+  if (lastTry === -1) return false;
+  const between = prefix.slice(lastTry);
+  const open = (between.match(/\{/g) || []).length;
+  const close = (between.match(/\}/g) || []).length;
+  return open > close;
+}
+
+// Returns array of { spec, kind, isOptional, pos } for the file.
+function extractRequires(filePath) {
+  let src;
+  try {
+    src = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+  const clean = stripComments(src);
+  const out = [];
+  let m;
+  REQUIRE_LIT_RE.lastIndex = 0;
+  while ((m = REQUIRE_LIT_RE.exec(clean))) {
+    const spec = m[1];
+    if (!spec.startsWith('.') && !spec.startsWith('/')) continue; // bare package
+    out.push({
+      spec,
+      kind: 'literal',
+      isOptional: isInTryCatch(clean, m.index),
+      pos: m.index,
+    });
+  }
+  PATH_RESOLVE_REQUIRE_RE.lastIndex = 0;
+  while ((m = PATH_RESOLVE_REQUIRE_RE.exec(clean))) {
+    out.push({ spec: m[1], kind: 'path-resolve', isOptional: false, pos: m.index });
+  }
+  return out;
+}
+
+// ─── Resolution ─────────────────────────────────────────────────────────────
+
+function resolveLocal(fromDir, spec) {
+  const base = path.resolve(fromDir, spec);
+  // CJS resolution order — try in turn.
+  const candidates = [
+    base,
+    base + '.js',
+    base + '.json',
+    path.join(base, 'index.js'),
+    path.join(base, 'package.json'),
+  ];
+  for (const c of candidates) {
+    let stat;
+    try {
+      stat = fs.statSync(c);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile()) continue;
+    if (path.basename(c) === 'package.json') {
+      try {
+        const pj = JSON.parse(fs.readFileSync(c, 'utf8'));
+        const main = pj.main || 'index.js';
+        const target = path.resolve(path.dirname(c), main);
+        if (fs.existsSync(target)) return target;
+      } catch {
+        /* fall through */
+      }
+      continue;
+    }
+    return c;
+  }
+  return null;
+}
+
+// A path.resolve/path.join spec is treated as repo-rooted (most common pattern
+// in OSS tests that do `require(path.resolve(MONOREPO_ROOT, 'bot/.../x'))`).
+function resolvePathResolve(spec) {
+  // Heuristic: only resolve specs that look like a file path. A bare 'pdfkit'
+  // through path.join(node_modules, 'pdfkit') is NOT a file path we audit —
+  // skip if there's no slash and no extension.
+  if (!spec.includes('/') && !spec.endsWith('.js') && !spec.endsWith('.json')) {
+    return 'BARE_MODULE';
+  }
+  const tries = [
+    path.join(ROOT, spec),
+    path.join(ROOT, spec) + '.js',
+    path.join(ROOT, spec, 'index.js'),
+    path.join(BOT_ROOT, spec),
+    path.join(BOT_ROOT, spec) + '.js',
+  ];
+  for (const t of tries) {
+    try {
+      if (fs.statSync(t).isFile()) return t;
+    } catch {
+      /* skip */
+    }
+  }
+  return null;
+}
+
+// ─── Entry-point discovery ──────────────────────────────────────────────────
+
+function* walkJs(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (full.includes('/node_modules/')) continue;
+    if (e.isDirectory()) {
+      yield* walkJs(full);
+    } else if (e.isFile() && e.name.endsWith('.js')) {
+      yield full;
+    }
+  }
+}
+
+function discoverEntries() {
+  const eps = new Set();
+  // Web server
+  const web = path.join(BOT_ROOT, 'whatsapp-bot.js');
+  if (fs.existsSync(web)) eps.add(web);
+  const dashboard = path.join(BOT_ROOT, 'dashboard', 'index.js');
+  if (fs.existsSync(dashboard)) eps.add(dashboard);
+
+  // Workers
+  const workersDir = path.join(BOT_ROOT, 'workers');
+  if (fs.existsSync(workersDir)) {
+    for (const f of fs.readdirSync(workersDir)) {
+      if (f.endsWith('.js')) eps.add(path.join(workersDir, f));
+    }
+  }
+
+  // `node X.js` mentions in any package.json scripts
+  for (const pkgPath of [path.join(BOT_ROOT, 'package.json'), path.join(ROOT, 'package.json')]) {
+    let pkg;
+    try {
+      pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    } catch {
+      continue;
+    }
+    for (const [, val] of Object.entries(pkg.scripts || {})) {
+      const re = /node\s+([\w./-]+\.js)/g;
+      let m;
+      while ((m = re.exec(val))) {
+        const candidate = path.resolve(path.dirname(pkgPath), m[1]);
+        if (fs.existsSync(candidate)) eps.add(candidate);
+      }
+    }
+  }
+
+  // Infrastructure scripts
+  const infra = path.join(ROOT, 'infrastructure', 'scripts');
+  if (fs.existsSync(infra)) for (const f of walkJs(infra)) eps.add(f);
+
+  // Top-level scripts
+  const scripts = path.join(ROOT, 'scripts');
+  if (fs.existsSync(scripts)) for (const f of walkJs(scripts)) eps.add(f);
+
+  // ALL test files (root tests/ + bot/tests/)
+  for (const t of [path.join(ROOT, 'tests'), path.join(BOT_ROOT, 'tests')]) {
+    if (!fs.existsSync(t)) continue;
+    for (const f of walkJs(t)) {
+      if (f.endsWith('.test.js')) eps.add(f);
+    }
+  }
+
+  return [...eps].map((p) => path.resolve(p));
+}
+
+// ─── Build the reachable set + edge list ────────────────────────────────────
+
+function buildGraph(entries) {
+  const visited = new Set();
+  const unresolvedRequired = []; // [{ from, spec }]
+  const unresolvedOptional = []; // same shape
+  const edges = []; // [{ from, to }]
+
+  const stack = entries.slice();
+  while (stack.length) {
+    const f = stack.pop();
+    if (visited.has(f)) continue;
+    visited.add(f);
+
+    for (const r of extractRequires(f)) {
+      let target;
+      if (r.kind === 'literal') {
+        target = resolveLocal(path.dirname(f), r.spec);
+      } else {
+        target = resolvePathResolve(r.spec);
+        if (target === 'BARE_MODULE') continue; // ignore bare deps via path.join
+      }
+      if (target === null) {
+        if (r.isOptional) unresolvedOptional.push({ from: f, spec: r.spec });
+        else unresolvedRequired.push({ from: f, spec: r.spec });
+        continue;
+      }
+      if (target.includes('/node_modules/')) continue;
+      edges.push({ from: f, to: target });
+      if (!visited.has(target)) stack.push(target);
+    }
+  }
+  return { reachable: visited, unresolvedRequired, unresolvedOptional, edges };
+}
+
+// ─── Tarjan's SCC (iterative) ───────────────────────────────────────────────
+
+function tarjanSCC(nodes, adj) {
+  const indexes = new Map();
+  const lowlinks = new Map();
+  const onStack = new Set();
+  const stack = [];
+  let index = 0;
+  const result = [];
+
+  function strongconnectIter(start) {
+    const work = [[start, 0, adj.get(start) ? [...adj.get(start)] : []]];
+    indexes.set(start, index);
+    lowlinks.set(start, index);
+    index += 1;
+    stack.push(start);
+    onStack.add(start);
+
+    while (work.length) {
+      const frame = work[work.length - 1];
+      const [node, , succs] = frame;
+      if (frame[1] < succs.length) {
+        const succ = succs[frame[1]];
+        frame[1] += 1;
+        if (!indexes.has(succ)) {
+          indexes.set(succ, index);
+          lowlinks.set(succ, index);
+          index += 1;
+          stack.push(succ);
+          onStack.add(succ);
+          work.push([succ, 0, adj.get(succ) ? [...adj.get(succ)] : []]);
+        } else if (onStack.has(succ)) {
+          lowlinks.set(node, Math.min(lowlinks.get(node), indexes.get(succ)));
+        }
+      } else {
+        work.pop();
+        if (work.length) {
+          const parent = work[work.length - 1][0];
+          lowlinks.set(parent, Math.min(lowlinks.get(parent), lowlinks.get(node)));
+        }
+        if (lowlinks.get(node) === indexes.get(node)) {
+          const scc = [];
+          for (;;) {
+            const w = stack.pop();
+            onStack.delete(w);
+            scc.push(w);
+            if (w === node) break;
+          }
+          if (scc.length > 1) result.push(scc);
+        }
+      }
+    }
+  }
+
+  for (const n of nodes) {
+    if (!indexes.has(n)) strongconnectIter(n);
+  }
+  return result;
+}
+
+// ─── Memoised public API ────────────────────────────────────────────────────
+
+let _cache = null;
+
+function getGraph() {
+  if (_cache) return _cache;
+  const entries = discoverEntries();
+  const g = buildGraph(entries);
+  // Build the adjacency map for SCC use.
+  const adj = new Map();
+  for (const e of g.edges) {
+    if (!adj.has(e.from)) adj.set(e.from, new Set());
+    adj.get(e.from).add(e.to);
+  }
+  const allNodes = new Set([...adj.keys()]);
+  for (const succs of adj.values()) for (const s of succs) allNodes.add(s);
+  _cache = {
+    entries,
+    reachable: g.reachable,
+    unresolvedRequired: g.unresolvedRequired,
+    unresolvedOptional: g.unresolvedOptional,
+    edges: g.edges,
+    adj,
+    allNodes,
+    findCycles() {
+      return tarjanSCC([...this.allNodes], this.adj);
+    },
+  };
+  return _cache;
+}
+
+// For testing: lets a test reset the cache between integration runs.
+function _resetCache() {
+  _cache = null;
+}
+
+// File enumeration in the dirs the orphan guard audits.
+const AUDITED_DIRS = [
+  path.join(BOT_ROOT, 'shared', 'services'),
+  path.join(BOT_ROOT, 'shared', 'handlers'),
+  path.join(BOT_ROOT, 'shared', 'storage'),
+  path.join(BOT_ROOT, 'shared', 'utils'),
+  path.join(BOT_ROOT, 'shared', 'config'),
+];
+
+function auditedFiles() {
+  const out = [];
+  for (const d of AUDITED_DIRS) {
+    if (!fs.existsSync(d)) continue;
+    for (const f of walkJs(d)) {
+      if (f.includes('/__mocks__/') || f.includes('/__tests__/')) continue;
+      out.push(path.resolve(f));
+    }
+  }
+  return out;
+}
+
+function relPath(p) {
+  return p.replace(ROOT + '/', '');
+}
+
+module.exports = {
+  ROOT,
+  BOT_ROOT,
+  getGraph,
+  auditedFiles,
+  relPath,
+  // Lower-level pieces exported so individual guards can use them:
+  stripComments,
+  extractRequires,
+  resolveLocal,
+  isInTryCatch,
+  tarjanSCC,
+  _resetCache,
+};

--- a/tests/setup/circular-deps.allowlist.json
+++ b/tests/setup/circular-deps.allowlist.json
@@ -1,0 +1,24 @@
+[
+  {
+    "cycle": [
+      "bot/shared/services/coaching/frameworks/oecd-framework.js",
+      "bot/shared/services/coaching/frameworks/framework-registry.js",
+      "bot/shared/constants/scoring.constants.js"
+    ],
+    "reason": "Pre-existing constants↔framework cycle. scoring.constants.js requires the framework registry to look up the active framework at runtime; the registry lazy-requires each framework module via a factory function. Works because the lazy require defers until call time. A true fix would lift the constants out of the framework path; out of scope here."
+  },
+  {
+    "cycle": [
+      "bot/shared/services/coaching/report-renderers/renderer-registry.js",
+      "bot/shared/services/pdf-report.service.js"
+    ],
+    "reason": "Introduced by bd-1843 (the hero report). pdf-report.service.js eager-requires the renderer-registry to dispatch; the registry lazy-requires pdf-report.service.js inside pdfkitRenderer.render() and htmlRenderer.render(). Works because the lazy require defers until render time."
+  },
+  {
+    "cycle": [
+      "bot/shared/services/elevenlabs.service.js",
+      "bot/shared/services/audio.service.js"
+    ],
+    "reason": "Pre-existing cross-dependency between the TTS service and the audio-processing service. Both lazy-require each other inside their respective methods (audio.service.js does it 4× for different TTS variants). Works at runtime."
+  }
+]

--- a/tests/setup/circular-deps.test.js
+++ b/tests/setup/circular-deps.test.js
@@ -1,0 +1,49 @@
+/**
+ * Circular-dependency audit (Wave 3 PR α / α.3).
+ *
+ * Tarjan's SCC on the static require graph. Any SCC of size > 1 is a cycle.
+ * CommonJS tolerates cycles but the second import returns `{}` until the first
+ * finishes evaluating — producing surprising `undefined` exports at runtime,
+ * usually only on cold start.
+ *
+ * Allowlisted cycles are still detected; the guard just doesn't fail on them.
+ * A NEW cycle (one not in the allowlist) fails the build, naming the files.
+ */
+
+const path = require('path');
+const { getGraph, ROOT } = require('./_audit-helpers/require-graph');
+const ALLOWLIST = require('./circular-deps.allowlist.json');
+
+function cycleKey(scc) {
+  return scc.slice().sort().join('|');
+}
+
+describe('Circular-dependency audit', () => {
+  const graph = getGraph();
+
+  it('no circular requires (or every cycle is allowlisted with a reason)', () => {
+    const cycles = graph.findCycles();
+    const allowedKeys = new Set(
+      ALLOWLIST.map((a) => a.cycle.map((f) => path.resolve(ROOT, f)).slice().sort().join('|'))
+    );
+    const newCycles = cycles
+      .filter((scc) => !allowedKeys.has(cycleKey(scc)))
+      .map((scc) => scc.map((n) => n.replace(ROOT + '/', '')));
+    expect(newCycles).toEqual([]);
+  });
+
+  it('every allowlist entry is still actually a live cycle', () => {
+    const cycles = graph.findCycles();
+    const liveCycleKeys = new Set(cycles.map(cycleKey));
+    const stale = ALLOWLIST.filter((a) => {
+      const k = a.cycle.map((f) => path.resolve(ROOT, f)).slice().sort().join('|');
+      return !liveCycleKeys.has(k);
+    }).map((a) => a.cycle.join(' ↔ '));
+    expect(stale).toEqual([]);
+  });
+
+  it('every allowlist entry has a non-trivial reason (>= 10 chars)', () => {
+    const thin = ALLOWLIST.filter((a) => !a.reason || a.reason.trim().length < 10);
+    expect(thin).toEqual([]);
+  });
+});

--- a/tests/setup/orphan-modules.allowlist.json
+++ b/tests/setup/orphan-modules.allowlist.json
@@ -1,0 +1,54 @@
+[
+  {
+    "file": "bot/shared/services/bandit.service.js",
+    "reason": "Thompson-sampling multi-armed bandit. Documented in .claude/skills/ab-testing as an opt-in customization pattern; no live caller in OSS. A cloner enabling A/B testing wires it themselves. KEEP."
+  },
+  {
+    "file": "bot/shared/services/chart.service.js",
+    "reason": "PENDING DELETION in Wave 3 PR β — confirmed-dead chart generation utility, no live caller."
+  },
+  {
+    "file": "bot/shared/services/coaching/coaching-flow-helpers.service.js",
+    "reason": "PENDING DELETION in Wave 3 PR β — confirmed-dead coaching helper, superseded by inline helpers in coaching-orchestrator."
+  },
+  {
+    "file": "bot/shared/services/password-reset.service.js",
+    "reason": "PENDING DELETION in Wave 3 PR β (after a second dashboard/EJS grep) — portal-only feature with no live caller in the bot or dashboard entry points."
+  },
+  {
+    "file": "bot/shared/services/pdf-report-pdfmake.service.js",
+    "reason": "PENDING DELETION in Wave 3 PR β — confirmed-dead alternative-PDF utility (pdfmake-based), superseded by the PDFKit + Playwright paths."
+  },
+  {
+    "file": "bot/shared/services/pdf.service.js",
+    "reason": "PENDING DELETION in Wave 3 PR β — confirmed-dead PDF utility, no live caller."
+  },
+  {
+    "file": "bot/shared/utils/language-validator.js",
+    "reason": "PENDING DELETION in Wave 3 PR β — confirmed-dead language-validation utility."
+  },
+  {
+    "file": "bot/shared/utils/punjabi-tone.js",
+    "reason": "PENDING DELETION in Wave 3 PR β — confirmed-dead Punjabi-tone utility."
+  },
+  {
+    "file": "bot/shared/utils/roman-urdu.js",
+    "reason": "PENDING DELETION in Wave 3 PR β — confirmed-dead Roman-Urdu utility."
+  },
+  {
+    "file": "bot/shared/utils/sticker-converter.js",
+    "reason": "PENDING DELETION in Wave 3 PR β — confirmed-dead sticker-conversion utility."
+  },
+  {
+    "file": "bot/shared/utils/style-policy.js",
+    "reason": "PENDING DELETION in Wave 3 PR β — confirmed-dead style-policy utility."
+  },
+  {
+    "file": "bot/shared/utils/voice-script.js",
+    "reason": "PENDING DELETION in Wave 3 PR β — confirmed-dead voice-script utility."
+  },
+  {
+    "file": "bot/shared/config/system-messages.js",
+    "reason": "PENDING DELETION in Wave 3 PR β (after a second grep) — config file with no live caller."
+  }
+]

--- a/tests/setup/orphan-modules.test.js
+++ b/tests/setup/orphan-modules.test.js
@@ -1,0 +1,49 @@
+/**
+ * Orphan-module audit (Wave 3 PR α / α.1).
+ *
+ * Asserts every .js file under the audited dirs (services / handlers / storage
+ * / utils / config) is reachable via static `require()` from at least one
+ * entry point (web + workers + scripts + tests), OR is explicitly allowlisted
+ * with a documented reason.
+ *
+ * An orphan that wasn't allowlisted = dead code a cloner sees but can't trace
+ * back to anywhere live. Either delete it or document why it stays.
+ *
+ * The allowlist lives at `tests/setup/orphan-modules.allowlist.json`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { getGraph, auditedFiles, relPath, ROOT } = require('./_audit-helpers/require-graph');
+
+const ALLOWLIST = require('./orphan-modules.allowlist.json');
+
+describe('Orphan-module audit', () => {
+  const graph = getGraph();
+  const reachable = graph.reachable;
+  const allowedSet = new Set(ALLOWLIST.map((a) => path.resolve(ROOT, a.file)));
+
+  it('every audited .js file is reachable from an entry point (or allowlisted)', () => {
+    const orphans = auditedFiles()
+      .filter((f) => !reachable.has(f) && !allowedSet.has(f))
+      .map(relPath);
+    expect(orphans).toEqual([]);
+  });
+
+  it('every allowlist entry still exists on disk', () => {
+    const missing = ALLOWLIST.filter((a) => !fs.existsSync(path.resolve(ROOT, a.file)));
+    expect(missing).toEqual([]);
+  });
+
+  it('every allowlist entry carries a non-trivial reason (>= 10 chars)', () => {
+    const thin = ALLOWLIST.filter((a) => !a.reason || a.reason.trim().length < 10);
+    expect(thin).toEqual([]);
+  });
+
+  it('every allowlisted file is genuinely orphaned right now (else clean up the allowlist)', () => {
+    const stale = ALLOWLIST
+      .filter((a) => reachable.has(path.resolve(ROOT, a.file)))
+      .map((a) => a.file);
+    expect(stale).toEqual([]);
+  });
+});

--- a/tests/setup/unresolved-requires.allowlist.json
+++ b/tests/setup/unresolved-requires.allowlist.json
@@ -1,0 +1,17 @@
+[
+  {
+    "from": "bot/shared/services/pic-to-lp/lp-handoff.service.js",
+    "spec": "../lesson-plan-prompts.service",
+    "reason": "OSS-stripped Gamma 'Detailed' path. The require is INSIDE a try/catch inside generateAndDeliver() — load + pickBackend() both work without it. The file's own JSDoc documents this as an explicit OSS-strip."
+  },
+  {
+    "from": "bot/workers/homework-bundle.worker.js",
+    "spec": "../shared/services/lp-feedback.service",
+    "reason": "OSS-stripped post-delivery feedback prompt. Lazy-required inside the post-delivery branch, no-op if absent. The file's own JSDoc documents this."
+  },
+  {
+    "from": "bot/workers/pic-lp-kieai.worker.js",
+    "spec": "../shared/services/lp-feedback.service",
+    "reason": "Same OSS-stripped service as homework-bundle; lazy-required inside the post-delivery branch."
+  }
+]

--- a/tests/setup/unresolved-requires.test.js
+++ b/tests/setup/unresolved-requires.test.js
@@ -1,0 +1,57 @@
+/**
+ * Unresolved-require audit (Wave 3 PR α / α.2).
+ *
+ * Every literal `require('./x')` in reachable code resolves to a real file,
+ * OR is wrapped in a try/catch (intentional OSS-strip pattern) AND is listed
+ * in the allowlist with a documented reason.
+ *
+ * A non-allowlisted, non-try-catch require to a missing file is a real bug
+ * that would crash at runtime when the code path executes.
+ */
+
+const path = require('path');
+const { getGraph, ROOT } = require('./_audit-helpers/require-graph');
+const ALLOWLIST = require('./unresolved-requires.allowlist.json');
+
+function key(from, spec) {
+  return `${from}|${spec}`;
+}
+
+describe('Unresolved-require audit', () => {
+  const graph = getGraph();
+  const allowedSet = new Set(
+    ALLOWLIST.map((a) => key(path.resolve(ROOT, a.from), a.spec))
+  );
+
+  it('no literal require() in reachable code points at a missing file', () => {
+    const failures = graph.unresolvedRequired.map((u) => ({
+      from: u.from.replace(ROOT + '/', ''),
+      spec: u.spec,
+    }));
+    expect(failures).toEqual([]);
+  });
+
+  it('every try-catch-wrapped unresolved require is allowlisted', () => {
+    const unwhitelisted = graph.unresolvedOptional
+      .filter((u) => !allowedSet.has(key(u.from, u.spec)))
+      .map((u) => ({ from: u.from.replace(ROOT + '/', ''), spec: u.spec }));
+    expect(unwhitelisted).toEqual([]);
+  });
+
+  it('every allowlist entry is still actually unresolved (else clean it up)', () => {
+    const actualUnresolved = new Set(
+      [...graph.unresolvedOptional, ...graph.unresolvedRequired].map((u) =>
+        key(u.from, u.spec)
+      )
+    );
+    const stale = ALLOWLIST.filter(
+      (a) => !actualUnresolved.has(key(path.resolve(ROOT, a.from), a.spec))
+    ).map((a) => `${a.from} → ${a.spec}`);
+    expect(stale).toEqual([]);
+  });
+
+  it('every allowlist entry has a non-trivial reason (>= 10 chars)', () => {
+    const thin = ALLOWLIST.filter((a) => !a.reason || a.reason.trim().length < 10);
+    expect(thin).toEqual([]);
+  });
+});

--- a/tests/setup/worker-boot.test.js
+++ b/tests/setup/worker-boot.test.js
@@ -1,0 +1,133 @@
+/**
+ * Worker-boot audit (Wave 3 PR α / α.4).
+ *
+ * For every Node entry point (web + workers), fork a child process with a
+ * minimum-shaped env and assert the require chain resolves without load-time
+ * errors. The check is forked, NOT in-process, because no OSS worker today
+ * gates on `require.main === module` — requiring a worker file starts it.
+ *
+ * Pass criteria:
+ *   - Child is still alive at the 1.5s timeout (require chain resolved, the
+ *     main loop kicked in) → PASS, kill it
+ *   - Child exited with code 0 in < 1.5s → PASS (clean require + early exit)
+ *   - Child exited with code != 0 in < 1.5s → FAIL (load-time error in stderr)
+ *
+ * Three entries are allowlisted as KNOWN_BOOT_IO_FAIL because they do
+ * Supabase I/O at boot — fragile under DNS flap but harmless in real prod.
+ * Tracked as a Wave-4 architectural cleanup.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+const { ROOT, BOT_ROOT } = require('./_audit-helpers/require-graph');
+
+// Same minimum-shaped env the dry-pass used. All values pass presence-gating
+// without dialling real services.
+const MINIMUM_ENV = {
+  NODE_ENV: 'test',
+  PORT: '0', // ephemeral port — no collision
+  SUPABASE_URL: 'http://localhost:54321',
+  SUPABASE_SERVICE_ROLE_KEY: 'eyJ-test-placeholder',
+  OPENROUTER_API_KEY: 'sk-or-v1-placeholder',
+  OPENAI_API_KEY: 'sk-placeholder',
+  REDIS_URL: 'redis://localhost:6379',
+  WHATSAPP_TOKEN: 'EAA-test',
+  PHONE_NUMBER_ID: '0000000000',
+  WABA_ID: '1111111111',
+  WEBHOOK_VERIFY_TOKEN: 'test-verify-token',
+};
+
+const LOAD_TIME_ERROR_RE =
+  /SyntaxError|MODULE_NOT_FOUND|Cannot find module|^Error:/m;
+
+function discoverWorkerEntries() {
+  const list = [];
+  const web = path.join(BOT_ROOT, 'whatsapp-bot.js');
+  if (fs.existsSync(web)) list.push(web);
+  const workersDir = path.join(BOT_ROOT, 'workers');
+  if (fs.existsSync(workersDir)) {
+    for (const f of fs.readdirSync(workersDir)) {
+      if (f.endsWith('.js')) list.push(path.join(workersDir, f));
+    }
+  }
+  return list;
+}
+
+function bootCheck(entry, timeoutMs = 1500) {
+  return new Promise((resolve) => {
+    let out = '';
+    const child = spawn('node', [entry], {
+      cwd: ROOT,
+      env: { ...process.env, ...MINIMUM_ENV },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout.on('data', (d) => {
+      out += d.toString();
+    });
+    child.stderr.on('data', (d) => {
+      out += d.toString();
+    });
+    const t = setTimeout(() => {
+      try { child.kill('SIGTERM'); } catch { /* already dead */ }
+      const errorLine = LOAD_TIME_ERROR_RE.test(out)
+        ? out.match(LOAD_TIME_ERROR_RE)[0]
+        : null;
+      resolve({ status: errorLine ? 'fail' : 'pass', errorLine, code: null, out });
+    }, timeoutMs);
+    child.on('exit', (code) => {
+      clearTimeout(t);
+      const errorLine = LOAD_TIME_ERROR_RE.test(out)
+        ? out.match(LOAD_TIME_ERROR_RE)[0]
+        : null;
+      const ok = (code === 0 || code === null) && !errorLine;
+      resolve({ status: ok ? 'pass' : 'fail', errorLine, code, out });
+    });
+  });
+}
+
+// Allowlist: workers that fail at boot because they do Supabase I/O before
+// entering their message loop. Tracked as a Wave-4 follow-up.
+const KNOWN_BOOT_IO_FAIL = new Set([
+  path.join(BOT_ROOT, 'workers', 'coaching-processor.js'),
+  path.join(BOT_ROOT, 'workers', 'sqs-worker.js'),
+  path.join(BOT_ROOT, 'workers', 'stale-session.worker.js'),
+]);
+
+// Booting workers requires the bot's own node_modules (ioredis, @aws-sdk, etc).
+// CI runs the root test suite BEFORE `cd bot && npm ci`, so bot/node_modules is
+// absent at first-pass; the workers would fail with MODULE_NOT_FOUND for npm
+// packages, which isn't what α.4 is checking. Detect and skip gracefully.
+const BOT_NODE_MODULES_PRESENT = fs.existsSync(path.join(BOT_ROOT, 'node_modules'));
+
+describe('Worker-boot audit — every entry loads (forked)', () => {
+  const entries = discoverWorkerEntries();
+
+  if (!BOT_NODE_MODULES_PRESENT) {
+    it.skip('SKIPPED — bot/node_modules absent (CI first-pass); run after `cd bot && npm ci`', () => {});
+    return;
+  }
+
+  for (const entry of entries) {
+    const rel = entry.replace(ROOT + '/', '');
+    const isAllowed = KNOWN_BOOT_IO_FAIL.has(entry);
+    const label = isAllowed ? `[allowlist] ${rel}` : rel;
+    it(
+      label,
+      async () => {
+        const r = await bootCheck(entry, 2000);
+        if (isAllowed) {
+          // Document but don't gate the build.
+          return;
+        }
+        if (r.status !== 'pass') {
+          throw new Error(
+            `${rel} failed boot:\n  ${r.errorLine || 'exit code ' + r.code}\n  ` +
+              `stderr/stdout tail:\n${r.out.split('\n').slice(-5).join('\n')}`
+          );
+        }
+      },
+      5000
+    );
+  }
+});


### PR DESCRIPTION
## What this adds

Four jest conformance guards that catch what the existing 8 don't:

| Guard | What it catches |
|---|---|
| `α.1 orphan-modules` | `.js` files under `bot/shared/{services,handlers,storage,utils,config}` reachable from no entry point — i.e. dead code |
| `α.2 unresolved-requires` | Literal `require('./x')` where `./x` doesn't resolve. Optional (try-catch-wrapped) ones get an allowlist; required ones fail |
| `α.3 circular-deps` | Tarjan SCC over the require graph — any cycle > 1 node, allowlisted with file-by-file reason |
| `α.4 worker-boot` | Every web/worker entry forks as a child with minimum env; require chain must resolve without load-time error |

## How it works

The shared helper at `tests/setup/_audit-helpers/require-graph.js` (~280 LOC):
- Strips JS comments before regex (handles `// require(...)` and JSDoc `* require(...)`).
- Negative look-behind `(?<!["'])` skips `require()` literals inside JS strings (e.g. inside `expect().toContain('require(...)')` assertions).
- Memoises the graph across the 4 guards (single build per jest run).
- `path.resolve`/`path.join` dynamic-require detection with a bare-package skip (`path.join(node_modules, 'pdfkit')` doesn't false-fail).
- Iterative Tarjan SCC (no recursion limit on the 400-node graph).

## Current measurements (against this PR's branch)

| Metric | Value |
|---|---|
| Entries | 163 (web + 11 workers + scripts + 142 test files) |
| Reachable | 391 `.js` files |
| Orphans | 13 (1 kept opt-in, 12 pending deletion in PR β) |
| Unresolved required | 0 |
| Unresolved optional (OSS-strip) | 3 (allowlisted) |
| Cycles | 3 (all lazy-required, allowlisted) |
| Workers booting cleanly | 8/11 |
| Workers in KNOWN_BOOT_IO_FAIL allowlist | 3 (Wave-4 follow-up) |

## Allowlist file structure

Three JSON files document current state honestly:

- `tests/setup/orphan-modules.allowlist.json` — 13 entries, each with a per-file `reason`. Twelve are tagged **PENDING DELETION in Wave 3 PR β**; that's the explicit hand-off.
- `tests/setup/unresolved-requires.allowlist.json` — 3 OSS-strip patterns. Reasons cite the file's own JSDoc note ("not part of this OSS bundle, required lazily inside try/catch").
- `tests/setup/circular-deps.allowlist.json` — 3 lazy-required cycles. Each cycle named with the file paths + how the lazy require breaks the import-time cycle.

The guards also assert that allowlist entries are still **actually** orphaned / unresolved / cyclic — a stale allowlist entry fails the build, forcing cleanup.

## The α.4 implementation note

The Wave-3 readiness pack's v2 sketch used in-process `require()` for α.4. That doesn't work — **no worker in OSS gates on `require.main === module`**, so requiring a worker file starts it (and never returns in Jest). v3 uses **forked-process testing**: `child_process.spawn('node', [entry])` with a 2-second timeout per worker.

Pass criteria:
- Child still alive at timeout (require chain resolved + main loop kicked in) → PASS, kill
- Child exited code 0 in < 2s → PASS (clean require + early exit)
- Child exited code ≠ 0 + load-time error in stderr → FAIL

3 workers (`coaching-processor`, `sqs-worker`, `stale-session`) do boot-time Supabase I/O. Under real prod they're harmless; under DNS flap they crash-loop. Allowlisted as `KNOWN_BOOT_IO_FAIL` with a Wave-4 architectural cleanup tracked separately.

## CI-condition handling

The worker-boot test detects `bot/node_modules` presence. CI runs root tests BEFORE `cd bot && npm ci`, so on first-pass the test SKIPS with a clear message ("run after cd bot && npm ci"). After bot deps are installed, it runs the full 11-entry check.

## Test status

- **108 suites / 1263 tests green** (was 104 / 1241 → +4 suites, +22 tests)
- **CI-condition smoke** (`mv bot/node_modules /tmp/_nm && node tests/run.js`): green; worker-boot skips gracefully
- **Source-hygiene + leak-grep:** clean
- **Wall-clock**: ~15s total (worker-boot dominates; the static guards are <1s each)

## Why ship α before β

PR β's scope (delete 12 confirmed orphans + add hero-fail PDFKit fallback + remove `wkhtmltopdf-selfcontained` + write Wave-4 bead) is **driven by the findings from α's allowlists**. As β deletes each orphan, it removes the corresponding allowlist entry. The guards keep the count honest.

This is also the implementation pattern for Wave 4+ — every cleanup PR will be one allowlist entry removal at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)