### PR TITLE
fix(ci): deploy.yml step-level gating — stops "No jobs were run" failure emails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,15 @@
 # 2. Add a new secret called RAILWAY_TOKEN
 # 3. Paste the deploy token from your provisioning response
 # 4. Push to main branch - auto-deploys!
+#
+# Why the gate lives at STEP level, not JOB level:
+# A workflow whose ALL jobs are skipped by a job-level `if:` is reported by
+# GitHub Actions as a FAILED run (and triggers a "Run failed: No jobs were
+# run" notification). This used to mean every merge to main on a fork without
+# RAILWAY_TOKEN set sent a spurious failure email. By gating at step level,
+# the job ALWAYS runs and ALWAYS succeeds — it just skips the deploy steps
+# and emits a friendly `::notice::` annotation when the token is unset.
+# (Locked by tests/setup/ci-workflow-jobs-always-runnable.test.js.)
 
 name: Deploy to Railway
 
@@ -29,22 +38,36 @@ jobs:
   deploy:
     name: Deploy Bot to Railway
     runs-on: ubuntu-latest
-    # Skip if RAILWAY_TOKEN is not configured (e.g., on the upstream template repo)
-    if: ${{ secrets.RAILWAY_TOKEN != '' }}
-
     steps:
+      - name: Check deployment configuration
+        id: gate
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::notice::RAILWAY_TOKEN secret not set — auto-deploy skipped. This is expected on the upstream template repo. Set RAILWAY_TOKEN in repo Settings → Secrets and variables → Actions to enable Railway auto-deploys on your fork."
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "RAILWAY_TOKEN detected — proceeding with deployment."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout code
+        if: steps.gate.outputs.should_deploy == 'true'
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: steps.gate.outputs.should_deploy == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install Railway CLI
+        if: steps.gate.outputs.should_deploy == 'true'
         run: npm install -g @railway/cli
 
       - name: Deploy to Railway
+        if: steps.gate.outputs.should_deploy == 'true'
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
@@ -54,6 +77,7 @@ jobs:
           echo "Deployment complete!"
 
       - name: Verify deployment
+        if: steps.gate.outputs.should_deploy == 'true'
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |

