### PR TITLE
ci: drop both `|| true` masks + add fresh-clone weekly smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,16 @@ jobs:
 
       - name: Verify no hardcoded credentials
         run: |
-          # Check for common credential patterns in source files
+          # Check for common credential patterns in source files. The `!` in
+          # front of the grep inverts the exit code: grep returns 0 on a hit
+          # (which means the credential leaked), and the `!` flips that to a
+          # non-zero exit so the step fails. The trailing `|| true` was a
+          # defensive mistake that silently masked any hit; removed so a
+          # real leak now actually fails CI.
           ! grep -rn 'EAAUmy\|eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.' \
             --include='*.js' --include='*.ts' --include='*.json' \
             --exclude-dir=node_modules --exclude-dir=.git \
-            bot/shared/ dashboard/ portal/ || true
+            bot/shared/ dashboard/ portal/ scripts/ infrastructure/
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,4 +58,4 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           echo "Checking deployment status..."
-          railway status || true
+          railway status

--- a/.github/workflows/fresh-clone-smoke.yml
+++ b/.github/workflows/fresh-clone-smoke.yml
@@ -1,0 +1,82 @@
+# Fresh-clone smoke test — verifies that someone running `git clone && npm
+# install && npm test` against the latest main gets a working repo. Runs:
+#
+#   - Weekly (Mondays 06:00 UTC) — catches passive rot in deps / npm / Node
+#   - Manual dispatch — re-verify on demand without pushing a commit
+#
+# The smoke is structured to exercise the path a NEW user takes:
+#   1. Fresh checkout (no prior installs)
+#   2. `npm install` at root + `npm ci` in bot/ (the documented install path)
+#   3. `node tests/run.js` (1280+ tests, ~15s)
+#   4. Cold-boot probe with EMPTY env — must show the friendly boot-fail
+#      box and exit cleanly with code 78, NOT a Node stack trace.
+#
+# Failures here surface as a notification to repo maintainers; a passing run
+# is silent (the green check is the signal).
+
+name: Fresh-clone smoke
+
+on:
+  schedule:
+    # Mondays 06:00 UTC. Late enough for npm registry to have processed any
+    # weekend point-release; early enough that maintainers see breakages
+    # before the work-week starts.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: Fresh-clone smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (clean)
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install root deps
+        run: npm install --no-audit --no-fund
+
+      - name: Install bot/ deps (npm ci — lockfile authoritative)
+        working-directory: bot
+        run: npm ci --no-audit --no-fund
+
+      - name: Run full test suite
+        run: node tests/run.js
+
+      - name: Cold-boot probe — bot must friendly-exit on missing required env
+        run: |
+          # Run with an empty env (only PATH + Node basics). Bot should print
+          # the friendly box and exit cleanly with code 78 — NOT a Node stack.
+          set +e
+          OUTPUT=$(env -i PATH=/usr/local/bin:/usr/bin:/bin NODE_PATH=node_modules \
+            node bot/whatsapp-bot.js 2>&1)
+          EXIT_CODE=$?
+          set -e
+          echo "Exit code: $EXIT_CODE"
+          echo "Output (first 30 lines):"
+          echo "$OUTPUT" | head -30
+
+          # Assert: exit code is 78 (sysexits EX_CONFIG).
+          if [ "$EXIT_CODE" -ne 78 ]; then
+            echo "::error::cold-boot exit code was $EXIT_CODE (expected 78). The bot should fail cleanly with a friendly box on missing required env, not crash with a Node stack."
+            exit 1
+          fi
+
+          # Assert: the friendly box header is present.
+          if ! echo "$OUTPUT" | grep -q "Rumi bot — boot aborted"; then
+            echo "::error::cold-boot stderr did not contain the friendly box header. The bot may be crashing instead of failing cleanly."
+            exit 1
+          fi
+
+          # Assert: NO Node stack trace.
+          if echo "$OUTPUT" | grep -q "at Module._compile\|node:internal/modules"; then
+            echo "::error::cold-boot stderr contained a Node stack trace. The friendly box should have replaced it."
+            exit 1
+          fi
+
+          echo "✓ Cold-boot probe passed — friendly box, exit 78, no Node stack."

