### PR TITLE
fix(boot): lazy-init the 7 remaining module-load SDK constructors + lock the contract

### DIFF
--- a/bot/shared/services/aws-textract.service.js
+++ b/bot/shared/services/aws-textract.service.js
@@ -1,19 +1,46 @@
 const { TextractClient, AnalyzeDocumentCommand } = require('@aws-sdk/client-textract');
 const { logToFile } = require('../utils/logger');
+const { lazyClient } = require('../utils/lazy-client');
 
+// AWS Textract is the optional exam-checker OCR fallback (the primary is
+// Mistral). Lazy-initialised: the bot can boot without AWS Textract
+// credentials; the only call path that needs them is `extractText` itself.
+//
+// Supports the standard AWS env-var names; falls back to the dedicated
+// `AWS_TEXTRACT_*` names if a deployment wants to isolate Textract credentials
+// from other AWS-SDK consumers.
 const textractRegion = process.env.AWS_REGION_TEXTRACT
   || process.env.AWS_REGION
   || 'us-east-1';
 
-const textractCredentials = {
-  accessKeyId: process.env.AWS_TEXTRACT_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID,
-  secretAccessKey: process.env.AWS_TEXTRACT_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY,
-};
+const getTextractClient = lazyClient(
+  TextractClient,
+  // We accept EITHER pair (AWS_TEXTRACT_* or generic AWS_*) — the lazyClient
+  // helper checks each listed env var as required. To allow EITHER, normalise
+  // first: copy the generic-AWS values into the AWS_TEXTRACT_ slots before
+  // calling the SDK constructor.
+  [], // checked manually below to support the OR-pair semantics
+  () => ({
+    region: textractRegion,
+    credentials: {
+      accessKeyId: process.env.AWS_TEXTRACT_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_TEXTRACT_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY,
+    },
+  })
+);
 
