### PR TITLE
docs(sync+schema): move maintainer-only sync files out of root; document 73-table schema by domain

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,44 @@ Meta WhatsApp API
 
 - **PostgreSQL via Supabase** with Row Level Security (RLS)
 - Schema: `infrastructure/supabase/00_complete-schema.sql`
-- 25+ tables covering users, conversations, coaching, reading, exams, attendance
+- **73 tables** today, grouped by domain below. The schema is fed by a
+  consolidated dump rather than per-feature migrations, so a few tables are
+  declared but not yet wired to code — those are called out explicitly so
+  cloners don't waste time wondering whether they're missing a feature.
+
+### Schema reference — tables by domain
+
+| Domain | Tables | Status |
+|---|---|---|
+| **Users + identity** | `users`, `access_scopes`, `dashboard_users`, `dashboard_audit_log` | active |
+| **Conversation state** | `conversations`, `chat_sessions`, `chat_starts`, `cta_clicks`, `feature_suggestions`, `user_feature_first_use` | active |
+| **Configuration** | `app_settings`, `region_features` | active |
+| **Coaching** | `coaching_sessions`, `coaching_quality_metrics`, `audio_sessions` | active |
+| **Lesson plans** | `lesson_plans`, `lesson_plan_requests`, `pre_generated_lps`, `pic_lp_sessions` (read via the `TABLE` constant in `pic-lp-session.service.js`) | active |
+| **Reading assessment** | `reading_assessments`, `student_lists`, `students` | active |
+| **Quizzes** | `quizzes`, `quiz_sessions`, `quiz_questions`, `quiz_answers` | active |
+| **Exam checker** | `exam_check_sessions`, `exam_submissions`, `exam_grades`, `image_analysis_requests` | active |
+| **Video generation** | `video_requests`, `video_tasks`, `student_videos`, `student_video_feedback` | active |
+| **Attendance** | `attendance_sessions`, `attendance_records` | active |
+| **Homework + content** | `homework_chapters`, `textbook_toc` | active |
+| **BYOF (bring-your-own-flow)** | `byof_plans`, `byof_sessions`, `byof_messages`, `byof_approval_log` | active |
+| **Broadcasts** | `broadcast_logs`, `broadcast_messages`, `website_visits`, `release_notes` | active |
+| **A/B testing** | `ab_tests`, `ab_test_variants`, `ab_test_events` | active |
+| **Logging + telemetry** | `api_usage_log` | active |
+| *Internal-only* | `qa_analyst_proposals`, `qa_bug_patterns`, `qa_test_runs`, `ama_conversations`, `ama_messages`, `ama_query_audit` | declared, no OSS-side code — internal QA + Ask-Me-Anything tools that ship with the schema dump but aren't part of the OSS feature surface. Safe to ignore. |
+| *Declared, not wired* | `coaching_jobs`, `coaching_processing_queue`, `exam_templates`, `failed_operations`, `feature_permissions`, `grade_audit_log`, `invitations`, `lcpm_benchmarks`, `migration_test`, `portal_organizations`, `schema_versions`, `teacher_facts`, `teacher_progress`, `textbook_pages`, `textbooks`, `videos`, `wcpm_percentiles` | declared in the schema but not referenced from any `bot/` or `dashboard/` `.from()` call — either historical, planned, or used only by external SQL views. They occupy no runtime budget; leave them in place unless you're sure no analyst tool reads them. |
+
+### Schema integrity guards
+
+Three `tests/setup/*` ratchets keep the schema honest:
+
+- `schema-completeness.test.js` — every table the code writes to MUST exist
+  in `00_complete-schema.sql`.
+- `column-completeness.test.js` — every column the code writes (insert /
+  update / upsert top-level keys) or reads (select / eq / order / …) MUST
+  exist on its table.
+- `flow-config-conformance.test.js` — every WhatsApp Flow declared in
+  `flow-configs.js` has a corresponding route mounted under `/api/flows`.
 
 ## Job Queue
 

--- a/infrastructure/scripts/sync-from-internal.sh
+++ b/infrastructure/scripts/sync-from-internal.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 #
 # Generates a unified diff patch from the internal repo to the public monorepo,
 # respecting the path mappings, exclusions, and publicOnly rules defined in
-# .sync-manifest.json at the monorepo root.
+# infrastructure/sync/manifest.json.
 #
 # Usage:
 #   ./infrastructure/scripts/sync-from-internal.sh \
@@ -27,7 +27,7 @@ DRY_RUN=false
 OUTPUT_FILE=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MONOREPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-MANIFEST="$MONOREPO_ROOT/.sync-manifest.json"
+MANIFEST="$MONOREPO_ROOT/infrastructure/sync/manifest.json"
 TODAY="$(date +%Y-%m-%d)"
 TEMP_DIR=""
 
@@ -128,7 +128,7 @@ fi
 
 if [[ ! -f "$MANIFEST" ]]; then
   error "Sync manifest not found at: $MANIFEST"
-  error "Expected .sync-manifest.json at the monorepo root ($MONOREPO_ROOT)"
+  error "Expected infrastructure/sync/manifest.json under the monorepo root ($MONOREPO_ROOT)"
   exit 1
 fi
 

