### PR TITLE
docs(fidelity): fix 7 verified-broken claims + strip tier system + refresh stale flow comment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -53,7 +53,9 @@ OPENROUTER_API_KEY=CHANGEME-sk-or-v1-your-openrouter-key
 REDIS_URL=redis://localhost:6379
 
 # --- WhatsApp — from Meta Business Manager (see docs/whatsapp-setup) ---------
-# These four are filled by `npm run bootstrap:whatsapp`, or paste them manually.
+# Fill these manually OR via `npm run setup:flows` (which registers Flow assets
+# and prints PHONE_NUMBER_ID / WABA_ID for you on first run). Full step-by-step:
+# docs/onboarding/whatsapp.md.
 
 # WhatsApp Cloud API access token (a permanent system-user token)
 WHATSAPP_TOKEN=CHANGEME-whatsapp-token

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ npm run simulate  # Test without WhatsApp
 - Node.js CommonJS (require/module.exports)
 - No TypeScript in bot/ (portal/ uses TypeScript)
 - Use branding.js for customizable strings
-- Use feature-tiers.js for feature gating
+- Use `bot/shared/config/feature-availability.js` for presence-based feature gating
 - Use llm-client.js for all AI calls
 
 ## Testing

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,10 +21,10 @@ What you expected to happen.
 What actually happened.
 
 ## Environment
-- **Tier**: Minimal / Recommended / Full
 - **Node.js version**:
 - **Deployment**: Railway / Local / Other
 - **Feature**: Chat / Coaching / Reading Assessment / Other
+- **Features enabled** (from `npm run doctor`):
 
 ## Logs
 ```

--- a/.github/ISSUE_TEMPLATE/setup_help.md
+++ b/.github/ISSUE_TEMPLATE/setup_help.md
@@ -26,8 +26,8 @@ Paste any error messages here
 ## Environment
 - **OS**: macOS / Linux / Windows
 - **Node.js version**:
-- **Tier**: Minimal / Recommended / Full
 - **Using /setup skill**: Yes / No (manual setup)
+- **Features enabled** (from `npm run doctor`):
 
 ## .setup-state.json
 If available, paste the contents of your `.setup-state.json`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] - 2026-04-03
 
+**BREAKING (vs v1.0.0):** The three-tier feature system (Minimal / Recommended /
+Full) is removed. Features are now **presence-gated**: a feature is ON iff its
+required env var(s) are set. There is no `RUMI_TIER` env var; `feature-availability.js`
+is the single source of truth. `npm run doctor` shows a per-feature ON/OFF matrix
+based on the keys you've provided.
+
 ### Added
 - **Multi-framework coaching system** — OECD, HOTS, TEACH, and FICO frameworks selectable per teacher
 - **HOTS framework** — aligned to PESRP/PECTAA official spec (16 indicators, 48 marks, 6 areas)
@@ -23,8 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 25 new coaching test scenarios across framework registry, HOTS, FICO, OECD, TEACH, report transformers, and coaching card generation (753 total tests, up from 728)
 
 ### Fixed
-- HOTS report: empty PDF when no lesson plan linked (BUG-053) — now uses raw analysis as fallback
-- HOTS evidence: was English-only; now infers subject/topic from transcript context (BUG-009)
+- HOTS report: empty PDF when no lesson plan linked — now uses raw analysis as fallback
+- HOTS evidence: was English-only; now infers subject/topic from transcript context
 - HOTS framework selector: wrong DB column used when reading user preference
 - Coaching photo flow: state mismatch, missing `photo_yes` button handler, 2-minute timeout
 

--- a/bot/README.md
+++ b/bot/README.md
@@ -43,8 +43,8 @@ bot/
 | Service | File | Description |
 |---------|------|-------------|
 | LLM Client | `shared/services/llm-client.js` | OpenRouter/OpenAI integration |
-| Queue | `shared/services/queue/sqs-queue.service.js` | AWS SQS job queue |
-| Coaching | `shared/services/coaching.service.js` | OECD coaching analysis |
+| Queue | `shared/services/queue/index.js` | Pluggable via `QUEUE_DRIVER` (sqs \| bullmq) |
+| Coaching | `shared/services/coaching.service.js` | Multi-framework classroom observation (OECD, HOTS, TEACH, FICO, MEWAKA) |
 | Reading | `shared/services/reading-assessment.service.js` | Fluency assessment |
 | WhatsApp | `shared/services/whatsapp.service.js` | Message send/receive |
 

--- a/bot/scripts/setup/register-all-flows.js
+++ b/bot/scripts/setup/register-all-flows.js
@@ -1,10 +1,13 @@
 /**
  * Register All WhatsApp Flows
  *
- * Registers all 3 WhatsApp Flows with Meta's Graph API:
- *   1. Reading Assessment  (navigate type, no endpoint)
- *   2. Attendance Setup    (endpoint type, encrypted)
- *   3. Attendance Marking  (endpoint type, encrypted)
+ * Registers all WhatsApp Flows configured in flow-configs.js with Meta's Graph
+ * API. The set of flows registered is the set in flow-configs.js (currently 9:
+ * Reading Assessment, Attendance Setup, Attendance Marking, Settings, Status,
+ * Homework Request, Edit Class, Student Videos, Pic-to-LP Confirm). Adding a
+ * new flow = adding one entry to flow-configs.js — this script picks it up
+ * automatically. Every entry is registered idempotently (flows that already
+ * exist in Meta are skipped via findFlowByName).
  *
  * Uses MetaAPI for Graph API calls and SetupState for tracking
  * registration progress. Designed for idempotency — skips flows

--- a/docs/agent-customization.md
+++ b/docs/agent-customization.md
@@ -533,7 +533,6 @@ Open `bot/shared/config/reading-benchmarks.js` and replace the threshold numbers
 | `bot/shared/services/pdf-report.service.js` | Default (PDFKit) renderer — the shared OECD/HOTS/TEACH/FICO PDF layout |
 | `bot/shared/services/coaching/templates/mewaka-report.template.js` | MEWAKA's HTML template, rendered to PDF via Playwright (`shared/utils/html-to-pdf.js`) |
 | `bot/shared/services/coaching/report-generator.service.js` | Orchestrates report generation (transform analysis → `reportData`, call the renderer, upload + send the PDF) |
-| `bot/shared/services/chart.service.js` | Chart.js chart generation (bar charts, radar charts) |
 
 ### How report design is pluggable
 
@@ -566,14 +565,21 @@ const renderers = {
 };
 ```
 
