### PR TITLE
fix(deploy): bot/Procfile worker pointed at a nonexistent bullmq-worker.js

### DIFF
--- a/bot/Procfile
+++ b/bot/Procfile
@@ -1,3 +1,3 @@
 web: node whatsapp-bot.js
-worker: node workers/bullmq-worker.js
+worker: node workers/sqs-worker.js
 dashboard: node dashboard/index.js

--- a/tests/setup/procfile-targets-resolve.test.js
+++ b/tests/setup/procfile-targets-resolve.test.js
@@ -1,0 +1,71 @@
+/**
+ * Ratchet: every Procfile process command points at a file that exists.
+ *
+ * `bot/Procfile` shipped `worker: node workers/bullmq-worker.js` — a file
+ * that exists NOWHERE in the repo (bullmq is only a queue *driver*, not a
+ * worker entrypoint). A Railway service rooted at `bot/` reads that Procfile
+ * and its `worker` process fails to boot with "Cannot find module". Fixed in
+ * Wave 6 (bd-1874) → `worker: node workers/sqs-worker.js` (the
+ * queue-driver-agnostic worker).
+ *
+ * This guard parses every Procfile and asserts each `name: node <path>`
+ * command's script resolves to a real file. Procfiles use different path
+ * roots depending on the service's configured root directory:
+ *   - bot/Procfile               → paths relative to bot/ (web: node whatsapp-bot.js)
+ *   - infrastructure/railway/...  → paths relative to repo root (web: node bot/whatsapp-bot.js)
+ * so we accept a command if its script resolves relative to EITHER the
+ * Procfile's own directory OR the repo root. The real bug class — a path
+ * that resolves to nothing anywhere — still fails. Empty allowlist.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+function findProcfiles(dir) {
+  const out = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (['node_modules', '.git', 'dist', 'build', 'coverage'].includes(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...findProcfiles(full));
+    else if (e.name === 'Procfile') out.push(full);
+  }
+  return out;
+}
+
+// Parse "name: command" lines; extract the `node <script>` script path.
+function nodeScripts(procfilePath) {
+  const src = fs.readFileSync(procfilePath, 'utf8');
+  const scripts = [];
+  for (const line of src.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const m = trimmed.match(/^[\w-]+:\s*node\s+(\S+)/);
+    if (m) scripts.push({ line: trimmed, script: m[1] });
+  }
+  return scripts;
+}
+
+describe('Procfile process targets resolve (bd-1874)', () => {
+  const procfiles = findProcfiles(ROOT);
+
+  it('finds at least one Procfile to check', () => {
+    expect(procfiles.length).toBeGreaterThan(0);
+  });
+
+  it('every `node <script>` in every Procfile resolves to a real file', () => {
+    const unresolved = [];
+    for (const pf of procfiles) {
+      const pfDir = path.dirname(pf);
+      for (const { line, script } of nodeScripts(pf)) {
+        const relToProcfile = path.resolve(pfDir, script);
+        const relToRoot = path.resolve(ROOT, script);
+        if (!fs.existsSync(relToProcfile) && !fs.existsSync(relToRoot)) {
+          unresolved.push(`${path.relative(ROOT, pf)} — "${line}" → ${script} (resolves nowhere)`);
+        }
+      }
+    }
+    expect(unresolved).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

`bot/Procfile` shipped:
```
worker: node workers/bullmq-worker.js
```
…but **`bullmq-worker.js` does not exist anywhere in the repo** — `bullmq` is only a pluggable queue *driver* (`bot/shared/services/queue/bullmq-queue.service.js`), not a worker entrypoint. A Railway service whose root directory is `bot/` reads this Procfile and its `worker` process **fails to boot** with `Cannot find module 'workers/bullmq-worker.js'`.

The operative deploy Procfile (`infrastructure/railway/Procfile`) was already correct (`worker: node bot/workers/sqs-worker.js`); only `bot/Procfile` was broken.

## Fix

```diff
-worker: node workers/bullmq-worker.js
+worker: node workers/sqs-worker.js
```
`sqs-worker.js` is the **queue-driver-agnostic** worker — it selects sqs vs bullmq internally via `require('../queue')` honouring `QUEUE_DRIVER`. (The "sqs" in the filename is a pre-existing naming nit; renaming the file is out of scope.)

## Ratchet

NEW `tests/setup/procfile-targets-resolve.test.js` parses every Procfile and asserts each `name: node <script>` resolves to a real file. The two Procfiles use different path roots (`bot/Procfile` → relative to `bot/`; the railway one → relative to repo root), so a command passes if its script resolves relative to **either** the Procfile's dir or the repo root — the real bug class (*resolves nowhere*) still fails. Verified the guard would have caught `bullmq-worker.js` (resolves in neither base). Empty allowlist.

## Verification

- `node tests/run.js`: **124 suites / 1309 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)