### PR TITLE
fix(boot): friendly Supabase boot-fail + honest doctor wording + capped Redis reconnect

### DIFF
--- a/bot/scripts/setup/doctor.js
+++ b/bot/scripts/setup/doctor.js
@@ -217,7 +217,7 @@ function formatReport(result) {
   lines.push('Rumi doctor — deployment preflight');
   lines.push('');
   if (result.missingRequired.length) {
-    lines.push('❌ MISSING REQUIRED variables — the bot will boot but features needing these will be OFF until you set them:');
+    lines.push('❌ MISSING REQUIRED variables — the bot will REFUSE TO START until you set these:');
     for (const v of result.missingRequired) {
       const src = keySource(v);
       lines.push(`   - ${v}${src ? `  → get it: ${src}` : ''}`);

--- a/bot/shared/config/supabase.js
+++ b/bot/shared/config/supabase.js
@@ -1,20 +1,58 @@
+/**
+ * Supabase client singleton — also the bot's cold-boot env-gate.
+ *
+ * SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY are REQUIRED for any code path
+ * that touches the DB (i.e. essentially all of them). When either is missing,
+ * we exit with a structured, action-oriented message that points the
+ * operator at `npm run doctor` for the full missing-vars matrix. Exit code
+ * 78 (EX_CONFIG per sysexits.h) lets process supervisors and CI know this
+ * was a configuration error, not a code crash.
+ *
+ * This file is the canonical entry-point check — most other env vars only
+ * matter at runtime when their specific feature fires, but Supabase is
+ * touched at the top of every handler and worker. Failing fast here means a
+ * cloner who skipped reading SETUP.md gets a useful pointer at second one
+ * instead of a 12-line node stack at line 9.
+ */
+
 require('dotenv').config();
 const { createClient } = require('@supabase/supabase-js');
 
-// Supabase configuration
 const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!supabaseUrl || !supabaseServiceRoleKey) {
-  throw new Error('Missing Supabase environment variables. Please check your .env file.');
+  const missing = [
+    !supabaseUrl && 'SUPABASE_URL',
+    !supabaseServiceRoleKey && 'SUPABASE_SERVICE_ROLE_KEY',
+  ].filter(Boolean);
+
+  const message = [
+    '',
+    '┌─ Rumi bot — boot aborted ──────────────────────────────────────────────',
+    '│ Missing REQUIRED env var(s): ' + missing.join(', '),
+    '│',
+    '│ Next steps:',
+    "│   1. If you haven't yet, copy the template:   cp .env.template .env",
+    '│   2. Fill in the REQUIRED block (see SETUP.md §2 — Supabase).',
+    '│   3. Confirm everything is set:               npm run doctor',
+    '│',
+    '│ `npm run doctor` prints a presence-checked matrix of every key the bot',
+    '│ understands, with a `where to get it` link per missing key. It exits',
+    '│ cleanly and shows exactly what still needs to be filled in.',
+    '└────────────────────────────────────────────────────────────────────────',
+    '',
+  ].join('\n');
+
+  process.stderr.write(message);
+  process.exit(78); // sysexits.h EX_CONFIG — "configuration error"
 }
 
-// Create Supabase client with service role key (for full database access)
 const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
   auth: {
     autoRefreshToken: false,
-    persistSession: false
-  }
+    persistSession: false,
+  },
 });
 
 module.exports = supabase;

--- a/bot/shared/services/cache/railway-redis.service.js
+++ b/bot/shared/services/cache/railway-redis.service.js
@@ -28,10 +28,32 @@ class RailwayRedisService {
       return;
     }
 
