### PR TITLE
fix(dashboard): reconcile schema↔code drift (byof workflow + broadcast)

### DIFF
--- a/bot/shared/database/bot-helpers.js
+++ b/bot/shared/database/bot-helpers.js
@@ -20,6 +20,18 @@ async function getOrCreateUser(phoneNumber) {
       .single();
 
     if (existingUser) {
+      // Stamp the user's most-recent INBOUND message time on every message.
+      // This feeds the WhatsApp 24-hour customer-service-window check used by
+      // dashboard broadcasts (isWithinServiceWindow). Best-effort + isolated in
+      // its own try/catch so a transient failure neither blocks message handling
+      // nor falls through to the create path below.
+      const nowIso = new Date().toISOString();
+      try {
+        await supabase.from('users').update({ last_message_at: nowIso }).eq('id', existingUser.id);
+        existingUser.last_message_at = nowIso;
+      } catch (stampErr) {
+        console.error('last_message_at update failed:', stampErr.message);
+      }
       return existingUser;
     }
 
@@ -30,6 +42,7 @@ async function getOrCreateUser(phoneNumber) {
         phone_number: phoneNumber,
         registration_completed: false,
         created_at: new Date().toISOString(),
+        last_message_at: new Date().toISOString(),
       })
       .select()
       .single();
@@ -51,6 +64,7 @@ async function getOrCreateUser(phoneNumber) {
           phone_number: phoneNumber,
           registration_completed: false,
           created_at: new Date().toISOString(),
+          last_message_at: new Date().toISOString(),
         })
         .select()
         .single();