-const textractClient = new TextractClient({
-  region: textractRegion,
-  credentials: textractCredentials,
-});
+function assertTextractCredentialsPresent() {
+  const hasKey = process.env.AWS_TEXTRACT_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID;
+  const hasSecret = process.env.AWS_TEXTRACT_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY;
+  if (!hasKey || !hasSecret) {
+    throw new Error(
+      'AWS Textract cannot be invoked — missing credentials. Set either ' +
+      '`AWS_TEXTRACT_ACCESS_KEY_ID`+`AWS_TEXTRACT_SECRET_ACCESS_KEY` OR the ' +
+      'generic `AWS_ACCESS_KEY_ID`+`AWS_SECRET_ACCESS_KEY` in .env, or use ' +
+      'the Mistral OCR primary instead.'
+    );
+  }
+}
 
 class AWSTextractService {
   static async extractText(buffer) {
@@ -27,7 +54,8 @@ class AWSTextractService {
           FeatureTypes: ['TABLES', 'FORMS'],
         });
 
-        const response = await textractClient.send(command);
+        assertTextractCredentialsPresent();
+        const response = await getTextractClient().send(command);
 
         let extractedText = '';
         let totalConfidence = 0;

--- a/bot/shared/services/coaching/reflective-questions/llm-router.service.js
+++ b/bot/shared/services/coaching/reflective-questions/llm-router.service.js
@@ -42,6 +42,7 @@
 
 const OpenAI = require('openai');
 const { logToFile } = require('../../../utils/logger');
+const { lazyClient } = require('../../../utils/lazy-client');
 
 // Default per-attempt deadline. Sized for the corpus call's ~2-3k-token output on a
 // throughput-sorted provider (≥30 tok/s → ≤~100s), with headroom; well short of the SDK's
@@ -53,11 +54,14 @@ const PROVIDER_ROUTING = { sort: 'throughput', allow_fallbacks: true };
 
 // Single OpenRouter client. maxRetries:0 — our ladder owns retries (don't let the SDK
 // stack its own retries on top, which would multiply latency on a bad provider).
-const openrouter = new OpenAI({
-  apiKey: process.env.OPENROUTER_API_KEY,
+// Lazy-initialised: OPENROUTER_API_KEY is in REQUIRED_VARS so the bot won't pass
+// `doctor` without it, but we don't want module-load to crash before doctor's
+// friendly missing-key matrix runs.
+const getOpenRouter = lazyClient(OpenAI, ['OPENROUTER_API_KEY'], (env) => ({
+  apiKey: env.OPENROUTER_API_KEY,
   baseURL: 'https://openrouter.ai/api/v1',
   maxRetries: 0,
-});
+}));
 
 const PRIMARY_MODEL = 'deepseek/deepseek-v3.2';
 const FALLBACK_MODEL = 'openai/gpt-5.4';
@@ -80,7 +84,7 @@ const isOurTimeout = (e) =>
  */
 async function callReflective(messages, { maxTokens = 2000, temperature = 0.7, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
   const attempt = (model, extra = {}) =>
-    openrouter.chat.completions.create(
+    getOpenRouter().chat.completions.create(
       {
         model,
         messages,

--- a/bot/shared/services/coaching/transcript-enhancer.service.js
+++ b/bot/shared/services/coaching/transcript-enhancer.service.js
@@ -16,11 +16,13 @@
 const OpenAI = require('openai');
 const { logToFile } = require('../../utils/logger');
 const { logEvent } = require('../../utils/structured-logger');
+const { lazyClient } = require('../../utils/lazy-client');
 
-// Initialize OpenAI client
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY
-});
+// Lazy-initialised: the enhancer only runs when a coaching transcript is being
+// post-processed. Setting OPENAI_API_KEY is optional at boot time.
+const getOpenAI = lazyClient(OpenAI, ['OPENAI_API_KEY'], (env) => ({
+  apiKey: env.OPENAI_API_KEY,
+}));
 
 /**
  * Phonetic Urdu → English Dictionary
@@ -638,7 +640,7 @@ class TranscriptEnhancerService {
       const prompt = this.buildPromptWithFewShot(segments, enhancementOptions);
 
       // Call GPT-4o
-      const response = await openai.chat.completions.create({
+      const response = await getOpenAI().chat.completions.create({
         model: 'gpt-4o',
         messages: [
           {

--- a/bot/shared/services/pic-to-lp/classifier.service.js
+++ b/bot/shared/services/pic-to-lp/classifier.service.js
@@ -18,9 +18,13 @@
 
 const OpenAI = require('openai');
 const { logToFile } = require('../../utils/logger');
-const { OPENAI_API_KEY } = require('../../utils/constants');
+const { lazyClient } = require('../../utils/lazy-client');
 
-const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+// Lazy-initialised so the bot can boot without OPENAI_API_KEY set; the
+// classifier only needs it when an image actually arrives.
+const getOpenAI = lazyClient(OpenAI, ['OPENAI_API_KEY'], (env) => ({
+  apiKey: env.OPENAI_API_KEY,
+}));
 
 const VALID_TYPES = ['BOOK_PAGE', 'CLASSROOM', 'STUDENT_WORK', 'EXAM', 'OTHER'];
 const MODEL = process.env.PIC_LP_CLASSIFIER_MODEL || 'gpt-4o-mini';
@@ -56,7 +60,7 @@ async function classifyImageType(imageBuffer, mimeType, caption = '') {
       ? `Caption from sender: "${caption.substring(0, 200)}"`
       : '(No caption)';
 
-    const completion = await openai.chat.completions.create(
+    const completion = await getOpenAI().chat.completions.create(
       {
         model: MODEL,
         messages: [

--- a/bot/shared/services/pic-to-lp/metadata-extractor.service.js
+++ b/bot/shared/services/pic-to-lp/metadata-extractor.service.js
@@ -9,7 +9,7 @@
 const OpenAI = require('openai');
 const axios = require('axios');
 const { logToFile } = require('../../utils/logger');
-const { OPENAI_API_KEY } = require('../../utils/constants');
+const { lazyClient } = require('../../utils/lazy-client');
 // Presign R2 URLs before passing to OpenAI vision. The R2 bucket is private —
 // raw URLs return 400 from OpenAI's image download. Without the presign the
 // metadata extractor silently fails (the form just opens with blank pre-fills
@@ -18,7 +18,11 @@ const { getPresignedUrl } = require('../../storage/r2');
 
 const { extractFromCaption, mergeWithCaption } = require('./caption-prefill');
 
-const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+// Lazy: the bot can boot without OPENAI_API_KEY; only invoking the extractor
+// (i.e. a teacher sending a textbook page) needs the key.
+const getOpenAI = lazyClient(OpenAI, ['OPENAI_API_KEY'], (env) => ({
+  apiKey: env.OPENAI_API_KEY,
+}));
 const MODEL = process.env.PIC_LP_EXTRACTOR_MODEL || 'gpt-4o-mini';
 const TIMEOUT_MS = 45000;
 
@@ -127,7 +131,7 @@ async function extract(pages, caption = '', userContext = null) {
       `Number of pages: ${pages.length}`,
     ].join('\n');
 
-    const completion = await openai.chat.completions.create(
+    const completion = await getOpenAI().chat.completions.create(
       {
         model: MODEL,
         messages: [

--- a/bot/shared/services/reading/vocabulary-image.service.js
+++ b/bot/shared/services/reading/vocabulary-image.service.js
@@ -16,9 +16,11 @@
 const { GoogleGenerativeAI } = require('@google/generative-ai');
 const { uploadImageBuffer, buildR2PublicUrl } = require('../../storage/r2');
 const { logToFile } = require('../../utils/logger');
+const { lazyClient } = require('../../utils/lazy-client');
 
-// Initialize Gemini client
-const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+// Lazy-initialised: vocabulary image generation only runs when a reading
+// assessment exercises this branch. GEMINI_API_KEY is optional at boot time.
+const getGenAI = lazyClient(GoogleGenerativeAI, ['GEMINI_API_KEY'], (env) => env.GEMINI_API_KEY);
 
 class VocabularyImageService {
   /**
@@ -73,7 +75,7 @@ STRICT REQUIREMENTS:
 - Child-friendly colorful cartoon style suitable for ages 5-8
 - Make each object clearly recognizable`;
 
-      const model = genAI.getGenerativeModel({
+      const model = getGenAI().getGenerativeModel({
         model: 'gemini-2.0-flash-exp-image-generation',  // Tested & verified Nov 30, 2025
         generationConfig: {
           responseModalities: ['Text', 'Image']

--- a/bot/shared/storage/r2.js
+++ b/bot/shared/storage/r2.js
@@ -7,16 +7,20 @@ const { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand } = re
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const fs = require('fs');
 const path = require('path');
+const { lazyClient } = require('../utils/lazy-client');
 
-// Initialize R2 client
-const r2Client = new S3Client({
+// R2 client is lazy-initialised. The bot can boot without R2 credentials set —
+// every R2 helper below calls getR2Client() at the moment the actual S3-API
+// command is sent. If R2 isn't configured, the upload throws a structured
+// "missing env" error that the caller can catch (or surface to the user).
+const getR2Client = lazyClient(S3Client, ['R2_ENDPOINT', 'R2_ACCESS_KEY_ID', 'R2_SECRET_ACCESS_KEY'], (env) => ({
   region: 'auto',
-  endpoint: process.env.R2_ENDPOINT,
+  endpoint: env.R2_ENDPOINT,
   credentials: {
-    accessKeyId: process.env.R2_ACCESS_KEY_ID,
-    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+    accessKeyId: env.R2_ACCESS_KEY_ID,
+    secretAccessKey: env.R2_SECRET_ACCESS_KEY,
   },
-});
+}));
 
 const BUCKET_NAME = process.env.R2_BUCKET_NAME;
 
@@ -43,7 +47,7 @@ async function uploadAudio(filePath, userId, messageId) {
       ContentType: getContentType(fileExt),
     });
 
-    await r2Client.send(command);
+    await getR2Client().send(command);
 
     // Construct public URL
     const publicUrl = `${process.env.R2_ENDPOINT}/${BUCKET_NAME}/${key}`;
@@ -98,7 +102,7 @@ async function uploadLessonPlanBuffer({ buffer, userId, sessionId, fileType = 'p
     }
   });
 
-  await r2Client.send(command);
+  await getR2Client().send(command);
   console.log(`✅ Lesson plan buffer uploaded to R2: ${key}`);
   return key;
 }
@@ -121,7 +125,7 @@ async function deleteAudio(url) {
       Key: key,
     });
 
-    await r2Client.send(command);
+    await getR2Client().send(command);
     console.log(`✅ Audio deleted from R2: ${key}`);
     return true;
   } catch (error) {
@@ -166,7 +170,7 @@ async function uploadClassroomAudio(filePath, userId, sessionId, metadata = {}) 
       }
     });
 
-    await r2Client.send(command);
+    await getR2Client().send(command);
 
     // Construct public URL
     const publicUrl = `${process.env.R2_ENDPOINT}/${BUCKET_NAME}/${key}`;
@@ -206,7 +210,7 @@ async function uploadLessonPlan(filePath, userId, sessionId) {
       }
     });
 
-    await r2Client.send(command);
+    await getR2Client().send(command);
 
     const publicUrl = `${process.env.R2_ENDPOINT}/${BUCKET_NAME}/${key}`;
 
@@ -244,7 +248,7 @@ async function uploadVoiceDebrief(audioBuffer, userId, sessionId, language) {
       }
     });
 
-    await r2Client.send(command);
+    await getR2Client().send(command);
 
     const publicUrl = `${process.env.R2_ENDPOINT}/${BUCKET_NAME}/${key}`;
 
@@ -280,7 +284,7 @@ async function uploadReportPDF(pdfBuffer, userId, sessionId) {
       }
     });
 
-    await r2Client.send(command);
+    await getR2Client().send(command);
 
     const publicUrl = `${process.env.R2_ENDPOINT}/${BUCKET_NAME}/${key}`;
 
@@ -311,7 +315,7 @@ async function uploadImageBuffer(imageBuffer, key) {
       }
     });
 
-    await r2Client.send(command);
+    await getR2Client().send(command);
     console.log(`✅ Vocabulary image uploaded to R2: ${key}`);
     return key;
   } catch (error) {
@@ -346,7 +350,7 @@ async function uploadFeatureVideo(filePath, featureName) {
       }
     });
 
-    await r2Client.send(command);
+    await getR2Client().send(command);
 
     const publicUrl = `${process.env.R2_ENDPOINT}/${BUCKET_NAME}/${key}`;
 
@@ -370,7 +374,7 @@ async function downloadFromR2(key) {
       Key: key,
     });
 
-    const response = await r2Client.send(command);
+    const response = await getR2Client().send(command);
 
     // Convert stream to buffer
     const chunks = [];
@@ -481,7 +485,7 @@ async function uploadVideoAsset(filePathOrBuffer, videoRequestId, filename) {
         }
       });
 
-      await r2Client.send(command);
+      await getR2Client().send(command);
 
       const publicUrl = `${process.env.R2_ENDPOINT}/${BUCKET_NAME}/${key}`;
       logToFile('Video asset uploaded to R2', {
@@ -585,7 +589,7 @@ async function getPresignedUrl(r2Url, expiresIn = 3600) {
       Key: key,
     });
 
-    const presignedUrl = await getSignedUrl(r2Client, command, { expiresIn });
+    const presignedUrl = await getSignedUrl(getR2Client(), command, { expiresIn });
 
     console.log(`✅ Generated presigned URL for ${key}:`);
     console.log(`   Original: ${r2Url.substring(0, 80)}...`);
@@ -657,7 +661,7 @@ async function uploadImageWithRetry(imageBuffer, userId, imageId, mimeType) {
         },
       });
 
-      await r2Client.send(command);
+      await getR2Client().send(command);
 
       const publicUrl = buildR2PublicUrl(key);
 
@@ -708,7 +712,7 @@ async function uploadBuffer(buffer, key, contentType = 'application/octet-stream
       }
     });
 
-    await r2Client.send(command);
+    await getR2Client().send(command);
     const publicUrl = buildR2PublicUrl(key);
 
     console.log(`✅ Buffer uploaded to R2: ${key} (${buffer.length} bytes)`);

--- a/bot/shared/utils/lazy-client.js
+++ b/bot/shared/utils/lazy-client.js
@@ -1,0 +1,78 @@
+/**
+ * Lazy SDK client construction.
+ *
+ * Several services in the bot need an external SDK client (OpenAI, Google
+ * Generative AI, AWS S3, AWS Textract, etc.) for the work they do. The
+ * obvious pattern is `const client = new SDK({ apiKey: KEY })` at the top of
+ * the module — but that pattern crashes the entire bot at cold-boot whenever
+ * the relevant API key isn't set, even if NO code path that requires the SDK
+ * is ever invoked. (Wave 4 hit this with ElevenLabs; Wave 5 found 5 more
+ * sister files with the same shape.)
+ *
+ * `lazyClient(...)` is the canonical fix: it returns a getter that
+ * constructs the SDK client on FIRST access. If a required env var is
+ * missing, the getter throws a structured, action-oriented error message
+ * pointing the operator at the specific env vars to set. The bot continues
+ * to boot cleanly when the keys are unset — the failure only happens at the
+ * exact call site that tries to use the SDK.
+ *
+ * Example:
+ *
+ *   const OpenAI = require('openai');
+ *   const { lazyClient } = require('../utils/lazy-client');
+ *
+ *   const getOpenAI = lazyClient(OpenAI, ['OPENAI_API_KEY'],
+ *     (env) => ({ apiKey: env.OPENAI_API_KEY })
+ *   );
+ *
+ *   async function classifyImage(buf) {
+ *     const client = getOpenAI();  // throws iff OPENAI_API_KEY missing
+ *     return client.images.generate(...);
+ *   }
+ *
+ * The cache is per-getter (closure-scoped) — repeat calls return the same
+ * client instance, matching the eager-construction pattern's behaviour.
+ */
+
+/**
+ * Wraps an SDK constructor with lazy + cached construction.
+ *
+ * @template T
+ * @param {new (config: object) => T} ClientClass
+ *   The SDK class constructor. Must be `new`-able.
+ * @param {string[]} requiredEnvVars
+ *   Env vars that MUST be set for construction to succeed. The error message
+ *   lists the missing subset.
+ * @param {(env: Record<string, string>) => object} buildArgs
+ *   Builds the constructor argument object from the (verified-present) env
+ *   vars. Receives a sanitized env subset containing only `requiredEnvVars`.
+ * @returns {() => T} A getter that returns the cached client instance.
+ */
+function lazyClient(ClientClass, requiredEnvVars, buildArgs) {
+  let cached = null;
+
+  return function getClient() {
+    if (cached) return cached;
+
+    const missing = [];
+    const env = {};
+    for (const key of requiredEnvVars) {
+      const value = process.env[key];
+      if (!value) missing.push(key);
+      else env[key] = value;
+    }
+
+    if (missing.length > 0) {
+      const className = ClientClass.name || 'SDK client';
+      throw new Error(
+        `${className} cannot be constructed — missing env: ${missing.join(', ')}. ` +
+        `Set these in .env (see .env.template) or avoid invoking this code path.`
+      );
+    }
+
+    cached = new ClientClass(buildArgs(env));
+    return cached;
+  };
+}
+
+module.exports = { lazyClient };

--- a/tests/pic-to-lp/classifier.test.js
+++ b/tests/pic-to-lp/classifier.test.js
@@ -5,12 +5,15 @@
 
 let Classifier;
 let createImpl;
+const ORIGINAL_OPENAI_KEY = process.env.OPENAI_API_KEY;
 
 function load() {
   jest.resetModules();
   createImpl = jest.fn();
+  // The classifier reads OPENAI_API_KEY from process.env via the lazy-client
+  // helper; set it here so lazyClient construction succeeds.
+  process.env.OPENAI_API_KEY = 'test-openai-key';
   jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
-  jest.doMock('../../bot/shared/utils/constants', () => ({ OPENAI_API_KEY: 'test-openai-key' }));
   jest.doMock('openai', () => {
     return jest.fn().mockImplementation(() => ({
       chat: { completions: { create: createImpl } },
@@ -19,7 +22,11 @@ function load() {
   Classifier = require('../../bot/shared/services/pic-to-lp/classifier.service');
 }
 
-afterEach(() => jest.resetModules());
+afterEach(() => {
+  jest.resetModules();
+  if (ORIGINAL_OPENAI_KEY === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = ORIGINAL_OPENAI_KEY;
+});
 
 const buf = Buffer.from('fake-image-bytes');
 

--- a/tests/setup/no-eager-sdk-construction.test.js
+++ b/tests/setup/no-eager-sdk-construction.test.js
@@ -1,0 +1,87 @@
+/**
+ * No-eager-SDK-construction conformance.
+ *
+ * Constructing an SDK client at module load (`const c = new OpenAI({...})`
+ * at column 0) crashes the bot at cold-boot whenever the relevant API key
+ * isn't set, even if NO code path that requires the SDK is ever invoked.
+ *
+ * This guard locks the lazy-init contract: every SDK constructor in shipped
+ * `bot/shared/` and `bot/workers/` must be wrapped in a function (so that
+ * cred-missing errors fire at call time, not at require time), via the
+ * `lazyClient()` helper or an equivalent inline pattern (static getter,
+ * function-scoped `new`, etc.).
+ *
+ * Detection is regex-based against the column-0 anti-pattern:
+ *
+ *   const <name> = new (OpenAI|S3Client|TextractClient|...)({ ... });
+ *
+ * Indented (≥2-space) `new <SDK>` calls are inside a method body and are
+ * lazy by location — those pass the guard.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCAN_DIRS = ['bot/shared', 'bot/workers'].map((d) => path.join(ROOT, d));
+
+// SDK classes whose eager construction at module-load is the bug pattern.
+// Add new SDKs here when the bot starts using them.
+const SDK_NAMES = [
+  'OpenAI',
+  'GoogleGenerativeAI',
+  'S3Client',
+  'TextractClient',
+  'IORedis',
+  'Redis',
+  'Anthropic',
+  'AssemblyAI',
+];
+
+// Files that legitimately construct an SDK at module load (e.g. a centralised
+// singleton getter that everyone else lazy-wraps). Keep this list tight; the
+// preferred pattern is `lazyClient()` and an empty allowlist.
+const ALLOWLIST = new Set([
+  // None today.
+]);
+
+const EAGER_PATTERN = new RegExp(
+  `^const\\s+\\w+\\s*=\\s*new\\s+(?:${SDK_NAMES.join('|')})\\b`
+);
+
+function findJsFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name === 'node_modules' || e.name === '__mocks__') continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...findJsFiles(full));
+    else if (e.name.endsWith('.js')) out.push(full);
+  }
+  return out;
+}
+
+describe('No eager SDK construction at module-load', () => {
+  it('every SDK client in bot/shared and bot/workers is lazy-initialised', () => {
+    const offenders = [];
+    const files = SCAN_DIRS.flatMap(findJsFiles);
+
+    for (const filePath of files) {
+      const rel = path.relative(ROOT, filePath);
+      if (ALLOWLIST.has(rel)) continue;
+
+      const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
+      lines.forEach((line, i) => {
+        if (EAGER_PATTERN.test(line)) {
+          offenders.push(
+            `${rel}:${i + 1} — ${line.trim()} — wrap in `
+            + '`lazyClient()` (bot/shared/utils/lazy-client.js) so the bot can boot '
+            + 'without this SDK\'s env vars set.'
+          );
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Wave 4 fixed \`elevenlabs.service.js\`'s eager \`static openai = new OpenAI({...})\` because it crashed the bot at cold-boot whenever \`OPENAI_API_KEY\` was unset. The audit-guard side didn't catch the same pattern in sibling files — this PR closes that gap.

## The 7 sites refactored

| File | SDK | Env vars |
|---|---|---|
| \`bot/shared/storage/r2.js\` | \`S3Client\` | \`R2_ENDPOINT\`, \`R2_ACCESS_KEY_ID\`, \`R2_SECRET_ACCESS_KEY\` |
| \`bot/shared/services/aws-textract.service.js\` | \`TextractClient\` | \`AWS_TEXTRACT_*\` or generic \`AWS_*\` (OR-pair) |
| \`bot/shared/services/reading/vocabulary-image.service.js\` | \`GoogleGenerativeAI\` | \`GEMINI_API_KEY\` |
| \`bot/shared/services/pic-to-lp/classifier.service.js\` | \`OpenAI\` | \`OPENAI_API_KEY\` |
| \`bot/shared/services/pic-to-lp/metadata-extractor.service.js\` | \`OpenAI\` | \`OPENAI_API_KEY\` |
| \`bot/shared/services/coaching/transcript-enhancer.service.js\` | \`OpenAI\` | \`OPENAI_API_KEY\` |
| \`bot/shared/services/coaching/reflective-questions/llm-router.service.js\` | \`OpenAI\` (OpenRouter routing) | \`OPENROUTER_API_KEY\` |

## The lazy helper

New \`bot/shared/utils/lazy-client.js\` — \`lazyClient(ClientClass, requiredEnvVars, buildArgs)\` returns a getter that constructs the SDK client on first access. Missing env vars surface as a structured, action-oriented error at call time.

## Ratchet

\`tests/setup/no-eager-sdk-construction.test.js\` — for every file under \`bot/shared/\` and \`bot/workers/\`, fail if any column-0 line matches \`^const \w+ = new (OpenAI|S3Client|TextractClient|GoogleGenerativeAI|IORedis|Redis|Anthropic|AssemblyAI)\`. Empty allowlist. Catches the bug class on day one for any future SDK added to the bot.

## Verification

- **113 suites / 1286 tests** green (+1 new guard test)
- Source-hygiene clean
- One classifier test updated to mock via \`process.env\` (the lazy helper reads from process.env directly, not from the constants module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)