### PR TITLE
fix(elevenlabs): lazy OpenAI client init — bot boots clean without OPENAI_API_KEY

### DIFF
--- a/bot/shared/services/elevenlabs.service.js
+++ b/bot/shared/services/elevenlabs.service.js
@@ -19,8 +19,26 @@ const { logToFile } = require('../utils/logger');
  * Includes OpenAI TTS fallback for all languages
  */
 class ElevenLabsService {
-  // Initialize OpenAI client as a static property for use in static methods
-  static openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+  // OpenAI client is lazy-initialized. Constructing it at module-load time
+  // threw `OpenAIError: Missing credentials` whenever OPENAI_API_KEY was
+  // unset, which crashed the bot at cold-boot even though OPENAI_API_KEY is
+  // documented as an optional key (used here only as a TTS fallback when
+  // ElevenLabs is unreachable). With lazy init, the bot boots cleanly without
+  // it; the only call site that needs the key (the OpenAI TTS fallback below)
+  // throws a clear error if invoked without a key set.
+  static _openai = null;
+  static get openai() {
+    if (!ElevenLabsService._openai) {
+      if (!OPENAI_API_KEY) {
+        throw new Error(
+          'OPENAI_API_KEY is required for the ElevenLabs OpenAI-TTS fallback. ' +
+          'Set OPENAI_API_KEY in .env or avoid calling the fallback path.'
+        );
+      }
+      ElevenLabsService._openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+    }
+    return ElevenLabsService._openai;
+  }
 
   /**
    * Generate speech from text using ElevenLabs (Jessica voice with emotion support)

--- a/tests/coaching/elevenlabs-lazy-openai.test.js
+++ b/tests/coaching/elevenlabs-lazy-openai.test.js
@@ -1,0 +1,84 @@
+/**
+ * ElevenLabs OpenAI-client lazy initialization regression.
+ *
+ * Locks the architectural fix: the OpenAI client used as the TTS fallback
+ * MUST NOT be constructed at module load time. Construction is deferred until
+ * the `ElevenLabsService.openai` getter is first accessed; that access throws
+ * a clear error if `OPENAI_API_KEY` is missing.
+ *
+ * Before this fix, `static openai = new OpenAI({ apiKey: OPENAI_API_KEY })`
+ * threw `OpenAIError: Missing credentials` at module load whenever
+ * `OPENAI_API_KEY` was unset — which crashed the bot at cold-boot despite
+ * `OPENAI_API_KEY` being documented as an optional feature key.
+ */
+
+// Virtual-mock the bot-only npm deps so this test runs in CI-condition
+// (root jest pass; bot/node_modules absent).
+jest.mock('axios', () => ({ post: jest.fn() }), { virtual: true });
+jest.mock('openai', () => {
+  return class MockOpenAI { constructor() {} };
+}, { virtual: true });
+
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/utils/constants', () => ({
+  ELEVENLABS_API_KEY: 'placeholder',
+  ELEVENLABS_VOICE_ID: 'placeholder',
+  ELEVENLABS_SPANISH_VOICE_ID: 'placeholder',
+  ELEVENLABS_ARABIC_VOICE_ID: 'placeholder',
+  VOICE_MODELS: {},
+  OPENAI_API_KEY: '', // SIMULATES the cold-boot scenario where the key is absent.
+}));
+
+describe('ElevenLabsService — lazy OpenAI client initialization', () => {
+  it('requiring the module does NOT construct an OpenAI client', () => {
+    // If construction were not lazy, require() itself would throw.
+    expect(() => {
+      jest.isolateModules(() => {
+        require('../../bot/shared/services/elevenlabs.service');
+      });
+    }).not.toThrow();
+  });
+
+  it('the source defines a getter (lazy), not an eager initializer', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../../bot/shared/services/elevenlabs.service.js'),
+      'utf8'
+    );
+    // Eager init pattern must not exist anywhere
+    expect(src).not.toMatch(/static\s+openai\s*=\s*new\s+OpenAI/);
+    // Lazy getter pattern must exist
+    expect(src).toMatch(/static\s+get\s+openai\s*\(\s*\)\s*\{/);
+  });
+
+  it('accessing .openai without OPENAI_API_KEY throws a CLEAR error', () => {
+    let ElevenLabsService;
+    jest.isolateModules(() => {
+      ElevenLabsService = require('../../bot/shared/services/elevenlabs.service');
+    });
+    expect(() => ElevenLabsService.openai).toThrow(/OPENAI_API_KEY is required/);
+  });
+});
+
+describe('ElevenLabsService — OPENAI_API_KEY present', () => {
+  it('constructs the client on first access AND caches it', () => {
+    jest.resetModules();
+    jest.doMock('axios', () => ({ post: jest.fn() }), { virtual: true });
+    jest.doMock('openai', () => class MockOpenAI { constructor() {} }, { virtual: true });
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/utils/constants', () => ({
+      ELEVENLABS_API_KEY: 'placeholder',
+      ELEVENLABS_VOICE_ID: 'placeholder',
+      ELEVENLABS_SPANISH_VOICE_ID: 'placeholder',
+      ELEVENLABS_ARABIC_VOICE_ID: 'placeholder',
+      VOICE_MODELS: {},
+      OPENAI_API_KEY: 'sk-test-placeholder',
+    }));
+    const ElevenLabsService = require('../../bot/shared/services/elevenlabs.service');
+    const a = ElevenLabsService.openai;
+    expect(a).toBeDefined();
+    // Cached — second access returns the same instance.
+    expect(ElevenLabsService.openai).toBe(a);
+  });
+});


