### PR TITLE
feat(coaching): flip live consumers to v12 reflective chain (Wave 3 PR δ)

### DIFF
--- a/bot/shared/services/coaching.service.js
+++ b/bot/shared/services/coaching.service.js
@@ -585,14 +585,42 @@ class CoachingService {
         throw new Error('Coaching session not found');
       }
 
-      // Generate reflective question using GPT-4o with full transcript
-      const conversationHistory = session.conversation_state.questions || [];
-      const question = await GPT5MiniService.generateReflectiveQuestion(
-        session.analysis_data,
-        conversationHistory,
-        questionNumber,
-        session.transcript_text  // Pass full transcript for specific evidence
-      );
+      // Generate reflective question via the v12 chain (corpus + per-turn
+      // adaptive Q1/Q2/Q3). The corpus was extracted at session-completion
+      // and persisted into analysis_data.reflective_corpus. If the
+      // corpus is missing (a session that pre-dates the v12 flow), fall back
+      // to a pre-canned safe question per language so the teacher still
+      // receives a prompt instead of an outage.
+      const corpus = session.analysis_data && session.analysis_data.reflective_corpus;
+      const teacherFirstName = (session.analysis_data && session.analysis_data.teacherFirstName) || '';
+      const questionLanguage = (session.analysis_data && session.analysis_data.language) || 'en';
+
+      let question;
+      if (corpus) {
+        const priorTurns = session.conversation_state.questions || [];
+        const conversationHistory = priorTurns
+          .filter((q) => q.answer)
+          .flatMap((q) => [
+            { role: 'assistant', content: q.question || '' },
+            { role: 'user', content: q.answer },
+          ]);
+        question = await GPT5MiniService._generateReflectiveQuestionV12(
+          corpus,
+          conversationHistory,
+          questionNumber,
+          questionLanguage,
+          teacherFirstName,
+        );
+      } else {
+        const { buildSafeFallback } = require('./coaching/reflective-questions/guardrails');
+        const { resolveProfile } = require('./coaching/reflective-questions/language-profiles');
+        question = buildSafeFallback(questionNumber, {}, resolveProfile(questionLanguage));
+        logToFile('[refl-q] no corpus → safe fallback', {
+          coachingSessionId,
+          questionNumber,
+          language: questionLanguage,
+        });
+      }
 
       logToFile('Reflective question generated', {
         coachingSessionId,

--- a/bot/shared/services/coaching/reflective-conversation.service.js
+++ b/bot/shared/services/coaching/reflective-conversation.service.js
@@ -57,15 +57,45 @@ class ReflectiveConversationService {
                          await getUserLanguage(session.user_id);
       }
 
-      // Generate reflective question using GPT-4o with full transcript
-      const conversationHistory = session.conversation_state.questions || [];
-      const question = await GPT5MiniService.generateReflectiveQuestion(
-        session.analysis_data,
-        conversationHistory,
-        questionNumber,
-        session.transcript_text,  // Pass full transcript for specific evidence
-        questionLanguage  // Pass language for generation
-      );
+      // Generate reflective question via the v12 chain (corpus + per-turn
+      // adaptive Q1/Q2/Q3). The corpus was extracted concurrently with the
+      // pedagogy analysis at session-completion and persisted into
+      // analysis_data.reflective_corpus. If for any reason the corpus is
+      // missing (a session that pre-dates the v12 flow or one where the
+      // concurrent corpus extraction failed), fall back to a pre-canned safe
+      // question per language so the teacher still receives a prompt instead
+      // of an outage.
+      const corpus = session.analysis_data && session.analysis_data.reflective_corpus;
+      const teacherFirstName = (session.analysis_data && session.analysis_data.teacherFirstName) || '';
+
+      let question;
+      if (corpus) {
+        // Build chain history from the prior Q/A turns. v12 expects an
+        // OpenAI-style messages-like array of alternating assistant/user turns.
+        const priorTurns = session.conversation_state.questions || [];
+        const conversationHistory = priorTurns
+          .filter((q) => q.answer)
+          .flatMap((q) => [
+            { role: 'assistant', content: q.question || '' },
+            { role: 'user', content: q.answer },
+          ]);
+        question = await GPT5MiniService._generateReflectiveQuestionV12(
+          corpus,
+          conversationHistory,
+          questionNumber,
+          questionLanguage,
+          teacherFirstName,
+        );
+      } else {
+        const { buildSafeFallback } = require('./reflective-questions/guardrails');
+        const { resolveProfile } = require('./reflective-questions/language-profiles');
+        question = buildSafeFallback(questionNumber, {}, resolveProfile(questionLanguage));
+        logToFile('[refl-q] no corpus → safe fallback', {
+          coachingSessionId,
+          questionNumber,
+          language: questionLanguage,
+        });
+      }
 
       logToFile('Reflective question generated', {
         coachingSessionId,

--- a/bot/shared/services/gpt5-mini.service.js
+++ b/bot/shared/services/gpt5-mini.service.js
@@ -1303,7 +1303,14 @@ GUIDELINES:
   }
 
   /**
-   * Generate context-aware reflective question
+   * @deprecated Use `_generateReflectiveQuestionV12` instead. The live coaching
+   * flow (both `coaching.service.js` and `reflective-conversation.service.js`)
+   * was flipped to the v12 chain in Wave 3 PR δ. This legacy single-shot
+   * generator is kept ONLY so the existing `coaching-debrief-config.test.js`
+   * suite stays green; no live code path calls it. Will be removed in a
+   * follow-up PR once the v12 path has soaked in production.
+   *
+   * Generate context-aware reflective question (legacy one-shot path).
    * @param {object} analysis - Pedagogical analysis object
    * @param {array} conversationHistory - Previous Q&A in this session
    * @param {number} questionNumber - Which question (1-3)

--- a/tests/coaching/reflective-conversation-v12-wiring.test.js
+++ b/tests/coaching/reflective-conversation-v12-wiring.test.js
@@ -1,0 +1,63 @@
+/**
+ * Reflective-conversation v12 wiring (Wave 3 PR δ).
+ *
+ * Locks: the live reflective-conversation flow (both `coaching.service.js` and
+ * the standalone `reflective-conversation.service.js`) now reads
+ * `analysis_data.reflective_corpus` (from bd-1842) and calls
+ * `_generateReflectiveQuestionV12` with the corpus + adapted chain history,
+ * NOT the legacy single-shot `generateReflectiveQuestion`.
+ *
+ * Falls back to `buildSafeFallback` when corpus is absent.
+ */
+
+jest.mock('jsonrepair', () => ({ jsonrepair: (s) => s }), { virtual: true });
+jest.mock('dotenv', () => ({ config: () => ({}) }), { virtual: true });
+jest.mock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+
+const mockV12 = jest.fn().mockResolvedValue('A clean v12 question.');
+const mockLegacy = jest.fn();
+jest.mock('../../bot/shared/services/gpt5-mini.service', () => ({
+  _generateReflectiveQuestionV12: (...args) => mockV12(...args),
+  generateReflectiveQuestion: (...args) => mockLegacy(...args),
+}));
+
+describe('Reflective-conversation v12 wiring — source-level guard', () => {
+  // We use a source-level grep on the two consumers because the live flow
+  // depends on supabase, elevenlabs, whatsapp, audio-cache — too many real
+  // deps to unit-test end-to-end. The source-level guard locks the call site
+  // shape and the corpus-absent fallback branch.
+  const fs = require('fs');
+  const path = require('path');
+  const ROOT = path.resolve(__dirname, '../..');
+
+  const CONSUMER_FILES = [
+    'bot/shared/services/coaching/reflective-conversation.service.js',
+    'bot/shared/services/coaching.service.js',
+  ];
+
+  for (const file of CONSUMER_FILES) {
+    describe(file, () => {
+      const src = fs.readFileSync(path.join(ROOT, file), 'utf8');
+
+      it('calls GPT5MiniService._generateReflectiveQuestionV12', () => {
+        expect(src).toMatch(/GPT5MiniService\._generateReflectiveQuestionV12\(/);
+      });
+
+      it('reads corpus from analysis_data.reflective_corpus', () => {
+        expect(src).toMatch(/analysis_data\.reflective_corpus|analysis_data && session\.analysis_data\.reflective_corpus/);
+      });
+
+      it('falls back to buildSafeFallback when corpus is missing', () => {
+        expect(src).toMatch(/require\(['"][^'"]*reflective-questions\/guardrails['"]\)/);
+        expect(src).toMatch(/buildSafeFallback/);
+      });
+
+      it('does NOT call the legacy generateReflectiveQuestion', () => {
+        // The deprecated method exists on GPT5MiniService but no consumer
+        // should call it any more.
+        expect(src).not.toMatch(/GPT5MiniService\.generateReflectiveQuestion\(/);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## What this activates

The v12 reflective chain (corpus + per-turn adaptive Q1/Q2/Q3 + guardrails) landed in PR #40 with corpus extraction running concurrent with pedagogy analysis at session-completion. But **the live coaching flow's question generator was NOT flipped at that time** — every teacher was still receiving questions from the legacy S.T.I.C.K.S. one-shot path. This PR completes the rollout.

## Pre-flight finding — TWO consumers, not one

The readiness pack named one consumer (`reflective-conversation.service.js`). A pre-flight grep found **two**:

| File | Path | Reached via |
|---|---|---|
| `bot/shared/services/coaching/reflective-conversation.service.js:62` | The message-loop path | `analysis-processor → reflective-conversation` |
| `bot/shared/services/coaching.service.js:590` | The legacy text-handler path | `text-message.handler → CoachingService.handleReflectiveResponse → conductReflectiveConversation` |

Both have live callers in the WhatsApp bot entry points (verified via `grep -rn CoachingService`). Flipping **both** keeps behaviour consistent regardless of which entry the teacher hits.

## The flip — applied to both consumers

```js
// Before
const conversationHistory = session.conversation_state.questions || [];
const question = await GPT5MiniService.generateReflectiveQuestion(
  session.analysis_data, conversationHistory, questionNumber, transcript, language
);

// After
const corpus = session.analysis_data && session.analysis_data.reflective_corpus;
let question;
if (corpus) {
  const priorTurns = session.conversation_state.questions || [];
  const conversationHistory = priorTurns
    .filter((q) => q.answer)
    .flatMap((q) => [
      { role: 'assistant', content: q.question || '' },
      { role: 'user', content: q.answer },
    ]);
  question = await GPT5MiniService._generateReflectiveQuestionV12(
    corpus, conversationHistory, questionNumber, questionLanguage, teacherFirstName,
  );
} else {
  // No corpus → safe pre-canned fallback (per-language).
  const { buildSafeFallback } = require('./reflective-questions/guardrails');
  const { resolveProfile } = require('./reflective-questions/language-profiles');
  question = buildSafeFallback(questionNumber, {}, resolveProfile(questionLanguage));
}
```

## Why `buildSafeFallback` matters

For coaching sessions that pre-date the v12 flow OR sessions where the concurrent corpus extraction failed, `analysis_data.reflective_corpus` is absent. Without the fallback, those teachers would see an unhandled exception → no question delivered. With the fallback, they get a safe pre-canned per-language question (one of three by question-number; ur/sw/en/ar covered) and the conversation continues.

## Legacy method — kept with `@deprecated` JSDoc

`GPT5MiniService.generateReflectiveQuestion` stays in place with a deprecation note. No live caller; kept only so the existing `coaching-debrief-config.test.js` suite stays green. Will be removed in a follow-up PR after operator observes the v12 path is stable in production.

## Test

New: `tests/coaching/reflective-conversation-v12-wiring.test.js` — source-level guard.

For each of the 2 consumers, asserts:
- calls `GPT5MiniService._generateReflectiveQuestionV12`
- reads corpus from `analysis_data.reflective_corpus`
- falls back to `buildSafeFallback` when corpus is missing
- does NOT call the legacy `generateReflectiveQuestion`

**Why source-level, not unit:** the consumer's live deps (supabase + elevenlabs + whatsapp + audio-cache) are too many to unit-test end-to-end; the guard locks the call-site shape + the corpus-absent fallback branch. A regression (someone re-introducing `generateReflectiveQuestion` or removing the corpus read) is caught immediately.

## Test status

- **110 suites / 1276 tests green** (was 109 / 1268 → +1 suite, +8 tests)
- **CI-condition smoke** (`mv bot/node_modules`): green
- **All 4 audit guards still green**
- **Source-hygiene + leak-grep:** clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)