--- a/infrastructure/sync/README.md
+++ b/infrastructure/sync/README.md
@@ -1,0 +1,39 @@
+# Sync configuration — maintainer-only
+
+This directory configures how the upstream **maintainers** sync code from
+the internal monorepo into the public `Orenda-Project/rumi-platform` repo.
+
+**You don't need any of this to clone or run the bot.** If you're here to
+set up a fork, ignore this directory and follow `SETUP.md` from the repo
+root.
+
+## Files
+
+| File | Used by | Purpose |
+|------|---------|---------|
+| `manifest.json` | `infrastructure/scripts/sync-from-internal.sh` | The single source of truth: `mappings` (internal → public path), `exclude` (never sync these), `publicOnly` (live in this repo only — do not overwrite from internal). |
+| `exclude.txt` | humans (companion doc) | The same exclusion patterns as `manifest.json` `exclude`, grouped + commented for review. Not consumed by any script — it exists so a reviewer can read the intent quickly. |
+
+## Why these moved here from the repo root
+
+Both files were at the repo root in earlier OSS revisions (`.sync-manifest.json`
++ `.sync-exclude`). A first-time cloner reading the file tree saw two
+dotfiles in their face that had nothing to do with running the bot;
+`infrastructure/` is the more honest home for maintainer-only tooling.
+The script's `MANIFEST` path was updated in lockstep.
+
+## Adding a new mapping
+
+Edit `manifest.json` and add an entry to `mappings`:
+
+```json
+{
+  "internal": "shared/services/<new>/",
+  "public":   "bot/shared/services/<new>/",
+  "direction": "internal-to-public",
+  "notes": "<one-line reviewer hint>"
+}
+```
+
+If the same change should also appear in `exclude.txt` for the human
+reviewer, add it there too.

--- a/infrastructure/sync/exclude.txt
+++ b/infrastructure/sync/exclude.txt
@@ -1,5 +1,11 @@
-# Files and directories to NEVER sync from internal to public repo
-# Used by infrastructure/scripts/sync-from-internal.sh
+# Files and directories to NEVER sync from internal to public repo.
+#
+# This file is a HUMAN-readable companion to the canonical exclude list
+# in infrastructure/sync/manifest.json. The sync script only consumes
+# the JSON; this file exists so a reviewer can read the intent quickly
+# (groupings + comments are preserved here that JSON can't carry).
+#
+# When updating the exclude list, edit BOTH files in the same commit.
 
 # QA / Testing infrastructure (internal only)
 bugbuster/

--- a/infrastructure/sync/manifest.json
+++ b/infrastructure/sync/manifest.json
@@ -95,8 +95,9 @@
     "SETUP.md",
     "LICENSE",
     "README.md",
-    ".sync-manifest.json",
-    ".sync-exclude"
+    "infrastructure/sync/manifest.json",
+    "infrastructure/sync/exclude.txt",
+    "infrastructure/sync/README.md"
   ],
   "translationRules": []
 }


### PR DESCRIPTION
## Why

Two clean-up items that came up together because both reduce first-impression cognitive load for cloners landing on the repo root or reading the schema dump.

## bd-1862 — sync files out of the repo root

Moved `.sync-manifest.json` → `infrastructure/sync/manifest.json` and `.sync-exclude` → `infrastructure/sync/exclude.txt`. Updated the script that consumes the manifest (`infrastructure/scripts/sync-from-internal.sh`'s `MANIFEST` path and its error message). The manifest's self-references in `publicOnly` were updated in lockstep so a future internal-to-OSS sync recognises the new paths as "do not overwrite from internal".

Added `infrastructure/sync/README.md` explaining that the directory is maintainer-only, that cloners can ignore it, and what each file does.

Net effect: the repo root has two fewer dotfiles that a first-time cloner has to mentally classify before they can find `SETUP.md`.

## bd-1863 — honest schema reference in docs/architecture.md

Added a "Schema reference — tables by domain" table to `docs/architecture.md`, covering all **73 tables** in `infrastructure/supabase/00_complete-schema.sql`. Each table is grouped by feature domain and one of three statuses:

| Status | Count | Examples |
|--------|-------|----------|
| **active** | 50 | `users`, `coaching_sessions`, `lesson_plans`, `exam_grades`, `pic_lp_sessions` (read via the `TABLE` constant pattern) |
| **internal-only** | 6 | `qa_*` (3), `ama_*` (3) — internal QA + Ask-Me-Anything tools that don't ship with OSS |
| **declared, not wired** | 17 | `coaching_jobs`, `exam_templates`, `migration_test`, `teacher_facts`, `textbooks`, `videos`, `wcpm_percentiles`, `lcpm_benchmarks`, `grade_audit_log`, `invitations`, `portal_organizations`, `feature_permissions`, `failed_operations`, `coaching_processing_queue`, `teacher_progress`, `textbook_pages`, `schema_versions` — historical or planned, no runtime budget |

Also corrected the previous "25+ tables" undercount to the actual **73** and pointed at the three schema-integrity ratchets that keep the schema honest (`schema-completeness`, `column-completeness`, `flow-config-conformance`).

### Audit method

Parsed `00_complete-schema.sql` for `CREATE TABLE` names; collected `.from(...)` references from every .js file under `bot/` and `dashboard/`, **including the `.from(CONSTANT)` pattern** (`const TABLE = '...'` → `.from(TABLE)`) that a naive grep misses. The first audit pass classified `pic_lp_sessions` as "unused" because `pic-lp-session.service.js` uses the constant; widening the parser caught it (now correctly listed as active).

## Verification

- `node tests/run.js`: **121 suites / 1308 tests pass** (unchanged)
- `link-integrity.test.js` green (no broken markdown links from the rewritten architecture.md)
- `customization-doc-accuracy.test.js` green
- Source-hygiene green
- Diff: 5 files changed (2 renames, 3 mods, 1 new README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)