### PR TITLE
fix(dashboard): lazy-init OpenAI + R2 clients so the dashboard boots without keys

### DIFF
--- a/dashboard/routes/portal.routes.js
+++ b/dashboard/routes/portal.routes.js
@@ -32,16 +32,23 @@ const supabase = require('../config/supabase');
 const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
 const { generatePresignedUrl, generatePresignedUrls, isValidR2Url } = require('../services/r2.service');
 
-// Configure R2 S3 client for private PDF access
-const r2Client = new S3Client({
-  region: 'auto',
-  endpoint: process.env.R2_ENDPOINT,
-  credentials: {
-    accessKeyId: process.env.R2_ACCESS_KEY_ID,
-    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
-  },
-  forcePathStyle: true, // Required for CloudFlare R2 (uses path-style URLs)
-});
+// Configure R2 S3 client for private PDF access. Lazy — resolved on first
+// use, not at module load, so mounting these routes never depends on R2 env
+// vars being set (mirrors the no-eager-sdk-construction guard contract).
+let _r2Client = null;
+function getR2Client() {
+  if (_r2Client) return _r2Client;
+  _r2Client = new S3Client({
+    region: 'auto',
+    endpoint: process.env.R2_ENDPOINT,
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+    },
+    forcePathStyle: true, // Required for CloudFlare R2 (uses path-style URLs)
+  });
+  return _r2Client;
+}
 
 // ============================================================================
 // RATE LIMITING (SECURITY)
@@ -1653,7 +1660,7 @@ router.get('/reading-assessment/:id/pdf', requirePortalAuth, async (req, res) =>
       Key: key,
     });
 
-    const response = await r2Client.send(command);
+    const response = await getR2Client().send(command);
 
     // Generate filename from assessment data
     const dateStr = new Date(assessment.created_at).toISOString().split('T')[0];

--- a/dashboard/services/r2.service.js
+++ b/dashboard/services/r2.service.js
@@ -8,15 +8,23 @@ const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 require('dotenv').config();
 
-// Initialize R2 client
-const r2Client = new S3Client({
-  region: 'auto',
-  endpoint: process.env.R2_ENDPOINT,
-  credentials: {
-    accessKeyId: process.env.R2_ACCESS_KEY_ID,
-    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
-  },
-});
+// Lazy R2 client — resolved on first use, not at module load, so requiring
+// this service (e.g. transitively from dashboard/index.js) never depends on
+// R2 env vars being set. Mirrors the bot's lazy-client pattern + the
+// no-eager-sdk-construction guard contract.
+let _r2Client = null;
+function getR2Client() {
+  if (_r2Client) return _r2Client;
+  _r2Client = new S3Client({
+    region: 'auto',
+    endpoint: process.env.R2_ENDPOINT,
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+    },
+  });
+  return _r2Client;
+}
 
 const BUCKET_NAME = process.env.R2_BUCKET_NAME;
 
@@ -33,7 +41,7 @@ async function downloadFromR2(key) {
       Key: key,
     });
 
-    const response = await r2Client.send(command);
+    const response = await getR2Client().send(command);
 
     // Convert stream to buffer
     const chunks = [];
@@ -63,7 +71,7 @@ async function streamFromR2(key) {
       Key: key,
     });
 
-    const response = await r2Client.send(command);
+    const response = await getR2Client().send(command);
     console.log(`✅ Streaming from R2: ${key} (${response.ContentLength} bytes)`);
 
     return {
@@ -150,7 +158,7 @@ async function generatePresignedUrl(r2Url, expiresIn = 3600) {
       Key: key,
     });
 
