### PR TITLE
fix(constants): break framework↔constants cycle by removing 2 unused helpers

### DIFF
--- a/bot/shared/constants/scoring.constants.js
+++ b/bot/shared/constants/scoring.constants.js
@@ -1,9 +1,15 @@
 /**
  * Centralized scoring constants for classroom coaching reports.
- * Ensures every consumer (GPT analysis, reports, portals) uses the same totals.
  *
- * OECD constants are exported directly for backward compatibility.
- * Multi-framework helpers delegate to framework-registry for other frameworks.
+ * OECD constants exported directly for backward compat with the OECD
+ * framework module + the legacy PDFKit reporter. Other frameworks own their
+ * own constants (e.g. MEWAKA's MAX_MARKS = 75 lives inside mewaka-framework.js).
+ *
+ * Strictly a data module — no requires of framework-registry or any framework
+ * module. This file used to expose `getFrameworkMaxMarks` and
+ * `getFrameworkDisplayName` helpers that lazy-required the framework registry,
+ * creating a conceptual cycle (constants → registry → framework → constants).
+ * Both helpers had zero callers and were removed.
  */
 
 // ─── OECD-specific constants (backward compat) ───────────────────────
@@ -14,36 +20,10 @@ const CLASSROOM_MARKS_WITH_LP = CLASSROOM_MARKS_BASE + LP_CRITERIA_MARKS;
 const DEBRIEF_MARKS = 15;
 const PRIOR_FEEDBACK_MARKS = 5;
 
-// ─── Multi-framework helpers ─────────────────────────────────────────
-
-/**
- * Get max marks for any registered framework.
- * @param {string} frameworkKey - Framework key (oecd, hots, teach, fico)
- * @returns {number} Max marks for that framework
- */
-function getFrameworkMaxMarks(frameworkKey) {
-  const { getFramework } = require('../services/coaching/frameworks/framework-registry');
-  return getFramework(frameworkKey).maxMarks;
-}
-
-/**
- * Get display name for any registered framework.
- * @param {string} frameworkKey - Framework key
- * @returns {string} Display name
- */
-function getFrameworkDisplayName(frameworkKey) {
-  const { getFramework } = require('../services/coaching/frameworks/framework-registry');
-  return getFramework(frameworkKey).displayName;
-}
-
 module.exports = {
-  // OECD constants (backward compat)
   CLASSROOM_MARKS_BASE,
   LP_CRITERIA_MARKS,
   CLASSROOM_MARKS_WITH_LP,
   DEBRIEF_MARKS,
   PRIOR_FEEDBACK_MARKS,
-  // Multi-framework
-  getFrameworkMaxMarks,
-  getFrameworkDisplayName,
 };

--- a/tests/setup/circular-deps.allowlist.json
+++ b/tests/setup/circular-deps.allowlist.json
@@ -1,18 +1,10 @@
 [
   {
     "cycle": [
-      "bot/shared/services/coaching/frameworks/oecd-framework.js",
-      "bot/shared/services/coaching/frameworks/framework-registry.js",
-      "bot/shared/constants/scoring.constants.js"
-    ],
-    "reason": "Pre-existing constants↔framework cycle. scoring.constants.js requires the framework registry to look up the active framework at runtime; the registry lazy-requires each framework module via a factory function. Works because the lazy require defers until call time. A true fix would lift the constants out of the framework path; out of scope here."
-  },
-  {
-    "cycle": [
       "bot/shared/services/coaching/report-renderers/renderer-registry.js",
       "bot/shared/services/pdf-report.service.js"
     ],
-    "reason": "Introduced by bd-1843 (the hero report). pdf-report.service.js eager-requires the renderer-registry to dispatch; the registry lazy-requires pdf-report.service.js inside pdfkitRenderer.render() and htmlRenderer.render(). Works because the lazy require defers until render time."
+    "reason": "renderer-registry.js eager-requires pdf-report.service.js to dispatch; pdf-report.service.js lazy-requires renderer-registry.js inside pdfkitRenderer.render() and htmlRenderer.render(). Works because the lazy require defers until render time."
   },
   {
     "cycle": [


### PR DESCRIPTION
## What this fixes

Wave 3 PR α's circular-deps guard flagged a 3-node cycle:

```
oecd-framework.js → scoring.constants.js → framework-registry.js
                                       → oecd-framework.js
```

The Wave 3 closeout described it as 'pre-existing, lazy-required, works at runtime' and allowlisted it as a Wave-4 follow-up.

## Investigation

`scoring.constants.js` exposed two helpers that lazy-required the framework registry:

```js
function getFrameworkMaxMarks(frameworkKey) {
  const { getFramework } = require('../services/coaching/frameworks/framework-registry');
  return getFramework(frameworkKey).maxMarks;
}

function getFrameworkDisplayName(frameworkKey) {
  const { getFramework } = require('../services/coaching/frameworks/framework-registry');
  return getFramework(frameworkKey).displayName;
}
```

A full grep across `bot/ tests/ scripts/ infrastructure/` for both names showed **zero callers** besides the definition + export themselves. They were ports of a prod multi-framework facade that the OSS codebase never actually used.

## Resolution

Delete both helpers (~25 lines). `scoring.constants.js` becomes a **pure data module** — only the OECD-specific marks (`CLASSROOM_MARKS_BASE` etc., still consumed by `oecd-framework.js`).

The cycle vanishes because the require of `framework-registry` from the constants file goes away. The remaining edge `oecd-framework.js → scoring.constants.js` is uni-directional.

## Files

| Path | Change |
|---|---|
| `bot/shared/constants/scoring.constants.js` | -2 functions, -1 require. JSDoc updated to document the constraint going forward ('strictly a data module — no requires of framework-registry'). |
| `tests/setup/circular-deps.allowlist.json` | Removed the 3-node cycle entry. Allowlist shrinks from 3 → 2 entries (renderer-registry↔pdf-report and elevenlabs↔audio remain). |

## Test status

- **112 suites / 1285 tests green** (no change — the removed helpers had no tests because they had no callers)
- **CI-condition smoke** (`mv bot/node_modules`): green
- **circular-deps guard**: was 3 cycles allowlisted, now 2
- **Source-hygiene + leak-grep:** clean

## Wave 4 status

**This is the last Wave-4 deferred bead.** With this PR:

| Wave-4 bead | Status |
|---|---|
| bd-WAVE4-001a (coaching-processor boot I/O) | Closed by PR #51 — false positive, test regex tightened |
| bd-WAVE4-001b (sqs-worker boot I/O) | Closed by PR #51 — false positive, same |
| bd-WAVE4-001c (stale-session boot I/O) | Closed by PR #51 — false positive, same |
| bd-WAVE4-002 (require.main gates) | Closed by PR #49 |
| bd-WAVE4-003 (constants↔framework cycle) | Closed by this PR |
| bd-WAVE4-004 (elevenlabs OpenAI lazy) | Closed by PR #50 |

**WAVE 4 COMPLETE.** Every architectural finding from PR α surfaced, triaged, and either resolved or honestly-allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)