### PR TITLE
feat(workers): require.main gates on 4 entry points + locking test

### DIFF
--- a/bot/whatsapp-bot.js
+++ b/bot/whatsapp-bot.js
@@ -1645,9 +1645,12 @@ Si no solicitaste esto, ignora este mensaje.`
 });
 
 /**
- * Start server
+ * Start server. Gated behind `require.main === module` so requiring this
+ * file as a library (e.g. from a test harness or a downstream that wants the
+ * Express `app` without its listener) does NOT bind to a port.
  */
-app.listen(constants.PORT, () => {
+function startServer() {
+  return app.listen(constants.PORT, () => {
   // Read version from VERSION file
   const path = require('path');
   const versionFile = path.join(__dirname, 'VERSION');
@@ -1717,4 +1720,11 @@ ${'='.repeat(70)}
       // version-check is optional — skip silently if not present
     }
   }, 10000);
-});
+  });
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { app, startServer };

--- a/bot/workers/coaching-processor.js
+++ b/bot/workers/coaching-processor.js
@@ -450,32 +450,38 @@ app.get('/ready', (req, res) => {
   });
 });
 
-app.listen(HEALTH_PORT, () => {
-  logToFile(`Health check endpoint listening on port ${HEALTH_PORT}`, {
-    workerId: WORKER_ID
-  });
-});
-
 // ============================================================================
-// START WORKER
+// START WORKER (gated — requiring this file as a library does NOT start it)
 // ============================================================================
 
-logToFile('🚀 Starting Classroom Coaching Worker', {
-  workerId: WORKER_ID,
-  nodeVersion: process.version,
-  platform: process.platform,
-  concurrency: CONCURRENCY_PER_WORKER,
-  pollInterval: POLL_INTERVAL_MS,
-  environment: process.env.NODE_ENV || 'development'
-});
-
-worker.start().catch((error) => {
-  logToFile('❌ Fatal error in worker', {
-    error: error.message,
-    stack: error.stack
+function startWorker() {
+  app.listen(HEALTH_PORT, () => {
+    logToFile(`Health check endpoint listening on port ${HEALTH_PORT}`, {
+      workerId: WORKER_ID,
+    });
   });
-  process.exit(1);
-});
+
+  logToFile('🚀 Starting Classroom Coaching Worker', {
+    workerId: WORKER_ID,
+    nodeVersion: process.version,
+    platform: process.platform,
+    concurrency: CONCURRENCY_PER_WORKER,
+    pollInterval: POLL_INTERVAL_MS,
+    environment: process.env.NODE_ENV || 'development',
+  });
+
+  return worker.start().catch((error) => {
+    logToFile('❌ Fatal error in worker', {
+      error: error.message,
+      stack: error.stack,
+    });
+    process.exit(1);
+  });
+}
+
+if (require.main === module) {
+  startWorker();
+}
 
 // Export for testing
-module.exports = { CoachingWorker, WORKER_ID };
+module.exports = { CoachingWorker, WORKER_ID, startWorker };

--- a/bot/workers/sqs-worker.js
+++ b/bot/workers/sqs-worker.js
@@ -636,11 +636,13 @@ app.get('/ready', (req, res) => {
   });
 });
 
-app.listen(HEALTH_PORT, () => {
-  logToFile(`Health check endpoint listening on port ${HEALTH_PORT}`, {
-    workerId: WORKER_ID
+function startHealthEndpoint() {
+  return app.listen(HEALTH_PORT, () => {
+    logToFile(`Health check endpoint listening on port ${HEALTH_PORT}`, {
+      workerId: WORKER_ID,
+    });
   });
-});
+}
 
 // ============================================================================
 // LESSON PLAN RECOVERY
@@ -874,38 +876,44 @@ logToFile('🚀 Starting SQS Coaching Worker', {
   sqsQueueUrl: process.env.SQS_QUEUE_URL
 });
 
-// Recover stale requests before starting worker
-// Issue #38: Added video request recovery alongside lesson plan recovery
-// Added exam grading recovery
-Promise.all([
-  recoverStaleLessonPlanRequests(),
-  recoverStaleVideoRequests(),
-  ExamGradingWorker.recoverStaleExamSessions()
-]).then(() => {
-  worker.start().catch((error) => {
-    logToFile('❌ Fatal error in worker', {
-      error: error.message,
-      stack: error.stack
+// Recover stale requests before starting worker. Gated behind
+// require.main === module so the file can be required as a library without
+// firing the recovery sweep + worker start.
+function startWorker() {
+  startHealthEndpoint();
+  return Promise.all([
+    recoverStaleLessonPlanRequests(),
+    recoverStaleVideoRequests(),
+    ExamGradingWorker.recoverStaleExamSessions(),
+  ]).then(() => {
+    worker.start().catch((error) => {
+      logToFile('❌ Fatal error in worker', {
+        error: error.message,
+        stack: error.stack,
+      });
+      process.exit(1);
     });
-    process.exit(1);
+
+    // Periodic stale job recovery - runs every 5 minutes
+    const STALE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+    setInterval(async () => {
+      if (worker.isShuttingDown) return;
+      try {
+        await recoverStaleLessonPlanRequests();
+        await recoverStaleVideoRequests();
+        await ExamGradingWorker.recoverStaleExamSessions();
+      } catch (error) {
+        logToFile('Error in periodic stale check', { error: error.message });
+      }
+    }, STALE_CHECK_INTERVAL_MS);
+
+    logToFile('Periodic stale job recovery enabled (every 5 minutes)');
   });
+}
 
-  // Periodic stale job recovery - runs every 5 minutes
-  // Catches jobs that got stuck after deployment (not caught by startup check)
-  const STALE_CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
-  setInterval(async () => {
-    if (worker.isShuttingDown) return;
-    try {
-      await recoverStaleLessonPlanRequests();
-      await recoverStaleVideoRequests();
-      await ExamGradingWorker.recoverStaleExamSessions();
-    } catch (error) {
-      logToFile('Error in periodic stale check', { error: error.message });
-    }
-  }, STALE_CHECK_INTERVAL_MS);
-
-  logToFile('Periodic stale job recovery enabled (every 5 minutes)');
-});
+if (require.main === module) {
+  startWorker();
+}
 
 // Export for testing
-module.exports = { SQSCoachingWorker, WORKER_ID };
+module.exports = { SQSCoachingWorker, WORKER_ID, startWorker };

--- a/bot/workers/stale-session.worker.js
+++ b/bot/workers/stale-session.worker.js
@@ -382,5 +382,11 @@ async function autoCompleteSession(session) {
   }
 }
 
-// Run the worker
-main();
+// Gated — requiring this file as a library (e.g. from a test harness) does
+// NOT fire the stale-session sweep. To run the sweep manually, invoke the
+// exported `main` function.
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };

--- a/tests/setup/entry-require-main-gates.test.js
+++ b/tests/setup/entry-require-main-gates.test.js
@@ -1,0 +1,60 @@
+/**
+ * Entry-point require.main gates.
+ *
+ * Locks the architectural fix: every entry that has a top-level start call
+ * (Express listen, worker.start, main()) gates it behind
+ * `if (require.main === module) { … }` so the file can be required as a
+ * library without side effects.
+ *
+ * The audit's α.4 worker-boot test (forked) catches gross failures; this
+ * source-level test catches a regression where someone re-introduces an
+ * un-gated top-level start call.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+// The entries that had explicit top-level start calls before entry-gating.
+// Adding the gate is a non-functional change at run-time (the executable
+// `node X.js` behaviour is identical) but makes the file safe to require.
+const GATED_ENTRIES = [
+  'bot/whatsapp-bot.js',
+  'bot/workers/coaching-processor.js',
+  'bot/workers/sqs-worker.js',
+  'bot/workers/stale-session.worker.js',
+];
+
+// The regex catches both:
+//   if (require.main === module) { startServer(); }
+//   if (require.main === module) { startServer(); }
+// but does NOT match comments mentioning `require.main`. Strict — must be
+// at column 0 or after whitespace.
+const GATE_RE = /^[ \t]*if\s*\(\s*require\.main\s*===\s*module\s*\)/m;
+
+describe('Entry-point require.main gates (entry-gating)', () => {
+  for (const entry of GATED_ENTRIES) {
+    it(`${entry} gates its top-level start behind require.main === module`, () => {
+      const src = fs.readFileSync(path.join(ROOT, entry), 'utf8');
+      expect(GATE_RE.test(src)).toBe(true);
+    });
+  }
+
+  // Companion: the gated entries SHOULD also export their start function so
+  // a test / downstream can invoke it explicitly when desired.
+  it('every gated entry exports the start function', () => {
+    const exportsByFile = {
+      'bot/whatsapp-bot.js':           /module\.exports\s*=\s*\{[^}]*startServer/,
+      'bot/workers/coaching-processor.js': /module\.exports\s*=\s*\{[^}]*startWorker/,
+      'bot/workers/sqs-worker.js':     /module\.exports\s*=\s*\{[^}]*startWorker/,
+      'bot/workers/stale-session.worker.js': /module\.exports\s*=\s*\{[^}]*main/,
+    };
+    const failures = [];
+    for (const [entry, re] of Object.entries(exportsByFile)) {
+      const src = fs.readFileSync(path.join(ROOT, entry), 'utf8');
+      if (!re.test(src)) failures.push(entry);
+    }
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this fixes

Wave 3 PR α found that **none of the 11 entry points** (1 web server + 10 workers) gated their top-level start calls behind `require.main === module`. Requiring any of them STARTED the service, which meant:
- The audit's α.4 worker-boot test had to use forked-process testing (15s wall-clock)
- Tests can't safely require workers for their exported helpers
- Downstream code can't reuse worker logic without firing the loop

This PR adds the canonical gate to the 4 entries that actually had top-level start calls.

## Files gated (4)

| File | Before | After |
|---|---|---|
| `bot/whatsapp-bot.js` | `app.listen(...)` at module bottom | Wrapped in `startServer()`, gated; exports `{ app, startServer }` |
| `bot/workers/coaching-processor.js` | `app.listen()` + `worker.start()` at bottom | Wrapped in `startWorker()`, gated; exports `{ CoachingWorker, WORKER_ID, startWorker }` |
| `bot/workers/sqs-worker.js` | Health listen + Promise.all(recover*).then(worker.start) + setInterval at bottom | All wrapped in `startWorker()`, gated; exports `{ SQSCoachingWorker, WORKER_ID, startWorker }` |
| `bot/workers/stale-session.worker.js` | `main()` at bottom | Gated; exports `{ main }` |

## Files NOT changed (7)

The other 7 workers (exam-grading, homework-bundle, lesson-plan-extraction, lesson-plan-generation, pic-lp-kieai, quiz-job-handler, video-generation) are already export-only at module bottom — no top-level start call to gate. They're invoked by other workers (e.g. sqs-worker dispatches to them).

## Runtime behaviour: IDENTICAL

When invoked via `node X.js` the behaviour is **byte-identical** to before. The gate only affects the `require()` path — there it makes the file safe to import without firing the start.

## New test

`tests/setup/entry-require-main-gates.test.js` — 5 assertions:
- Each of the 4 gated entries contains the `if (require.main === module)` pattern
- Each exports the canonical start function

If a future PR re-introduces an un-gated top-level start, this test fails.

## Test status

- **111 suites / 1281 tests green** (was 110 / 1276 → +1 suite, +5 tests)
- **CI-condition smoke** (`mv bot/node_modules`): green
- **worker-boot test** still passes (forked-process testing unaffected by the gates)
- **Source-hygiene + leak-grep:** clean

## Why this comes before the boot-I/O fixes

Adding the gates is a no-blast-radius foundation. The next 3 PRs (boot-I/O fixes for `coaching-processor`, `sqs-worker`, `stale-session`) move the actual I/O calls out of module load + main()'s synchronous startup, which removes those workers from the worker-boot test's allowlist. Each subsequent PR removes one allowlist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)