### PR DESCRIPTION
## What this fixes

`ElevenLabsService` had a class-static initializer at module load:

```js
class ElevenLabsService {
  static openai = new OpenAI({ apiKey: OPENAI_API_KEY });  // throws if key absent
```

When `OPENAI_API_KEY` was unset, the OpenAI SDK threw `OpenAIError: Missing credentials` synchronously, which propagated through the require chain and crashed the bot during cold-boot. Wave 3's DoD checklist (PR #49) flagged this: boot succeeded only with `OPENAI_API_KEY` set, despite the presence-gating model documenting it as **optional**.

The OpenAI client is used here only as a TTS fallback when ElevenLabs is unreachable. **Deferring construction until first use** lets the bot boot cleanly without the key.

## Change

Single file: `bot/shared/services/elevenlabs.service.js`. Replaced the eager static field with a lazy getter:

```js
static _openai = null;
static get openai() {
  if (!ElevenLabsService._openai) {
    if (!OPENAI_API_KEY) {
      throw new Error('OPENAI_API_KEY is required for the ElevenLabs OpenAI-TTS fallback. …');
    }
    ElevenLabsService._openai = new OpenAI({ apiKey: OPENAI_API_KEY });
  }
  return ElevenLabsService._openai;
}
```

The only existing caller (`this.openai.audio.speech.create` at line 256) works transparently via the getter — no other code change needed.

## Cold-boot verification (manual)

With 8 required env vars set but **NO** `OPENAI_API_KEY`:
- Bot starts cleanly
- `GET /health` → 200
- 0 `OpenAIError` lines in stderr at boot

## Regression test

`tests/coaching/elevenlabs-lazy-openai.test.js` (4 tests):
- Requiring the module does NOT construct an OpenAI client (locks the lazy contract)
- Source defines a getter, not an eager initializer (catches re-introduction)
- Accessing `.openai` without `OPENAI_API_KEY` throws a CLEAR error (UX guarantee)
- Constructs + caches on first access (with key set)

CI-condition compatible: virtual-mocks `axios` + `openai` for the bot-deps-absent first pass.

## Test status

- **112 suites / 1285 tests green** (was 111 / 1281 → +1 suite, +4 tests)
- **CI-condition smoke** (`mv bot/node_modules`): green
- **Source-hygiene + leak-grep:** clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)