-    const presignedUrl = await getSignedUrl(r2Client, command, { expiresIn });
+    const presignedUrl = await getSignedUrl(getR2Client(), command, { expiresIn });
     console.log(`✅ Generated presigned URL for: ${key} (expires in ${expiresIn}s)`);
     return presignedUrl;
   } catch (error) {

--- a/dashboard/services/transcript-processor.service.js
+++ b/dashboard/services/transcript-processor.service.js
@@ -12,9 +12,24 @@ require('dotenv').config();
 const OpenAI = require('openai');
 const { withCache } = require('./gpt-cache.service');
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY
-});
+// Lazy OpenAI client. The openai SDK (v4) THROWS at construction when
+// apiKey is undefined, so constructing at module load crashed the entire
+// dashboard at boot for any clone that hadn't set OPENAI_API_KEY (and this
+// module is statically required at the top of dashboard/index.js). Resolve
+// the client on first use instead, surfacing a friendly EX_CONFIG error only
+// if transcript processing is actually invoked without a key.
+let _openai = null;
+function getOpenAI() {
+  if (_openai) return _openai;
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    const err = new Error('OPENAI_API_KEY not configured — transcript processing is unavailable');
+    err.code = 'EX_CONFIG';
+    throw err;
+  }
+  _openai = new OpenAI({ apiKey });
+  return _openai;
+}
 
 /**
  * System prompt for transcript processing
@@ -617,7 +632,7 @@ REMEMBER:
       'transcript',
       cacheContent,
       async () => {
-        const response = await openai.chat.completions.create({
+        const response = await getOpenAI().chat.completions.create({
           model: 'gpt-4o-mini-2024-07-18', // Specific model version supporting Structured Outputs
           messages: [
             { role: 'system', content: SYSTEM_PROMPT },
@@ -1021,7 +1036,7 @@ Your JSON response MUST include these top-level fields:
 }`;
 
     try {
-      const response = await openai.chat.completions.create({
+      const response = await getOpenAI().chat.completions.create({
         model: 'gpt-4o-2024-11-20', // Use latest GPT-4o (GPT-5 class model)
         messages: [
           { role: 'system', content: SYSTEM_PROMPT },

--- a/tests/setup/no-eager-sdk-construction.test.js
+++ b/tests/setup/no-eager-sdk-construction.test.js
@@ -6,10 +6,10 @@
  * isn't set, even if NO code path that requires the SDK is ever invoked.
  *
  * This guard locks the lazy-init contract: every SDK constructor in shipped
- * `bot/shared/` and `bot/workers/` must be wrapped in a function (so that
- * cred-missing errors fire at call time, not at require time), via the
- * `lazyClient()` helper or an equivalent inline pattern (static getter,
- * function-scoped `new`, etc.).
+ * `bot/shared/`, `bot/workers/`, and `dashboard/` must be wrapped in a
+ * function (so that cred-missing errors fire at call time, not at require
+ * time), via the `lazyClient()` helper or an equivalent inline pattern
+ * (static getter, function-scoped `new`, etc.).
  *
  * Detection is regex-based against the column-0 anti-pattern:
  *
@@ -23,7 +23,9 @@ const fs = require('fs');
 const path = require('path');
 
 const ROOT = path.resolve(__dirname, '../..');
-const SCAN_DIRS = ['bot/shared', 'bot/workers'].map((d) => path.join(ROOT, d));
+// Includes dashboard/ — it is part of the OSS distribution and was crashing
+// at cold-boot on an unset OPENAI_API_KEY (Wave 6 bd-1878).
+const SCAN_DIRS = ['bot/shared', 'bot/workers', 'dashboard'].map((d) => path.join(ROOT, d));
 
 // SDK classes whose eager construction at module-load is the bug pattern.
 // Add new SDKs here when the bot starts using them.
@@ -62,7 +64,7 @@ function findJsFiles(dir) {
 }
 
 describe('No eager SDK construction at module-load', () => {
-  it('every SDK client in bot/shared and bot/workers is lazy-initialised', () => {
+  it('every SDK client in bot/shared, bot/workers, and dashboard is lazy-initialised', () => {
     const offenders = [];
     const files = SCAN_DIRS.flatMap(findJsFiles);
 


### PR DESCRIPTION
## Why

The dashboard **crashed at cold-boot** on a fresh clone that hadn't set `OPENAI_API_KEY`. `dashboard/services/transcript-processor.service.js` constructed `new OpenAI({apiKey: process.env.OPENAI_API_KEY})` at **module load**, and that module is statically required at the top of `dashboard/index.js`. The openai SDK v4 **throws** when `apiKey` is `undefined` (an omitted `.env` line → undefined; the template ships an empty string which happens not to throw — masking the bug for template-copiers but not for key-omitters). Result: raw Node stack at boot.

This is the exact failure `bot/shared/utils/lazy-client.js` was built to prevent in Waves 4–5 — but the dashboard was never refactored and was outside the `no-eager-sdk-construction` guard's scope (`bot/shared` + `bot/workers` only).

## Fixes

- **`transcript-processor.service.js`**: OpenAI client resolved via a lazy `getOpenAI()` getter; the 2 `chat.completions` call sites use it. Surfaces a friendly `EX_CONFIG` error only if transcript processing is actually invoked without a key — never at require time.
- **`r2.service.js` + `portal.routes.js`**: the two dashboard `S3Client` constructions are also converted to lazy `getR2Client()` getters. (AWS SDK v3 doesn't actually throw at construction, so these weren't boot-crashes — but lazy keeps the dashboard fully compliant with the no-eager-sdk contract rather than weakening the guard with an allowlist.)

## Guard widening (the ratchet)

`tests/setup/no-eager-sdk-construction.test.js` `SCAN_DIRS` now includes `dashboard/`. It flagged all three constructions; after the lazy refactor it's green with an **empty allowlist**. This would have caught the OpenAI crash the moment it shipped.

> No `require()`-based cold-boot smoke test: CI does not `npm ci` the dashboard, so dashboard services can't be `require()`d in the test env — the static text guard is the correct ratchet and catches the bug class anyway.

## Verification

- `node tests/run.js`: **125 suites / 1311 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)