--- a/tests/setup/ci-workflow-no-silent-masks.test.js
+++ b/tests/setup/ci-workflow-no-silent-masks.test.js
@@ -1,0 +1,66 @@
+/**
+ * No-silent-mask CI-workflow conformance.
+ *
+ * GitHub Actions step bodies that end with `|| true` silently suppress
+ * every non-zero exit code in the preceding pipeline. That's sometimes
+ * intentional (a cleanup step that mustn't fail the run if the resource
+ * was never created) but is most often a defensive mistake: a credential
+ * grep `! grep CREDENTIAL_PATTERN files || true` always succeeds — the
+ * `|| true` masks the very failure the step was added to catch.
+ *
+ * This guard locks the contract: every `|| true` in a CI workflow must
+ * appear in the `ALLOWED_MASKS` set below, with a documented reason. New
+ * masks added without a justification cause the test to fail; the
+ * developer must either remove the mask or add an entry here explaining
+ * why it's load-bearing.
+ *
+ * Scoped to `.github/workflows/*.yml`. Bash scripts elsewhere can use
+ * `|| true` freely.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOWS_DIR = path.resolve(__dirname, '../../.github/workflows');
+
+// Each entry: { file, line, rationale }. Keep tight; prefer removing masks
+// to allowlisting them. Each entry should explain what the mask is
+// load-bearing for.
+const ALLOWED_MASKS = [
+  // (intentionally empty post-bd-1866 — both prior masks were defensive
+  //  mistakes that have been removed)
+];
+
+function findMasks() {
+  if (!fs.existsSync(WORKFLOWS_DIR)) return [];
+  const files = fs
+    .readdirSync(WORKFLOWS_DIR)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+
+  const masks = [];
+  for (const file of files) {
+    const text = fs.readFileSync(path.join(WORKFLOWS_DIR, file), 'utf-8');
+    const lines = text.split('\n');
+    lines.forEach((line, i) => {
+      // Match `|| true` at end of line, ignoring trailing whitespace.
+      if (/\|\|\s+true\s*$/.test(line)) {
+        masks.push({ file, line: i + 1, content: line.trim() });
+      }
+    });
+  }
+  return masks;
+}
+
+describe('CI workflows — no silent `|| true` masks', () => {
+  it('every `|| true` mask is documented in ALLOWED_MASKS', () => {
+    const masks = findMasks();
+    const unjustified = masks.filter(
+      (m) =>
+        !ALLOWED_MASKS.some(
+          (allowed) => allowed.file === m.file && allowed.line === m.line
+        )
+    );
+
+    expect(unjustified).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two CI workflows had \`|| true\` masks that defeated the very check they were added to enforce. Fixed both + added a guard test + added a weekly fresh-clone smoke workflow.

## Changes

1. **\`.github/workflows/ci.yml:45\`** — the credential-pattern grep ended with \`|| true\`, meaning a real leak was silently masked. Removed the mask. The \`!\` in front of \`grep\` already inverts the exit code so the step fails on a hit; \`|| true\` was a defensive mistake. Also widened the scope to include \`scripts/\` and \`infrastructure/\`.

2. **\`.github/workflows/deploy.yml:61\`** — \`railway status || true\` silently passed even when the deploy verification failed. Mask removed.

3. **\`tests/setup/ci-workflow-no-silent-masks.test.js\` (new)** — locks the contract: every \`|| true\` in any workflow must be in an explicit \`ALLOWED_MASKS\` list with a documented rationale. Empty allowlist.

4. **\`.github/workflows/fresh-clone-smoke.yml\` (new)** — weekly (Mondays 06:00 UTC) + on-demand smoke that exercises the path a NEW user takes: fresh checkout → \`npm install\` → \`npm ci\` → full test suite → cold-boot probe with empty env. The cold-boot probe asserts exit code 78 + the friendly box header + NO Node stack trace.

## Verification

- **113 suites / 1286 tests** green (+1 new ci-mask guard)
- Source-hygiene clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)