--- a/tests/setup/ci-workflow-jobs-always-runnable.test.js
+++ b/tests/setup/ci-workflow-jobs-always-runnable.test.js
@@ -1,0 +1,117 @@
+/**
+ * CI-workflow jobs-always-runnable conformance.
+ *
+ * Catches a specific GitHub Actions anti-pattern: a workflow with EXACTLY ONE
+ * job that is gated by a job-level `if:` referencing `secrets.*`. When the
+ * secret is unset (e.g. on the upstream template repo), GitHub Actions skips
+ * the only job, then reports the whole workflow run as FAILED and sends a
+ * "Run failed: No jobs were run" notification email per push.
+ *
+ * The fix is to move the gate to the STEP level: the job always runs (so the
+ * workflow always succeeds), and conditional steps skip the deploy work while
+ * a header step emits a friendly `::notice::` annotation explaining what to
+ * configure to enable the gated behaviour.
+ *
+ * (See `.github/workflows/deploy.yml` for the canonical step-level-gating shape.)
+ *
+ * This is a deterministic regex-based parser — does NOT require js-yaml. The
+ * shape we forbid is narrow enough that regex is robust:
+ *
+ *   1. Exactly one job under `jobs:` (counted by `^  [a-zA-Z_-]+:` at
+ *      2-space indent in the jobs block).
+ *   2. That job has `    if: ...secrets.<NAME>...` at 4-space indent (the
+ *      job-level `if:` position).
+ *
+ * Anything else passes.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOWS_DIR = path.resolve(__dirname, '../../.github/workflows');
+
+/**
+ * Extracts top-level job names and their job-level `if:` clauses from a
+ * GitHub Actions workflow YAML file. Returns an array of { name, ifClause }.
+ *
+ * Assumes 2-space indentation under `jobs:` (the convention used throughout
+ * the OSS repo's workflows + every workflow we've ever shipped). If a
+ * workflow ever uses 4-space or tab indentation, this parser will miss it
+ * and the test will silently pass — at that point swap in js-yaml.
+ */
+function extractJobs(yamlText) {
+  const lines = yamlText.split('\n');
+  const jobs = [];
+  let inJobsBlock = false;
+  let currentJob = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Detect entry into the `jobs:` block.
+    if (/^jobs:\s*$/.test(line)) {
+      inJobsBlock = true;
+      continue;
+    }
+    if (!inJobsBlock) continue;
+
+    // Exiting the jobs block (any top-level key after `jobs:` ends it).
+    if (/^[a-zA-Z_-]+:\s*$/.test(line) && !/^\s/.test(line)) {
+      inJobsBlock = false;
+      currentJob = null;
+      continue;
+    }
+
+    // A new job: `  <jobname>:` at exactly 2-space indent.
+    const jobHeaderMatch = line.match(/^  ([a-zA-Z_][a-zA-Z0-9_-]*):\s*$/);
+    if (jobHeaderMatch) {
+      currentJob = { name: jobHeaderMatch[1], ifClause: null };
+      jobs.push(currentJob);
+      continue;
+    }
+
+    // Job-level keys at 4-space indent inside the current job.
+    if (currentJob) {
+      const ifMatch = line.match(/^    if:\s*(.+?)\s*$/);
+      if (ifMatch) currentJob.ifClause = ifMatch[1];
+    }
+  }
+
+  return jobs;
+}
+
+describe('CI workflows — jobs-always-runnable conformance', () => {
+  const workflowFiles = fs.existsSync(WORKFLOWS_DIR)
+    ? fs.readdirSync(WORKFLOWS_DIR).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    : [];
+
+  it('workflows directory exists and has at least one file', () => {
+    expect(workflowFiles.length).toBeGreaterThan(0);
+  });
+
+  it('no workflow has a single job gated by a secrets.* job-level `if:`', () => {
+    const offenders = [];
+
+    for (const file of workflowFiles) {
+      const text = fs.readFileSync(path.join(WORKFLOWS_DIR, file), 'utf-8');
+      const jobs = extractJobs(text);
+
+      if (jobs.length !== 1) continue; // Multi-job workflows are fine.
+
+      const onlyJob = jobs[0];
+      if (!onlyJob.ifClause) continue; // No job-level if: → fine.
+
+      // Job-level if: that references secrets.* is the failure-spam trap.
+      if (/secrets\.[A-Z_][A-Z0-9_]*/.test(onlyJob.ifClause)) {
+        offenders.push(
+          `${file}: single job "${onlyJob.name}" has job-level \`if: ${onlyJob.ifClause}\` — ` +
+          'move the gate to STEP level so the job always succeeds even when the secret is unset. ' +
+          'Otherwise GitHub Actions reports "all-jobs-skipped" workflow runs as failed and sends ' +
+          '"No jobs were run" notification emails on every push. See `.github/workflows/deploy.yml` for the step-level-gating fix.'
+        );
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Root cause

`deploy.yml` had a single job gated by a job-level `if: \${{ secrets.RAILWAY_TOKEN != '' }}`. On the upstream template repo (which doesn't have `RAILWAY_TOKEN` set), the only job was skipped — and GitHub Actions reports a workflow with all jobs skipped as a **failed run** for notification purposes. Every merge to main produced a \"Run failed: No jobs were run\" email.

Observed: ~10 such emails in the past 48h across recent merges.

## Fix

Move the gate from **job level** to **step level**. The job now always runs (so the workflow always succeeds); the first step decides whether to deploy or to emit a friendly `::notice::` annotation explaining what to configure.

Why this is a root-cause fix, not a band-aid:

- **Doesn't remove the workflow** — preserves the Railway deploy capability for any cloner who sets `RAILWAY_TOKEN`.
- **Doesn't suppress notifications** — leaves the user's GitHub notification settings untouched.
- **Job always runs** → workflow conclusion = `success`.
- **Skip-state is explicit** — green check + a notice annotation, not a confusing red X.
- **Forks behave correctly** — a fork with `RAILWAY_TOKEN` set deploys exactly as before; a fork without it gets a friendly informational run.

## Ratchet

Added `tests/setup/ci-workflow-jobs-always-runnable.test.js` — regex-parses every `.github/workflows/*.yml` and fails if any workflow has a single job with a job-level `if:` that references `secrets.*`. Would have caught this anti-pattern on day one. Empty allowlist.

## Verification

- Full suite: **113 suites / 1287 tests** green (+2 from the new guard)
- Source-hygiene clean
- New `deploy.yml` validated by the new guard test

## What to watch after merge

Next push to `main` should:
- Show a green check on the Deploy to Railway workflow
- Display the `::notice::` \"RAILWAY_TOKEN not set\" annotation in the workflow summary
- Send NO \"Run failed\" notification email

🤖 Generated with [Claude Code](https://claude.com/claude-code)