+    // Reconnect cap. If REDIS_URL points at an unreachable host (e.g. a
+    // cloner accidentally left `redis://localhost:6379` from the .env.template
+    // default), ioredis would otherwise reconnect indefinitely — the bot
+    // "boots" but spams `🔄 Reconnecting…` forever with no clear signal that
+    // the operator needs to fix the URL. After this many failed attempts
+    // (~80s of total wait given the linear backoff up to 2s), we stop and let
+    // the caller treat Redis as unavailable.
+    const MAX_RECONNECT_ATTEMPTS = 60;
+    this._redisGaveUp = false;
+
     try {
       this.redis = new Redis(process.env.REDIS_URL, {
-        // Retry strategy: exponential backoff up to 2 seconds
+        // Retry strategy: exponential backoff up to 2 seconds, capped at
+        // MAX_RECONNECT_ATTEMPTS total attempts before giving up.
         retryStrategy: (times) => {
+          if (times >= MAX_RECONNECT_ATTEMPTS) {
+            if (!this._redisGaveUp) {
+              this._redisGaveUp = true;
+              logToFile(
+                `❌ Redis unreachable after ${times} attempts — giving up. ` +
+                'Check REDIS_URL or unset it to disable Redis features.',
+                { url: process.env.REDIS_URL.replace(/:[^:@]*@/, ':***@'), level: 'error' }
+              );
+            }
+            return null; // ioredis stops reconnecting when retryStrategy returns null
+          }
           const delay = Math.min(times * 50, 2000);
           logToFile('Redis retrying connection', { attempt: times, delayMs: delay });
           return delay;

--- a/tests/setup/doctor-wording.test.js
+++ b/tests/setup/doctor-wording.test.js
@@ -20,7 +20,7 @@ describe('doctor — honest wording', () => {
   beforeEach(() => { originalEnv = { ...process.env }; jest.resetModules(); });
   afterEach(() => { process.env = originalEnv; });
 
-  it('missing-required line no longer says "the bot will not start"', () => {
+  it('missing-required line tells the truth: the bot REFUSES TO START', () => {
     // Force at least one REQUIRED_VAR to be absent.
     delete process.env.SUPABASE_URL;
     delete process.env.WHATSAPP_TOKEN;
@@ -37,10 +37,13 @@ describe('doctor — honest wording', () => {
     };
     const out = formatReport(result);
 
-    expect(out).not.toMatch(/the bot will not start/i);
     expect(out).toMatch(/MISSING REQUIRED variables/);
-    // The new copy promises "features needing these will be OFF" — the truth.
-    expect(out).toMatch(/will be OFF/i);
+    // The doctor must tell the truth: missing REQUIRED vars cause the bot to
+    // refuse to start (bot/shared/config/supabase.js exits 78 with a friendly
+    // box). The previous copy promised "features will be OFF" — incorrect for
+    // required keys; that wording is now reserved for OPTIONAL features.
+    expect(out).toMatch(/REFUSE TO START/i);
+    expect(out).not.toMatch(/the bot will boot.*will be OFF/i);
   });
 
   it('Video feature carries a "VIDEO_GENERATION_ENABLED" note', () => {


### PR DESCRIPTION
Three Wave-5 cold-boot UX fixes on the same path: what happens when the operator hasn't finished filling \`.env\` yet?

## 1. Friendly Supabase boot-fail (\`bot/shared/config/supabase.js\`)

Replace the naked \`throw new Error(...)\` (which produces a 12-line Node stack at column 0) with a structured box-character message that names the missing required var(s), points at \`cp .env.template .env\`, points at SETUP.md §2, points at \`npm run doctor\`, and exits with **code 78** (sysexits \`EX_CONFIG\`). Process supervisors now see code 78 as "user needs to fix .env"; the cloner sees a friendly setup-wizard message.

\`\`\`
┌─ Rumi bot — boot aborted ──────────────────────────────────────────────
│ Missing REQUIRED env var(s): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
│
│ Next steps:
│   1. If you haven't yet, copy the template:   cp .env.template .env
│   2. Fill in the REQUIRED block (see SETUP.md §2 — Supabase).
│   3. Confirm everything is set:               npm run doctor
└────────────────────────────────────────────────────────────────────────
\`\`\`

## 2. Honest doctor wording (\`bot/scripts/setup/doctor.js\`)

The previous copy said \"the bot will boot but features needing these will be OFF\" for missing REQUIRED vars. That was a **lie pinned by a passing test** — the bot does NOT boot without \`SUPABASE_URL\` (it exits 78 per #1). Updated to: \"the bot will REFUSE TO START until you set these\". \`tests/setup/doctor-wording.test.js\` updated in lockstep.

## 3. Capped Redis reconnect (\`bot/shared/services/cache/railway-redis.service.js\`)

If \`REDIS_URL\` pointed at an unreachable host, ioredis would reconnect forever and the bot would log \`🔄 Reconnecting…\` indefinitely with no clear signal. After 60 attempts (~80s total wait given the linear backoff), the retry strategy returns \`null\` — ioredis gives up — and a single clear error message tells the operator to check \`REDIS_URL\` or unset it. Redis is then treated as unavailable downstream.

## Verification

- **112 suites / 1285 tests** green
- Source-hygiene clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)