### PR TITLE
docs: customization seam-map + coaching walkthrough alignment (Wave 3 PR ζ)

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -37,25 +37,82 @@ might want to change, it tells you **where** the seam is, **what kind** of chang
 - **Conformance test:** `tests/coaching/analyze-pedagogy-framework-dispatch.test.js`,
   `tests/coaching/framework-wiring.test.js`
 
-### The coaching report design (layout / visual / PDF vs HTML)
+### The coaching report design (layout / visual)
 - **Type:** `module` + `template`
 - **Seam:** a renderer registry —
   [`bot/shared/services/coaching/report-renderers/renderer-registry.js`](../bot/shared/services/coaching/report-renderers/renderer-registry.js).
-  `getReportRenderer(framework)` picks the renderer; OECD/HOTS/TEACH/FICO use the PDFKit renderer in
-  [`bot/shared/services/pdf-report.service.js`](../bot/shared/services/pdf-report.service.js), MEWAKA uses the
-  HTML template in [`bot/shared/services/coaching/templates/mewaka-report.template.js`](../bot/shared/services/coaching/templates/mewaka-report.template.js).
-  Add a framework's report design by registering one renderer — no `if (framework === …)` to edit.
-- **Conformance test:** `tests/coaching/report-renderer-registry.test.js`
+  `getReportRenderer(framework)` picks the renderer; **all five frameworks** (OECD/HOTS/TEACH/FICO/MEWAKA)
+  use the unified celebration ("hero") renderer that produces an inline PNG + caption. The legacy
+  PDFKit renderer in [`bot/shared/services/pdf-report.service.js`](../bot/shared/services/pdf-report.service.js)
+  is kept as the fallback for unknown frameworks and as the safety net the hero renderer falls back to
+  if its pipeline throws. Add a framework's report design by registering one renderer + adding a score
+  adapter — no `if (framework === …)` to edit.
+- **Conformance test:** `tests/coaching/report-renderer-registry.test.js`, `tests/coaching/hero-render-fallback.test.js`
 
