### PR TITLE
fix(exam-checker): persist grades against the real per-question schema + gate on Mistral OR Chandra

### DIFF
--- a/bot/scripts/setup/doctor.js
+++ b/bot/scripts/setup/doctor.js
@@ -87,10 +87,28 @@ function analyzeEnv(env) {
   const missingRequired = REQUIRED_VARS.filter((k) => !isSet(env[k]));
 
   const features = FEATURES.map((f) => {
+    // Features may declare keys two ways:
+    //   - `keys`     → ALL required (the default, conjunctive)
+    //   - `keysAny`  → ANY one suffices (e.g. exam-checker OCR: Mistral OR Chandra)
     // A feature with no env keys (e.g. Chromium) is keyed off its probe, not env.
-    const missingKeys = f.keys.filter((k) => !isSet(env[k]));
-    const available = f.keys.length > 0 ? missingKeys.length === 0 : null; // null = "ask the probe"
-    return { name: f.name, requiredKeys: f.keys, missingKeys, available, probe: f.probe || null, notes: f.notes || null };
+    if (Array.isArray(f.keysAny)) {
+      const presentKeys = f.keysAny.filter((k) => isSet(env[k]));
+      const missingKeys = presentKeys.length > 0 ? [] : [...f.keysAny];
+      const available = presentKeys.length > 0;
+      return {
+        name: f.name,
+        requiredKeys: f.keysAny,
+        missingKeys,
+        available,
+        probe: f.probe || null,
+        notes: f.notes || null,
+        anyOf: true,
+      };
+    }
+    const keys = f.keys || [];
+    const missingKeys = keys.filter((k) => !isSet(env[k]));
+    const available = keys.length > 0 ? missingKeys.length === 0 : null; // null = "ask the probe"
+    return { name: f.name, requiredKeys: keys, missingKeys, available, probe: f.probe || null, notes: f.notes || null };
   });
 
   return { requiredPresent, missingRequired, features };

--- a/bot/shared/config/feature-availability.js
+++ b/bot/shared/config/feature-availability.js
@@ -37,7 +37,15 @@ const FEATURES = [
   // gate — adding it would mark the feature OFF whenever the env var is unset,
   // which is the wrong semantics (you can set the key and gate it independently).
   { name: 'Video generation (Kie.ai)', keys: ['KIE_API_KEY'], notes: 'Also requires VIDEO_GENERATION_ENABLED=true at runtime.' },
-  { name: 'Exam-checker OCR (Mistral vision)', keys: ['MISTRAL_API_KEY'] },
+  // Exam-checker OCR has TWO supported backends — Mistral Vision (primary)
+  // and Chandra / Datalab (fallback). The OCR service tries Mistral when
+  // MISTRAL_API_KEY is set, falls back to Chandra when CHANDRA_API_KEY is
+  // set. The feature is therefore available iff EITHER key is present;
+  // `keysAny` carries that disjunction semantics (vs `keys` which is AND).
+  {
+    name: 'Exam-checker OCR (Mistral or Chandra)',
+    keysAny: ['MISTRAL_API_KEY', 'CHANDRA_API_KEY'],
+  },
   { name: 'Observability (Axiom)', keys: ['AXIOM_DATASET', 'AXIOM_TOKEN'] },
 ];
 
@@ -52,9 +60,18 @@ function missingRequired(env = process.env) {
   return REQUIRED_VARS.filter((k) => !isSet(env[k]));
 }
 
-/** Is a single feature (by display name or its keys array) available? */
+/**
+ * Is a single feature (by display name, entry object, or keys array)
+ * available? An entry with `keys` requires ALL listed env vars; an entry
+ * with `keysAny` requires AT LEAST ONE (e.g. exam-checker OCR works with
+ * Mistral OR Chandra). Passing a bare array of strings keeps the legacy
+ * AND-semantics call shape that downstream code relies on.
+ */
 function isFeatureAvailable(feature, env = process.env) {
   const entry = typeof feature === 'string' ? FEATURES.find((f) => f.name === feature) : feature;
+  if (entry && Array.isArray(entry.keysAny)) {
+    return entry.keysAny.some((k) => isSet(env[k]));
+  }
   const keys = entry && entry.keys ? entry.keys : Array.isArray(feature) ? feature : null;
   if (!keys) return false;
   return keys.every((k) => isSet(env[k]));

--- a/bot/shared/services/exam-checker/grading.service.js
+++ b/bot/shared/services/exam-checker/grading.service.js
@@ -76,7 +76,7 @@ class GradingService {
           successful.push(result);
 
           // Save to database
-          await this._saveGrade(session.id, student, result);
+          await this._saveGrade(session, student, result);
         } catch (error) {
           logToFile('❌ Grading failed for student', {
             student: student.name,
@@ -366,30 +366,131 @@ Maximum Marks: ${question.marks || 1}`
   }
 
   /**
-   * Save grade to database
-   * @param {string} sessionId - Session ID
-   * @param {object} student - Student info
-   * @param {object} result - Grading result
+   * Save a graded submission to the database.
+   *
+   * The schema is normalised across two tables:
+   *   - `exam_submissions` — one row per (session, student): image references,
+   *     extracted text, status. The summary view (total marks / percentage)
+   *     is computed at read time, not stored here.
+   *   - `exam_grades` — one row per (submission, question): awarded marks,
+   *     rationale, structured Feed Up/Back/Forward. Unique-indexed on
+   *     `(submission_id, question_id)` so re-grading is idempotent.
+   *
+   * Before this fix, `_saveGrade()` upserted a per-STUDENT summary row into
+   * `exam_grades` with columns (`session_id`, `student_name`, `total_marks`,
+   * `marks_obtained`, `percentage`, `grade`, `question_breakdown`,
+   * `graded_at`) — none of which exist in the schema. Every grading run
+   * silently failed to persist.
+   *
+   * @param {object} session - Exam session (read for image_urls + ocr_results)
+   * @param {object} student - Student info (name, rollNumber, pageNumbers)
+   * @param {object} result  - Grading result from `gradeStudent()`
    */
-  static async _saveGrade(sessionId, student, result) {
-    const { error } = await supabase
-      .from('exam_grades')
-      .upsert({
-        session_id: sessionId,
-        student_name: student.name,
-        roll_number: student.rollNumber,
-        total_marks: result.totalMarks,
-        marks_obtained: result.marksAwarded,
-        percentage: result.percentage,
-        grade: result.grade,
-        question_breakdown: result.questionResults,
-        graded_at: result.gradedAt
-      }, {
-        onConflict: 'session_id,student_name'
-      });
+  static async _saveGrade(session, student, result) {
+    const sessionId = session.id;
+    const studentPages = student.pageNumbers || [];
 
-    if (error) {
-      logToFile('⚠️ Failed to save grade to DB', { error: error.message });
+    // Slice the per-student image set out of the session-level array. Page
+    // numbers are 1-indexed in the OCR layer; convert to 0-indexed for array
+    // lookup. Empty array when pageNumbers is missing — image_urls is NOT
+    // NULL on exam_submissions so we provide [] not null.
+    const allImages = session.original_images || [];
+    const studentImageUrls = studentPages.length > 0
+      ? studentPages.map(p => allImages[p - 1]).filter(Boolean)
+      : [];
+
+    // 1) Upsert the exam_submissions row. The schema has no unique
+    //    constraint on (session_id, student_name) so we look it up
+    //    explicitly and update-or-insert.
+    const { data: existing, error: lookupError } = await supabase
+      .from('exam_submissions')
+      .select('id')
+      .eq('session_id', sessionId)
+      .eq('student_name', student.name)
+      .maybeSingle();
+
+    if (lookupError) {
+      logToFile('⚠️ Failed to look up exam submission', {
+        sessionId, studentName: student.name, error: lookupError.message,
+      });
+      return;
+    }
+
+    let submissionId;
+    if (existing) {
+      submissionId = existing.id;
+      const { error: updateError } = await supabase
+        .from('exam_submissions')
+        .update({
+          image_urls: studentImageUrls,
+          page_numbers: studentPages,
+          extracted_answers: { questionResults: result.questionResults },
+          status: 'graded',
+        })
+        .eq('id', submissionId);
+      if (updateError) {
+        logToFile('⚠️ Failed to update exam submission', {
+          submissionId, error: updateError.message,
+        });
+        return;
+      }
+    } else {
+      const { data: newSubmission, error: insertError } = await supabase
+        .from('exam_submissions')
+        .insert({
+          session_id: sessionId,
+          student_name: student.name,
+          image_urls: studentImageUrls,
+          page_numbers: studentPages,
+          extracted_answers: { questionResults: result.questionResults },
+          status: 'graded',
+        })
+        .select('id')
+        .single();
+      if (insertError || !newSubmission) {
+        logToFile('⚠️ Failed to insert exam submission', {
+          sessionId, studentName: student.name,
+          error: insertError ? insertError.message : 'no row returned',
+        });
+        return;
+      }
+      submissionId = newSubmission.id;
+    }
+
+    // 2) Upsert per-question grade rows. The (submission_id, question_id)
+    //    unique index makes re-grading idempotent — a second run replaces
+    //    prior grades rather than duplicating them.
+    const gradeRows = result.questionResults.map((qr) => {
+      const max = qr.maxMarks ?? 0;
+      const awarded = qr.marksAwarded ?? 0;
+      const isCorrect = max > 0 ? awarded >= max : null;
+      const isPartial = max > 0 ? awarded > 0 && awarded < max : false;
+      return {
+        submission_id: submissionId,
+        question_id: qr.questionId,
+        question_type: qr.questionType || 'unknown',
+        max_marks: max,
+        awarded_marks: awarded,
+        is_correct: isCorrect,
+        is_partial: isPartial,
+        grading_rationale: qr.feedback || null,
+        confidence: qr.confidence ?? null,
+        feedback_up: qr.structuredFeedback?.feedUp || null,
+        feedback_back: qr.structuredFeedback?.feedBack || null,
+        feedback_forward: qr.structuredFeedback?.feedForward || null,
+      };
+    });
+
+    if (gradeRows.length === 0) return;
+
+    const { error: gradesError } = await supabase
+      .from('exam_grades')
+      .upsert(gradeRows, { onConflict: 'submission_id,question_id' });
+
+    if (gradesError) {
+      logToFile('⚠️ Failed to upsert exam_grades rows', {
+        submissionId, count: gradeRows.length, error: gradesError.message,
+      });
     }
   }
 }

--- a/tests/exam-checker/grading-service.test.js
+++ b/tests/exam-checker/grading-service.test.js
@@ -1,0 +1,145 @@
+/**
+ * GradingService._saveGrade — schema-shape contract.
+ *
+ * Before this fix, `_saveGrade` upserted a per-STUDENT summary into the
+ * `exam_grades` table using columns (`session_id`, `student_name`,
+ * `total_marks`, `marks_obtained`, `percentage`, `grade`,
+ * `question_breakdown`, `graded_at`) — none of which exist on
+ * `exam_grades`. Every grading run silently failed to persist.
+ *
+ * The fix normalises the writes to match the schema:
+ *   - One INSERT (or UPDATE) into `exam_submissions` per (session, student)
+ *   - One INSERT per question into `exam_grades`, unique-keyed on
+ *     `(submission_id, question_id)` for idempotent re-grading
+ *
+ * This test pins the contract via a tracking Supabase mock — it asserts
+ * the table names + column names + chained methods, not the row contents.
+ * If `_saveGrade` ever regresses to the per-student shape, this fails fast.
+ */
+
+const path = require('path');
+
+jest.mock('../../bot/shared/config/supabase', () => {
+  // Capture every chained call so the test can assert table + payload shape.
+  const calls = [];
+  const builder = (table) => {
+    const ctx = { table, ops: [], _filters: [], _payload: null };
+    const noopThen = (resolve) => Promise.resolve({ data: null, error: null }).then(resolve);
+    const fluent = {
+      select() { ctx.ops.push('select'); return fluent; },
+      insert(payload) { ctx.ops.push('insert'); ctx._payload = payload; calls.push(ctx); return fluent; },
+      update(payload) { ctx.ops.push('update'); ctx._payload = payload; calls.push(ctx); return fluent; },
+      upsert(payload, opts) { ctx.ops.push('upsert'); ctx._payload = payload; ctx._opts = opts; calls.push(ctx); return fluent; },
+      eq(col, val) { ctx._filters.push([col, val]); return fluent; },
+      maybeSingle() {
+        // For the "look up existing submission" path, return null (no existing).
+        return Promise.resolve({ data: null, error: null });
+      },
+      single() {
+        // For ".select('id').single()" after insert — return a synthetic UUID.
+        return Promise.resolve({ data: { id: '00000000-0000-0000-0000-000000000999' }, error: null });
+      },
+      then: noopThen,
+    };
+    return fluent;
+  };
+  return {
+    from(table) {
+      // First lookup call (.from('exam_submissions').select('id').eq.eq.maybeSingle)
+      // returns no existing row. Subsequent insert/upsert tracked.
+      return builder(table);
+    },
+    __mockCalls: () => calls,
+    __resetMock: () => { calls.length = 0; },
+  };
+});
+
+jest.mock('../../bot/shared/services/llm-client', () => ({
+  getClient: () => ({}),
+}));
+
+jest.mock('../../bot/shared/services/exam-checker/grading-scale.service', () => ({
+  getFullReport: () => ({ grade: 'A' }),
+  convert: () => 'A',
+}));
+
+jest.mock('../../bot/shared/services/exam-checker/feedback.service', () => ({
+  generate: () => ({ feedUp: '', feedBack: '', feedForward: '' }),
+  generateOverall: () => ({ summary: '' }),
+}));
+
+const supabase = require('../../bot/shared/config/supabase');
+const GradingService = require('../../bot/shared/services/exam-checker/grading.service');
+
+describe('GradingService._saveGrade — schema-shape contract', () => {
+  beforeEach(() => supabase.__resetMock());
+
+  it('writes to exam_submissions then exam_grades, NOT a non-existent column on exam_grades', async () => {
+    const session = {
+      id: 'session-123',
+      original_images: ['https://example.test/page1.jpg', 'https://example.test/page2.jpg'],
+    };
+    const student = {
+      name: 'Asha',
+      rollNumber: 'R-001',
+      pageNumbers: [1, 2],
+    };
+    const result = {
+      gradedAt: new Date().toISOString(),
+      questionResults: [
+        { questionId: 'Q1', questionType: 'mcq', maxMarks: 2, marksAwarded: 2, feedback: 'Correct!' },
+        { questionId: 'Q2', questionType: 'short', maxMarks: 5, marksAwarded: 3, feedback: 'Partial.' },
+      ],
+    };
+
+    await GradingService._saveGrade(session, student, result);
+
+    const calls = supabase.__mockCalls();
+    const tables = calls.map((c) => c.table);
+
+    // The contract: at minimum one exam_submissions write + one exam_grades write.
+    expect(tables).toContain('exam_submissions');
+    expect(tables).toContain('exam_grades');
+
+    // Per-student summary columns (the OLD broken shape) MUST NOT appear on exam_grades writes.
+    const gradesWrites = calls.filter((c) => c.table === 'exam_grades');
+    for (const w of gradesWrites) {
+      const payload = Array.isArray(w._payload) ? w._payload : [w._payload];
+      for (const row of payload) {
+        // These are the per-STUDENT summary columns that don't exist on exam_grades.
+        for (const forbidden of ['total_marks', 'marks_obtained', 'percentage', 'grade', 'session_id', 'student_name', 'roll_number', 'question_breakdown', 'graded_at']) {
+          expect(Object.keys(row)).not.toContain(forbidden);
+        }
+        // These are the per-QUESTION columns that DO exist on exam_grades.
+        expect(Object.keys(row)).toEqual(expect.arrayContaining(['submission_id', 'question_id', 'max_marks', 'awarded_marks']));
+      }
+    }
+
+    // The exam_grades upsert MUST use the (submission_id, question_id) unique key.
+    const gradesUpsert = gradesWrites.find((w) => w.ops.includes('upsert'));
+    expect(gradesUpsert).toBeDefined();
+    expect(gradesUpsert._opts).toMatchObject({ onConflict: 'submission_id,question_id' });
+  });
+
+  it('produces one exam_grades row per question in the grading result', async () => {
+    const session = { id: 's', original_images: [] };
+    const student = { name: 'Bob', pageNumbers: [] };
+    const result = {
+      gradedAt: new Date().toISOString(),
+      questionResults: [
+        { questionId: 'Q1', maxMarks: 1, marksAwarded: 1 },
+        { questionId: 'Q2', maxMarks: 1, marksAwarded: 0 },
+        { questionId: 'Q3', maxMarks: 1, marksAwarded: 1 },
+      ],
+    };
+
+    await GradingService._saveGrade(session, student, result);
+
+    const calls = supabase.__mockCalls();
+    const gradesWrite = calls.find((c) => c.table === 'exam_grades' && c.ops.includes('upsert'));
+    expect(gradesWrite).toBeDefined();
+    expect(Array.isArray(gradesWrite._payload)).toBe(true);
+    expect(gradesWrite._payload).toHaveLength(3);
+    expect(gradesWrite._payload.map((r) => r.question_id).sort()).toEqual(['Q1', 'Q2', 'Q3']);
+  });
+});

--- a/tests/setup/column-completeness.test.js
+++ b/tests/setup/column-completeness.test.js
@@ -28,11 +28,14 @@ const BOT_DIR = path.resolve(__dirname, '../../bot');
 // Adding a column here is a deliberate, reviewed decision — prefer fixing the
 // schema (add the column) or the code (stop referencing it).
 const ALLOWLIST = {
-  // Pre-existing PROD inconsistency, faithfully mirrored: the OSS exam_grades is
-  // the per-QUESTION table (identical to prod's 015_exam_checker.sql). grading.service
-  // _saveGrade writes a per-STUDENT summary shape — this mismatch exists in prod too
-  // and is out of scope for OSS schema parity (the schema correctly mirrors prod).
-  exam_grades: ['grade', 'graded_at', 'marks_obtained', 'percentage', 'question_breakdown', 'roll_number', 'session_id', 'student_name', 'total_marks'],
+  // (exam_grades formerly held a per-STUDENT shape that didn't exist on the
+  // per-QUESTION schema; resolved by rewriting `_saveGrade()` to insert into
+  // `exam_submissions` then `exam_grades` keyed on (submission_id, question_id))
+  // `onconflict` is the Supabase `{ onConflict: '...' }` upsert OPTION, not a
+  // column. The parser picks it up because the rows argument is a variable
+  // (`.upsert(gradeRows, { onConflict: 'submission_id,question_id' })`) so the
+  // first object literal it sees after `.upsert(` is the options object.
+  exam_grades: ['onconflict'],
   // conversation_state is a coaching_sessions column mis-attributed to conversations
   // by chain proximity (parser artifact). (The stale context_data write was removed —
   // comprehension state lives in Redis, see redis-comprehension.service.)

--- a/tests/unit/sprint-1/feature-availability.test.js
+++ b/tests/unit/sprint-1/feature-availability.test.js
@@ -39,9 +39,25 @@ describe('feature-availability (presence-based gating)', () => {
     expect(fa.isFeatureAvailable(azure, { ...FULL_ENV, AZURE_SPEECH_KEY: 'k', AZURE_SPEECH_REGION: 'eastus' })).toBe(true);
   });
 
-  it('exam-checker keys on MISTRAL_API_KEY (verified against code), not AWS Textract', () => {
+  it('exam-checker gate is the disjunction of Mistral OR Chandra (matches OCR code)', () => {
+    // The OCR service tries Mistral first (MISTRAL_API_KEY), then falls
+    // back to Chandra (CHANDRA_API_KEY). The gate must reflect that: the
+    // feature is available iff EITHER key is configured.
     const exam = fa.FEATURES.find((f) => f.name.includes('Exam'));
-    expect(exam.keys).toEqual(['MISTRAL_API_KEY']);
+    expect(exam.keysAny).toEqual(['MISTRAL_API_KEY', 'CHANDRA_API_KEY']);
+    expect(exam.keys).toBeUndefined();
+  });
+
+  it('isFeatureAvailable honours `keysAny` (any-of) semantics', () => {
+    const exam = fa.FEATURES.find((f) => f.name.includes('Exam'));
+    // Neither key set — feature OFF
+    expect(fa.isFeatureAvailable(exam, FULL_ENV)).toBe(false);
+    // Mistral only — feature ON
+    expect(fa.isFeatureAvailable(exam, { ...FULL_ENV, MISTRAL_API_KEY: 'k' })).toBe(true);
+    // Chandra only — feature ON
+    expect(fa.isFeatureAvailable(exam, { ...FULL_ENV, CHANDRA_API_KEY: 'k' })).toBe(true);
+    // Both set — feature ON
+    expect(fa.isFeatureAvailable(exam, { ...FULL_ENV, MISTRAL_API_KEY: 'k', CHANDRA_API_KEY: 'k' })).toBe(true);
   });
 
   it('availableFeatures reflects exactly the keys provided', () => {


### PR DESCRIPTION
## Why

Two latent defects shipped together because the prod-side schema and prod-side code had drifted apart and no test exercised the integration:

### 1. `_saveGrade()` wrote columns that don't exist on `exam_grades`

`bot/shared/services/exam-checker/grading.service.js` upserted a per-STUDENT summary into the per-QUESTION `exam_grades` table:

```javascript
exam_grades.upsert({
  session_id, student_name, roll_number, total_marks,
  marks_obtained, percentage, grade, question_breakdown, graded_at,
})
```

But `exam_grades` is defined as `(id, submission_id, question_id, question_type, max_marks, awarded_marks, is_correct, is_partial, grading_rationale, confidence, feedback_up, feedback_back, feedback_forward, …)`. **None of the columns the code wrote actually exist on the table** — every grading run silently failed to persist. The mocked-Supabase test mock never noticed, and the column-completeness guard had an allowlist entry mirroring the broken contract.

### 2. Exam-checker feature gate ignored the Chandra fallback

`feature-availability.js` listed the gate as `{ name: 'Exam-checker OCR (Mistral vision)', keys: ['MISTRAL_API_KEY'] }` — but `ocr.service.js` has TWO backends:

- `_extractWithMistral` → reads `MISTRAL_API_KEY`
- `_extractWithChandra` → reads `CHANDRA_API_KEY` (Datalab/Surya)

So a deployment with only `CHANDRA_API_KEY` was technically working (OCR succeeds via the Chandra path) while `availableFeatures()` and `doctor` reported the feature as OFF.

## What

### Schema-correct persistence (bd-1868)

Rewrote `_saveGrade()` to follow the normalised schema:

- One upsert (lookup-then-insert-or-update) into `exam_submissions` per (session_id, student_name) — the per-student row carrying `image_urls`, `page_numbers`, `extracted_answers`, `status='graded'`.
- One upsert into `exam_grades` per question, keyed on the existing unique index `(submission_id, question_id)` so re-grading is idempotent.

Removed the `exam_grades` entry from the column-completeness allowlist (the broken contract is gone). Added a single artifact entry for `onconflict` which the parser surfaces as a "column" because the rows argument is a variable: `.upsert(gradeRows, { onConflict: '…' })` puts the options object next-to-`.upsert(`, so the parser walks into it.

### Disjunctive feature gate (bd-1870)

Added `keysAny` semantics alongside the existing `keys`:

| Field | Meaning |
|-------|---------|
| `keys`    | ALL required (AND, default) |
| `keysAny` | ANY one required (OR) |

Updated the exam-checker entry to `keysAny: ['MISTRAL_API_KEY', 'CHANDRA_API_KEY']`. Taught `isFeatureAvailable()` to honour `keysAny` (the `some()` path) before falling through to the `keys`/array-of-strings path that downstream callers rely on. Extended `bot/scripts/setup/doctor.js`'s `analyzeEnv()` to compute `available` from "at least one keysAny is present" — its report now shows the disjunction correctly and never crashes on a feature that lacks `keys`.

## Files changed (6)

| File | Change |
|------|--------|
| `bot/shared/services/exam-checker/grading.service.js` | Rewrote `_saveGrade()` to write `exam_submissions` then `exam_grades` per the actual schema. Caller signature updated (passes `session`, not just `sessionId`). |
| `bot/shared/config/feature-availability.js` | Added `keysAny` semantics to `isFeatureAvailable()`; replaced the exam-checker entry's `keys: ['MISTRAL_API_KEY']` with `keysAny: ['MISTRAL_API_KEY', 'CHANDRA_API_KEY']`. |
| `bot/scripts/setup/doctor.js` | `analyzeEnv()` now handles features declaring `keysAny` (presence-of-any) without crashing on the absent `keys` field. |
| `tests/exam-checker/grading-service.test.js` | **NEW** — tracking-Supabase-mock test pinning the schema-shape contract: asserts table names, the unique-conflict key, and EXPLICITLY rejects the old broken column set. |
| `tests/unit/sprint-1/feature-availability.test.js` | Replaced "exam-checker keys on MISTRAL_API_KEY" with the disjunction variant; added a parametric test exercising the four `keysAny` configurations (neither / Mistral only / Chandra only / both). |
| `tests/setup/column-completeness.test.js` | Removed per-student `exam_grades` allowlist; added a single `onconflict` parser-artifact entry with a comment. |

## Verification

- `node tests/run.js`: **120 suites / 1299 tests pass** (was 119 / 1296; +1 suite for the new grading-service contract test, +3 net tests after the feature-availability rewrite)
- Source-hygiene green
- Diff: 6 files changed; ~+140 / -25 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)