### PR TITLE
fix(flows): recognise the 8 endpoint-only flow NFM_REPLYs (no more "Unknown flow ID")

### DIFF
--- a/bot/shared/handlers/flow-response.handler.js
+++ b/bot/shared/handlers/flow-response.handler.js
@@ -1,12 +1,36 @@
 /**
  * WhatsApp Flow Response Handler
- * Handles responses from WhatsApp Flow templates
  *
- * Current Flows:
- * 1. Registration Flow (handled in registration.service.js)
- * 2. Reading Assessment Flow (ID: 819028084215847) - handled here
- * 3. Attendance Setup Flow - class setup for first-time users
- * 4. Attendance Marking Flow - tap-to-mark absent students
+ * Routes the WhatsApp NFM_REPLY payload (the message Meta sends to the bot
+ * when a teacher submits a Flow) to the right per-flow processor — or,
+ * for endpoint-data-exchange flows, recognises the completion and logs it
+ * for telemetry. Flow IDs are read from env vars; the canonical mapping
+ * lives in `bot/scripts/setup/flow-configs.js`.
+ *
+ * ─── Endpoint flows vs navigate flows ───────────────────────────────
+ * Endpoint flows (data_exchange) — the teacher's screen-by-screen input
+ *   round-trips through a server endpoint mounted under `/api/flows/...`
+ *   (registered in `bot/shared/routes/flow-endpoint.routes.js`). By the
+ *   time Meta sends the NFM_REPLY, the data has ALREADY been persisted
+ *   by the endpoint; the NFM_REPLY is a delivery acknowledgement, not a
+ *   data carrier. Examples: Settings, Status, Homework Request, Edit
+ *   Class, Student Videos, Pic-to-LP Confirm, Quiz Manager, Registration.
+ *   The attendance flows are the exception (see below).
+ *
+ * Navigate flows — no server endpoint; the entire form is rendered
+ *   client-side and the data arrives ONLY in the NFM_REPLY response_json.
+ *   The handler must parse it and do the work. Example: Reading
+ *   Assessment.
+ *
+ * Attendance Setup / Marking are endpoint flows whose NFM_REPLY ALSO
+ *   carries the final committed state because some downstream actions
+ *   (success ack message, class-roster delivery) live on the NFM side
+ *   rather than in the endpoint route. They are routed explicitly below.
+ *
+ * For the remaining endpoint flows, this handler logs the completion
+ * (so a debugger trying to confirm a teacher actually submitted has a
+ * trail) but does NOT re-process the payload — that would double-write
+ * the data the endpoint already saved.
  *
  * Flow Response Structure:
  * {
@@ -30,14 +54,38 @@ const AttendanceFlowHandler = require('./attendance-flow.handler');
 const AttendanceDeliveryService = require('../services/attendance-delivery.service');
 const { logToFile } = require('../utils/logger');
 
-// Flow IDs - configure via environment variables
+// Flow IDs - configure via environment variables. Canonical list lives in
+// `bot/scripts/setup/flow-configs.js`; this file only reads the IDs that
+// either dispatch to a NFM-handler function or warrant explicit completion
+// logging.
+
+// Navigate flow (no server endpoint — NFM_REPLY carries the entire payload).
 const READING_ASSESSMENT_FLOW_ID = process.env.READING_ASSESSMENT_FLOW_ID || '';
 
-// Attendance Flow IDs
+// Endpoint flows whose NFM_REPLY drives downstream side effects (ack message,
+// roster delivery). The endpoint route persists the data; this handler
+// continues from there.
 const ATTENDANCE_SETUP_FLOW_ID = process.env.ATTENDANCE_SETUP_FLOW_ID || '';
 const ATTENDANCE_MARKING_FLOW_ID = process.env.ATTENDANCE_MARKING_FLOW_ID || '';
 
-// Registration Flow ID
+// Endpoint flows whose NFM_REPLY is purely a delivery acknowledgement —
+// data is already persisted by the corresponding `/api/flows/<path>` route.
+// Tracked here so completion is observable in logs (vs the previous
+// "Unknown flow ID" warning that read like a routing bug).
+const ENDPOINT_ONLY_FLOWS = [
+  { name: 'Registration',      envVar: 'REGISTRATION_FLOW_ID',      endpoint: '/api/flows/registration' },
+  { name: 'Settings',          envVar: 'SETTINGS_FLOW_ID',          endpoint: '/api/flows/settings' },
+  { name: 'Status',            envVar: 'STATUS_FLOW_ID',            endpoint: '/api/flows/status' },
+  { name: 'Homework Request',  envVar: 'HOMEWORK_FLOW_ID',          endpoint: '/api/flows/homework-request' },
+  { name: 'Edit Class',        envVar: 'EDIT_CLASS_FLOW_ID',        endpoint: '/api/flows/edit-class' },
+  { name: 'Student Videos',    envVar: 'STUDENT_VIDEOS_FLOW_ID',    endpoint: '/api/flows/student-videos' },
+  { name: 'Pic-to-LP Confirm', envVar: 'PIC_LP_FLOW_ID',            endpoint: '/api/flows/pic-lp' },
+  { name: 'Quiz Manager',      envVar: 'QUIZ_FLOW_ID',              endpoint: '/api/flows/quiz' },
+];
+
+// Legacy reference — keep the symbol exported so any downstream import
+// of this module continues to resolve. The endpoint-only routing block
+// below handles the lookup.
 const REGISTRATION_FLOW_ID = process.env.REGISTRATION_FLOW_ID || '';
 
 /**
@@ -60,18 +108,39 @@ async function handleFlowResponse(message, phoneNumber, userId) {
       flowId
     });
 
-    // Route to appropriate handler based on flow ID
-    if (flowId === READING_ASSESSMENT_FLOW_ID) {
+    // Navigate flow — Reading Assessment carries the entire submission in
+    // NFM_REPLY; we extract + persist here.
+    if (flowId && flowId === READING_ASSESSMENT_FLOW_ID) {
       return await handleReadingAssessmentFlow(message, phoneNumber, userId);
     }
 
-    // Attendance flows
-    if (flowId === ATTENDANCE_SETUP_FLOW_ID && ATTENDANCE_SETUP_FLOW_ID) {
+    // Attendance flows are endpoint flows whose NFM_REPLY ALSO triggers
+    // downstream side effects (success ack message + roster delivery).
+    if (flowId && flowId === ATTENDANCE_SETUP_FLOW_ID) {
       return await handleAttendanceSetupFlow(message, phoneNumber, userId);
     }
-
-    if (flowId === ATTENDANCE_MARKING_FLOW_ID && ATTENDANCE_MARKING_FLOW_ID) {
+    if (flowId && flowId === ATTENDANCE_MARKING_FLOW_ID) {
       return await handleAttendanceMarkingFlow(message, phoneNumber, userId);
+    }
+
+    // Endpoint-only flows: the corresponding `/api/flows/<path>` route has
+    // ALREADY persisted the teacher's input by the time we see NFM_REPLY.
+    // We log completion (useful when debugging "did the teacher actually
+    // submit?") and return true — re-processing the payload here would
+    // double-write the data.
+    for (const flow of ENDPOINT_ONLY_FLOWS) {
+      const configuredId = process.env[flow.envVar] || '';
+      if (configuredId && flowId === configuredId) {
+        logToFile('📋 Endpoint-flow NFM completion received', {
+          flowName: flow.name,
+          flowId,
+          endpoint: flow.endpoint,
+          phoneNumber,
+          userId,
+          note: 'Data was persisted by the endpoint route; NFM is delivery ack only',
+        });
+        return true;
+      }
     }
 
     logToFile('⚠️ Unknown flow ID', { flowId, flowName });

--- a/tests/flow-response/endpoint-flow-routing.test.js
+++ b/tests/flow-response/endpoint-flow-routing.test.js
@@ -1,0 +1,108 @@
+/**
+ * Flow-response handler — endpoint-flow NFM_REPLY routing contract.
+ *
+ * Before this fix, only 3 flow IDs were routed (READING_ASSESSMENT_FLOW_ID +
+ * the two ATTENDANCE_*_FLOW_IDs). The other 8 endpoint flows — Settings,
+ * Status, Homework Request, Edit Class, Student Videos, Pic-to-LP Confirm,
+ * Quiz Manager, Registration — each landed on the catch-all
+ * `'⚠️ Unknown flow ID'` warning log and the function returned `false`,
+ * which read like a real routing bug in the field.
+ *
+ * In reality those flows are data_exchange endpoint flows: their actual
+ * submission was persisted by the corresponding `/api/flows/<path>` route
+ * BEFORE the NFM_REPLY arrived. The NFM is just a delivery ack.
+ *
+ * This contract asserts: when a configured endpoint-flow ID arrives, the
+ * handler returns true AND emits a structured "endpoint-flow NFM
+ * completion" log (so debugging can confirm the round-trip), NOT the
+ * unknown-flow warning.
+ */
+
+const path = require('path');
+
+jest.mock('../../bot/shared/config/supabase', () => ({}));
+jest.mock('../../bot/shared/services/whatsapp.service', () => ({
+  sendMessage: jest.fn(),
+}));
+jest.mock('../../bot/shared/services/reading/passage-generation.service', () => ({}));
+jest.mock('../../bot/shared/services/reading/auto-level-orchestrator.service', () => ({}));
+jest.mock('../../bot/shared/handlers/attendance-flow.handler', () => ({}));
+jest.mock('../../bot/shared/services/attendance-delivery.service', () => ({}));
+
+const mockLogSpy = jest.fn();
+jest.mock('../../bot/shared/utils/logger', () => ({
+  logToFile: (...args) => mockLogSpy(...args),
+}));
+
+const ENDPOINT_FLOWS = {
+  SETTINGS_FLOW_ID: { id: '111111', name: 'Settings', endpoint: '/api/flows/settings' },
+  STATUS_FLOW_ID: { id: '222222', name: 'Status', endpoint: '/api/flows/status' },
+  HOMEWORK_FLOW_ID: { id: '333333', name: 'Homework Request', endpoint: '/api/flows/homework-request' },
+  EDIT_CLASS_FLOW_ID: { id: '444444', name: 'Edit Class', endpoint: '/api/flows/edit-class' },
+  STUDENT_VIDEOS_FLOW_ID: { id: '555555', name: 'Student Videos', endpoint: '/api/flows/student-videos' },
+  PIC_LP_FLOW_ID: { id: '666666', name: 'Pic-to-LP Confirm', endpoint: '/api/flows/pic-lp' },
+  QUIZ_FLOW_ID: { id: '777777', name: 'Quiz Manager', endpoint: '/api/flows/quiz' },
+  REGISTRATION_FLOW_ID: { id: '888888', name: 'Registration', endpoint: '/api/flows/registration' },
+};
+
+function buildFlowMessage(flowId) {
+  return {
+    interactive: {
+      type: 'nfm_reply',
+      nfm_reply: {
+        name: `flow_${flowId}`,
+        response_json: '{"flow_token":"abc"}',
+        body: 'Submitted',
+      },
+    },
+  };
+}
+
+describe('flow-response handler — endpoint-only flows are recognised, not "unknown"', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    for (const [k, v] of Object.entries(ENDPOINT_FLOWS)) {
+      process.env[k] = v.id;
+    }
+    mockLogSpy.mockClear();
+  });
+
+  afterAll(() => { process.env = originalEnv; });
+
+  for (const [envVar, flow] of Object.entries(ENDPOINT_FLOWS)) {
+    it(`${flow.name} NFM_REPLY → logs completion, returns true (NOT "unknown flow ID")`, async () => {
+      const { handleFlowResponse } = require('../../bot/shared/handlers/flow-response.handler');
+      const ok = await handleFlowResponse(buildFlowMessage(flow.id), '923001234567', 'user-uuid');
+
+      expect(ok).toBe(true);
+
+      const completionLogs = mockLogSpy.mock.calls.filter(
+        ([msg]) => typeof msg === 'string' && msg.includes('Endpoint-flow NFM completion received')
+      );
+      expect(completionLogs.length).toBeGreaterThanOrEqual(1);
+      const [, payload] = completionLogs[0];
+      expect(payload.flowName).toBe(flow.name);
+      expect(payload.endpoint).toBe(flow.endpoint);
+      expect(payload.flowId).toBe(flow.id);
+
+      const unknownLogs = mockLogSpy.mock.calls.filter(
+        ([msg]) => typeof msg === 'string' && msg.includes('Unknown flow ID')
+      );
+      expect(unknownLogs).toEqual([]);
+    });
+  }
+
+  it('a flow ID that is unconfigured AND not one of the 8 endpoint flows still falls through to "Unknown flow ID"', async () => {
+    const { handleFlowResponse } = require('../../bot/shared/handlers/flow-response.handler');
+    const ok = await handleFlowResponse(buildFlowMessage('999999-not-real'), '923001234567', 'user-uuid');
+
+    expect(ok).toBe(false);
+    const unknownLogs = mockLogSpy.mock.calls.filter(
+      ([msg]) => typeof msg === 'string' && msg.includes('Unknown flow ID')
+    );
+    expect(unknownLogs.length).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Why

Before this PR, only 3 flow IDs were routed in `bot/shared/handlers/flow-response.handler.js`: Reading Assessment (navigate) + the two Attendance flows. The other 8 flows from `bot/scripts/setup/flow-configs.js` — Settings, Status, Homework Request, Edit Class, Student Videos, Pic-to-LP Confirm, Quiz Manager, Registration — each landed on the catch-all `'⚠️ Unknown flow ID'` warning every time a teacher submitted them, and the handler returned `false`. In production logs this read like real routing breakage and burned debugger attention every release.

The actual story: those 8 are data_exchange endpoint flows. The teacher's input has already been parsed + persisted by the corresponding `/api/flows/<path>` route (mounted in `bot/shared/routes/flow-endpoint.routes.js`) BEFORE Meta sends the NFM_REPLY back to the bot. The NFM is purely a delivery acknowledgement; re-processing it here would double-write the data.

## What

- Introduced an `ENDPOINT_ONLY_FLOWS` table (`name`, `envVar`, `endpoint` path) in the handler, populated from the 8 known endpoint-only flows.
- Routing now:
  - Navigate flow (`READING_ASSESSMENT_FLOW_ID`) → handler (the original behaviour).
  - Attendance endpoint flows → handler (these DO drive downstream side effects from NFM: success ack + roster delivery — the original behaviour).
  - The 8 other endpoint flows → emit a structured `'📋 Endpoint-flow NFM completion received'` log with `flowName`, `endpoint`, `flowId`, `phoneNumber`, `userId`, `note`; return `true`.
- Truly unknown flow IDs (not in any of the routed buckets) still surface the `'⚠️ Unknown flow ID'` warning + return `false`, so we haven't masked real routing bugs.
- Rewrote the file's header docstring with an explicit "endpoint flows vs navigate flows" section so a future reader can reason about the distinction without re-deriving it from Meta's docs each time.

## Tests

NEW `tests/flow-response/endpoint-flow-routing.test.js` exercises a parametric table of the 8 endpoint flows:

- Each NFM_REPLY produces the completion log (with the right `flowName` + `endpoint`) and returns `true`.
- The `'Unknown flow ID'` warning is NEVER emitted on a configured flow.
- Final test: a truly unknown ID still falls through to the warning.

## Verification

- `node tests/run.js`: **121 suites / 1308 tests pass** (was 120 / 1299; +1 suite, +9 tests for the new parametric routing contract).
- Source-hygiene green.
- Diff: 2 files changed; +192 / −15 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)