--- a/dashboard/database/queries.js
+++ b/dashboard/database/queries.js
@@ -751,11 +751,13 @@ async function getStatsForDateRange(startDate, endDate) {
       .gte('created_at', startISO)
       .lte('created_at', endISO),
 
-    // Users with completed registration in period
+    // Users with completed registration in period.
+    // Column is `registration_completed` (BOOLEAN) — there is no
+    // `registration_status` text column on `users`.
     supabase
       .from('users')
       .select('*', { count: 'exact', head: true })
-      .eq('registration_status', 'completed')
+      .eq('registration_completed', true)
       .gte('created_at', startISO)
       .lte('created_at', endISO),
 

--- a/dashboard/services/byof.service.js
+++ b/dashboard/services/byof.service.js
@@ -504,15 +504,18 @@ async function approvePlan(planId, approverId, notes = '') {
       return updateResult;
     }
 
-    // Log the approval
-    await supabase
+    // Log the approval. Schema columns are (plan_id, action, performed_by,
+    // reason) — NOT (user_id, notes). Check the error so a future drift fails
+    // loud instead of silently dropping the audit row.
+    const { error: logError } = await supabase
       .from('byof_approval_log')
       .insert({
         plan_id: planId,
         action: 'approved',
-        user_id: approverId,
-        notes
+        performed_by: approverId,
+        reason: notes
       });
+    if (logError) console.error('⚠️ byof approval log insert failed (approve):', logError.message);
 
     return { success: true, plan: updateResult.plan };
   } catch (err) {
@@ -540,15 +543,17 @@ async function rejectPlan(planId, rejecterId, reason) {
       return updateResult;
     }
 
-    // Log the rejection
-    await supabase
+    // Log the rejection. Schema columns are (plan_id, action, performed_by,
+    // reason) — NOT (user_id, notes).
+    const { error: logError } = await supabase
       .from('byof_approval_log')
       .insert({
         plan_id: planId,
         action: 'rejected',
-        user_id: rejecterId,
-        notes: reason
+        performed_by: rejecterId,
+        reason: reason
       });
+    if (logError) console.error('⚠️ byof approval log insert failed (reject):', logError.message);
 
     return { success: true, plan: updateResult.plan };
   } catch (err) {
@@ -1014,7 +1019,7 @@ async function getRecentActivity(limit = 10) {
     const { data: approvals, error: approvalsError } = await supabase
       .from('byof_approval_log')
       .select(`
-        id, action, notes, created_at,
+        id, action, reason, created_at,
         user:dashboard_users(id, username),
         plan:byof_plans(id, summary)
       `)

--- a/infrastructure/supabase/00_complete-schema.sql
+++ b/infrastructure/supabase/00_complete-schema.sql
@@ -3652,6 +3652,33 @@ ALTER TABLE conversations ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT 
 -- nonexistent table; the handler call sites now target chat_sessions.)
 ALTER TABLE chat_sessions ADD COLUMN IF NOT EXISTS conversation_state JSONB;
 
+-- byof_plans: the BYOF approval workflow (dashboard/services/byof.service.js)
+-- updates plans on every state transition (.update({ status, updated_at })) and
+-- orders plan lists by updated_at. The column predated the consolidated schema
+-- (byof_sessions had updated_at + a trigger; byof_plans did not), so every
+-- approve/reject/markStaging/markComplete/linkPR bailed on a "column does not
+-- exist" error.
+ALTER TABLE byof_plans ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+DROP TRIGGER IF EXISTS byof_plans_updated_at ON byof_plans;
+CREATE TRIGGER byof_plans_updated_at
+    BEFORE UPDATE ON byof_plans
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- dashboard_users: byof.service.getApproversForNotification() selects
+-- phone_number to WhatsApp-notify approvers; the column was never defined, so
+-- the approver-notification fetch errored.
+ALTER TABLE dashboard_users ADD COLUMN IF NOT EXISTS phone_number VARCHAR(20);
+
+-- users.last_message_at: timestamp of the user's most recent INBOUND message.
+-- Feeds the WhatsApp 24-hour customer-service-window check
+-- (dashboard/services/whatsapp-broadcast.service.js isWithinServiceWindow) that
+-- decides free-form vs template broadcast sends. No existing column carried this
+-- meaning (first_message_at is the opposite end; updated_at changes on any
+-- profile edit). The broadcast user-fetch SELECTed it and threw on the missing
+-- column. Populated on every inbound by bot-helpers.getOrCreateUser.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_message_at TIMESTAMPTZ;
+
 -- =============================================================================
 -- Function reconcile (Phase 5) — RPCs the bot invokes via supabase.rpc() that the
 -- consolidated schema predated. CREATE OR REPLACE keeps it idempotent. (get_column_info

--- a/tests/database/get-or-create-user-last-message.test.js
+++ b/tests/database/get-or-create-user-last-message.test.js
@@ -1,0 +1,66 @@
+/**
+ * getOrCreateUser populates users.last_message_at on EVERY inbound (bd-1877).
+ *
+ * last_message_at feeds the WhatsApp 24-hour service-window check used by
+ * dashboard broadcasts. It must be stamped on every inbound message — both for
+ * a returning user (an UPDATE) and a brand-new user (set at INSERT). The
+ * stamp must NOT throw into the create path (a transient failure should be
+ * logged, not treated as "user not found" → duplicate insert).
+ */
+
+// Mutable state the mock factory reads (must be `mock`-prefixed for jest).
+const mockState = { existingUser: null, calls: { updates: [], inserts: [] } };
+
+jest.mock('../../bot/shared/config/supabase', () => {
+  const api = {
+    from() { return api; },
+    select() { return api; },
+    eq() { return api; },
+    single() {
+      if (api._mode === 'insert') {
+        const row = api._lastInsert;
+        api._mode = null;
+        return Promise.resolve({ data: { id: 'new-uuid', ...row }, error: null });
+      }
+      return mockState.existingUser
+        ? Promise.resolve({ data: mockState.existingUser, error: null })
+        : Promise.resolve({ data: null, error: { code: 'PGRST116' } });
+    },
+    insert(row) { api._mode = 'insert'; api._lastInsert = row; mockState.calls.inserts.push(row); return api; },
+    update(row) {
+      mockState.calls.updates.push(row);
+      return { eq: () => Promise.resolve({ data: null, error: null }) };
+    },
+  };
+  return api;
+});
+
+const { getOrCreateUser } = require('../../bot/shared/database/bot-helpers');
+
+describe('getOrCreateUser — last_message_at stamping (bd-1877)', () => {
+  beforeEach(() => {
+    mockState.existingUser = null;
+    mockState.calls = { updates: [], inserts: [] };
+  });
+
+  it('UPDATEs last_message_at for a returning user', async () => {
+    mockState.existingUser = { id: 'u1', phone_number: '92300', registration_completed: true };
+
+    const user = await getOrCreateUser('92300');
+
+    const stamped = mockState.calls.updates.find(u => 'last_message_at' in u);
+    expect(stamped).toBeDefined();
+    expect(typeof stamped.last_message_at).toBe('string');
+    expect(user.last_message_at).toBe(stamped.last_message_at); // returned object reflects the stamp
+  });
+
+  it('sets last_message_at at INSERT for a brand-new user', async () => {
+    mockState.existingUser = null;
+
+    await getOrCreateUser('92301');
+
+    const insertedRow = mockState.calls.inserts.find(r => r.phone_number === '92301');
+    expect(insertedRow).toBeDefined();
+    expect(typeof insertedRow.last_message_at).toBe('string');
+  });
+});

--- a/tests/setup/column-completeness.test.js
+++ b/tests/setup/column-completeness.test.js
@@ -21,7 +21,12 @@ const fs = require('fs');
 const path = require('path');
 
 const SCHEMA_PATH = path.resolve(__dirname, '../../infrastructure/supabase/00_complete-schema.sql');
-const BOT_DIR = path.resolve(__dirname, '../../bot');
+// Scan both the bot and the dashboard — the dashboard is part of the OSS
+// distribution and grew its own schema↔code drift unguarded (Wave 6 bd-1876/1877).
+const SCAN_DIRS = [
+  path.resolve(__dirname, '../../bot'),
+  path.resolve(__dirname, '../../dashboard'),
+];
 
 // ── Reviewed allowlist ───────────────────────────────────────────────────────
 // (table -> columns) that the guard should NOT flag, each with a verified reason.
@@ -55,6 +60,16 @@ const ALLOWLIST = {
   // Nested keys inside the users.preferences / screen-data objects (parser artifact);
   // users stores language in preferred_language + preferences, grade in grades_taught.
   users: ['grade', 'language'],
+  // ── dashboard/ parser artifacts (verified Wave 6 bd-1876/1877) ──────────────
+  // `grade_level` is a real column on reading_assessments (and is selected there:
+  // queries.js:1365, portal.routes.js:1443) — chain-attributed to lesson_plans by
+  // proximity. `lessonplans` is the `lessonPlans` result var (portal.routes.js:844/857)
+  // lowercased. `limit`/`page` are `parseInt(req.query.{limit,page})` pagination vars
+  // feeding `.range(offset, offset+limit-1)`, not columns.
+  lesson_plans: ['grade_level', 'lessonplans', 'limit', 'page'],
+  // `videoswithpresignedurls` is a result var; `limit`/`page` are pagination vars
+  // (portal.routes.js video listing) — parser artifacts, not columns.
+  video_requests: ['limit', 'page', 'videoswithpresignedurls'],
 };
 
 // ── Parser ───────────────────────────────────────────────────────────────────
@@ -143,7 +158,7 @@ describe('Column Completeness', () => {
     const refs = {}; // table -> Set(col)
     const add = (t, c) => { (refs[t] = refs[t] || new Set()).add(c); };
 
-    for (const file of findJsFiles(BOT_DIR)) {
+    for (const file of SCAN_DIRS.flatMap(findJsFiles)) {
       const c = fs.readFileSync(file, 'utf-8');
       let m;
       const iu = /\.(insert|update|upsert)\s*\(/g;


### PR DESCRIPTION
## Why

The dashboard grew schema↔code drift that Wave 5's ratchets never caught — `column-completeness` scanned `bot/` only. Widening it to `dashboard/` surfaced 13 references: **6 real bugs** (fixed) + **7 parser artifacts** (allowlisted with verified reasons). A fresh clone bootstraps from `00_complete-schema.sql` only, so these columns existed in neither the consolidated schema nor the legacy dashboard migrations — **code bugs, not schema-file omissions**.

> BYOF is **dashboard-only** (`grep byof bot/shared/handlers whatsapp-bot.js` → empty), so bd-1876 doesn't touch the WhatsApp bot. bd-1877's `last_message_at` populate is the one bot-side change.

## bd-1876 — BYOF approval workflow

| Bug | Fix |
|-----|-----|
| `byof_plans` has no `updated_at`, but `updatePlanStatus()` writes it on every transition + orders by it → **approve/reject/markStaging/markComplete/linkPR all bailed** | Added column + `BEFORE UPDATE` trigger via existing `update_updated_at_column()` (mirrors byof_sessions) |
| `byof_approval_log` inserts wrote `(user_id, notes)`; schema is `(performed_by, reason)` → **every audit-log write silently failed** (error unchecked) | Fixed both insert sites + the `getRecentActivity` SELECT that referenced `notes`; added error checks |
| `dashboard_users` has no `phone_number`, but `getApproversForNotification()` selects it → **fetch errored** | Added column |

## bd-1877 — broadcast + metrics queries

**`users.last_message_at` was genuinely MISSING** (not a wrong name). It feeds the WhatsApp **24-hour service-window** check (`isWithinServiceWindow`) deciding free-form vs template broadcast sends. No existing column carried "last inbound message time" (`first_message_at` is the opposite end; `updated_at` changes on any profile edit). The broadcast user-fetch SELECTed it and **threw**. Fix is add + populate:
- **schema:** `ALTER TABLE users ADD COLUMN last_message_at TIMESTAMPTZ`
- **bot-side:** `bot-helpers.getOrCreateUser` now stamps `last_message_at` on **every inbound** — an UPDATE for returning users (isolated in its own try/catch so a transient failure can't fall into the create path and duplicate-insert), set at INSERT for new users.

**`users.registration_status`** filter → the column is `registration_completed` (BOOLEAN). Fixed the "completed registrations in period" metric.

## Guard widening (the ratchet for both)

`tests/setup/column-completeness.test.js` now scans `bot/` **and** `dashboard/`. Allowlisted 7 verified artifacts: `lesson_plans` [`grade_level` (real on reading_assessments, chain-misattributed), `lessonplans` (result var), `limit`/`page` (`parseInt(req.query.*)` pagination)], `video_requests` [`limit`/`page`, `videoswithpresignedurls` (result var)].

NEW `tests/database/get-or-create-user-last-message.test.js` — asserts the stamp on both returning (UPDATE) and new (INSERT) users.

## Verification

- `node tests/run.js`: **125 suites / 1311 tests pass**
- Source-hygiene green

🤖 Generated with [Claude Code](https://claude.com/claude-code)