-### Adding a Radar Chart
+### Adding charts (radar, bar, etc.)
 
-1. In `chart.service.js`, add a radar chart method:
-   ```javascript
-   static async generateRadarChart(labels, scores, maxScores) { ... }
-   ```
+Chart generation is **inlined into the report templates** (HTML
+renderers can use Chart.js via a CDN tag; the PDFKit renderer draws bars
+directly with `doc.rect()`). To add a new chart to a framework's report:
 
-2. In `report-generator.service.js`, call it during report generation and embed the chart image in the PDF.
+1. For an **HTML renderer** (e.g. MEWAKA, the hero report): edit the template
+   file (`*-report.template.js`) and include the chart markup inline.
+   Chart.js can be loaded from a CDN inside the HTML — the Playwright
+   renderer at `shared/utils/html-to-pdf.js` waits for `networkidle` so
+   the chart finishes drawing before the PDF is captured.
+2. For the **PDFKit renderer** (`pdf-report.service.js`): add a draw helper
+   that uses PDFKit's primitives (`doc.rect()`, `doc.path()`) to render the
+   chart shapes directly. PDFKit doesn't support `<canvas>`, so a third-party
+   library is not required.
 
 ---
 


### PR DESCRIPTION
Seven verified-broken doc claims from the harsh self-grading audit, plus the tier-system cleanup, plus the stale flow-comment fix.

## bd-1858 — verified-broken doc claims

| Location | Was | Now |
|---|---|---|
| \`.env.template:56\` | \"filled by \`npm run bootstrap:whatsapp\`\" (script doesn't exist) | \"Fill manually OR via \`npm run setup:flows\`\" + pointer to onboarding doc |
| \`.github/CONTRIBUTING.md:29\` | \`feature-tiers.js\` (file doesn't exist) | \`bot/shared/config/feature-availability.js\` (the real presence-gating file) |
| \`docs/agent-customization.md:536\` | table row for deleted \`chart.service.js\` | row removed |
| \`docs/agent-customization.md:569-577\` | \"Adding a Radar Chart\" recipe in deleted file | rewritten to document the actual current pattern (Chart.js via CDN in HTML renderers; PDFKit primitives) |
| \`CHANGELOG.md:26-27\` | \`(BUG-053)\` and \`(BUG-009)\` internal refs | stripped |
| \`bot/README.md:46\` | queue path → one driver | \`shared/services/queue/index.js\` + \`pluggable via QUEUE_DRIVER (sqs \| bullmq)\` |
| \`bot/README.md:47\` | coaching = OECD only | OECD, HOTS, TEACH, FICO, MEWAKA |

## bd-1859 — strip tier-system from GH templates + add CHANGELOG note

- \`.github/ISSUE_TEMPLATE/bug_report.md:24\` — removed \"Tier: Minimal/Recommended/Full\" field
- \`.github/ISSUE_TEMPLATE/setup_help.md:29\` — same
- \`CHANGELOG.md\` v1.1.0 — added explicit \"BREAKING (vs v1.0.0)\" note explaining that the three-tier system was removed and features are now presence-gated

## bd-1869 — register-all-flows.js stale header

Header said \"3 WhatsApp Flows\" when \`FLOW_CONFIGS.length === 9\`. Updated to refer to flow-configs.js as the source of truth, and made the comment forward-compatible (\"adding a new flow = adding one entry to flow-configs.js — this script picks it up automatically\").

## Verification

- 112 suites / 1285 tests green
- Source-hygiene clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)