-### The reflective debrief conversation + the coaching card
-- **Type:** `config`
-- **Seam:** the coaching model (questions, persona, rules, how many questions) lives in
-  [`bot/shared/config/coaching-debrief.config.js`](../bot/shared/config/coaching-debrief.config.js);
-  the card copy/buttons (per language) live in
-  [`bot/shared/config/coaching-card.config.js`](../bot/shared/config/coaching-card.config.js).
-  The "what to coach toward" policy is the pluggable `selectFocusIndicator` in
-  [`bot/shared/services/coaching/coaching-card/prioritized-action.service.js`](../bot/shared/services/coaching/coaching-card/prioritized-action.service.js).
-- **Conformance test:** `tests/coaching/coaching-debrief-config.test.js`
+### The hero report visual (colors, layout, fonts)
+- **Type:** `template`
+- **Seam:** [`bot/shared/services/coaching/report-v2/hero-report.template.js`](../bot/shared/services/coaching/report-v2/hero-report.template.js)
+  — the Playwright HTML template that renders to PNG. Variable-height single-page A4 design;
+  language-aware fonts (Lexend for LTR, Nastaliq for Urdu, Naskh for Arabic). Fonts + Rumi mark
+  are base64-embedded so the renderer is offline-safe.
+- **Conformance test:** rendered via `tests/coaching/hero-render-fallback.test.js`
+
+### Adding a new framework's score adapter for the hero report
+- **Type:** `module`
+- **Seam:** [`bot/shared/services/coaching/report-v2/score-adapters/`](../bot/shared/services/coaching/report-v2/score-adapters/)
+  + [`dispatch.js`](../bot/shared/services/coaching/report-v2/score-adapters/dispatch.js).
+  Each per-framework adapter turns `analysis_data` into `{ key, name, score, max, pct }[]` rows
+  for the hero template's scorecard. Add a new adapter file then register it in `dispatch.js`.
+- **Conformance test:** `tests/coaching/score-adapters.test.js`
+
+### The celebration narrative LLM prompt (per-language)
+- **Type:** `template` (prompt)
+- **Seam:** [`bot/shared/services/coaching/report-v2/narrative.service.js`](../bot/shared/services/coaching/report-v2/narrative.service.js)
+  — the `langRules()` function (per-language gender + code-switch rules) + `buildPrompt()` (the
+  celebration prompt body that feeds the hero report's narrative section). Reads from
+  `analysis.reflective_corpus` (lesson throughline + significant moments) when available.
+- **Conformance test:** `tests/coaching/hero-narrative-corpus.test.js`
+
+### The reflective debrief conversation
+- **Type:** `module` + `config`
+- **Seam:** five files under
+  [`bot/shared/services/coaching/reflective-questions/`](../bot/shared/services/coaching/reflective-questions/)
+  drive the v12 reflective chain (corpus + per-turn adaptive Q1/Q2/Q3):
+  [`corpus-prompt.js`](../bot/shared/services/coaching/reflective-questions/corpus-prompt.js) — the
+  one-shot corpus extraction prompt;
+  [`question-prompt.js`](../bot/shared/services/coaching/reflective-questions/question-prompt.js) —
+  per-question system prompts with Q1/Q2/Q3 beats;
+  [`guardrails.js`](../bot/shared/services/coaching/reflective-questions/guardrails.js) —
+  validation + per-language safe fallbacks;
+  [`language-profiles.js`](../bot/shared/services/coaching/reflective-questions/language-profiles.js) —
+  per-language data (script, region, gender rules);
+  [`llm-router.service.js`](../bot/shared/services/coaching/reflective-questions/llm-router.service.js) —
+  DeepSeek V3.2 → GPT-5.4 failover.
+  Number of questions is configurable in
+  [`bot/shared/config/coaching-debrief.config.js`](../bot/shared/config/coaching-debrief.config.js).
+- **Conformance test:** `tests/coaching/reflective-corpus-extraction.test.js`,
+  `tests/coaching/reflective-v12-question-chain.test.js`,
+  `tests/coaching/reflective-conversation-v12-wiring.test.js`
+
+### The commitment card content (Q3 → action prompt + per-language rules)
+- **Type:** `template` (prompt) + `config`
+- **Seam:** [`bot/shared/services/coaching/coaching-card/commitment-card.service.js`](../bot/shared/services/coaching/coaching-card/commitment-card.service.js)
+  — the `buildPrompt()` LLM prompt that turns the teacher's Q3 forward-commitment + the highest-leverage
+  growth area into a single lesson-rooted action. `GENDER_RULE` and `CODESWITCH_RULE` (per-language
+  Urdu/Kiswahili/Arabic/English) live in the same file as named exports; safe to edit
+  in-place. Falls back to the rule-based focus tip in
+  [`prioritized-action.service.js`](../bot/shared/services/coaching/coaching-card/prioritized-action.service.js)
+  when Q3 is missing or the LLM fails.
+- **Conformance test:** `tests/coaching/commitment-card-content.test.js`,
+  `tests/coaching/commitment-card-fallback.test.js`
+
+### The commitment card visual (band colors, RTL/LTR fonts, highlight style)
+- **Type:** `template`
+- **Seam:** [`bot/shared/services/coaching/coaching-card/card-template.js`](../bot/shared/services/coaching/coaching-card/card-template.js)
+  — the Playwright HTML template + `LABELS` (per-language eyebrow / try-label / footer strings)
+  + the colour-only RTL highlight rule. Rumi marks + fonts are base64-embedded so the renderer
+  is offline-safe.
+- **Conformance test:** `tests/coaching/render-commitment-card-image.test.js`
 
 ---
 

--- a/docs/features/coaching.md
+++ b/docs/features/coaching.md
@@ -54,7 +54,7 @@ A real, anonymized Tanzanian session in Kiswahili (teacher renamed **Asha**, stu
 
 ![Commitment card — Asha's own Q3 commitment + one specific action for next class](../images/walkthroughs/5_commitment_card.png)
 
-These five panels are the live shipped Tanzanian (MEWAKA) experience, captured exactly as the bot sends them (verbatim Kiswahili from `coaching-strings.js`, Q1/Q2/Q3 from a real anonymised session). Follow-up PRs make the hero + the post-observation commitment card the **default for every framework**, not just MEWAKA — so OECD/HOTS/TEACH/FICO adopters get the same celebration design rendered against their framework's own scorecard.
+These five panels are the live shipped Tanzanian (MEWAKA) experience, captured exactly as the bot sends them (verbatim Kiswahili from `coaching-strings.js`, Q1/Q2/Q3 from a real anonymised session). The hero report + the post-observation commitment card are the **default for every framework** — OECD/HOTS/TEACH/FICO and MEWAKA — so each adopter's teachers get the same celebration design rendered against their framework's own scorecard. The renderer-registry dispatches all five to the same hero renderer; the score adapter under [`bot/shared/services/coaching/report-v2/score-adapters/`](../../bot/shared/services/coaching/report-v2/score-adapters/) handles the per-framework score shape.
 
 ## Enable it
 


### PR DESCRIPTION
## What this closes

The doc gaps Wave 2's PRs #41 (hero report) and #42 (commitment card) left. Two files updated, no code change, no test change.

## docs/customization.md

Rewrote the **coaching report design** section to reflect Wave 2's shipped state (all 5 frameworks default to the hero renderer; PDFKit is fallback). **Added 6 new seam-map entries** so adopters can find every customization point:

| Seam | File |
|---|---|
| Hero report visual (colors, layout, fonts) | `report-v2/hero-report.template.js` |
| Adding a new framework's score adapter | `report-v2/score-adapters/` + `dispatch.js` |
| Celebration narrative LLM prompt (per-language) | `report-v2/narrative.service.js` |
| Reflective debrief conversation (v12 chain) | 5 files under `reflective-questions/` |
| Commitment card content (Q3 prompt + per-lang rules) | `coaching-card/commitment-card.service.js` |
| Commitment card visual (band, RTL/LTR fonts) | `coaching-card/card-template.js` |

Each entry follows the canonical `Type · Seam · Conformance test` shape used elsewhere in the doc.

## docs/features/coaching.md — Panel 5 verification

Cross-checked Panel 5 (commitment card) prose against the bd-1844 shipped implementation:

| Description claim | Implementation | Status |
|---|---|---|
| "Asha's own Q3 forward-commitment verbatim at the top" | `commitment-card.service.extractQ3` + `<h1>` in `card-template.js` | ✅ |
| "One specific lesson-rooted action for next class at the bottom" | The `action` field in the LLM prompt; rendered in `.action-box` | ✅ |
| "Key phrases highlighted" | `highlightText()` wraps highlights in `<span class="hi">` | ✅ |
| "Arrives last" | Phase 3 block in report-generator runs AFTER report PNG + voice debrief | ✅ |

**No prose drift detected.** No edits to Panel 5 itself.

Updated the post-5-panels paragraph: removed the stale "Follow-up PRs make this the default for every framework" framing now that PR γ shipped MEWAKA's flip onto the hero renderer. The five panels show the MEWAKA experience; the post-panels paragraph now states that the same hero + commitment card is the live default for all 5 frameworks.

## Test status

- **110 suites / 1276 tests green** (no test change)
- `customization-doc-accuracy` guard verifies every cited path resolves — green
- `source-hygiene` + `link-integrity` + leak-grep all clean
- CI-condition smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)