### PR TITLE
feat(exam-checker): build the confirm-students WhatsApp Flow end-to-end (was 3-way broken)

### DIFF
--- a/bot/scripts/setup/flow-configs.js
+++ b/bot/scripts/setup/flow-configs.js
@@ -119,6 +119,20 @@ const FLOW_CONFIGS = [
     envVar: 'REGISTRATION_FLOW_ID',
     categories: ['OTHER'],
   },
+  {
+    // Exam-checker "confirm detected students" step. data_exchange endpoint
+    // flow (the student list is dynamic per session) modelled on
+    // attendance-marking. Endpoint INIT loads the session's detected_students;
+    // completion returns confirmed_students. Only sent when the exam-checker
+    // feature is active (MISTRAL_API_KEY or CHANDRA_API_KEY) AND this Flow is
+    // registered (EXAM_CHECKER_STUDENTS_FLOW_ID set).
+    name: 'Exam Checker Confirm Students',
+    jsonPath: path.join(FLOWS_DIR, 'exam-checker-confirm-students-flow.json'),
+    type: 'endpoint',
+    endpointPath: '/api/flows/exam-confirm-students',
+    envVar: 'EXAM_CHECKER_STUDENTS_FLOW_ID',
+    categories: ['OTHER'],
+  },
 ];
 
 /** The flow names that a complete setup must have registered. */

--- a/bot/shared/handlers/exam-checker.handler.js
+++ b/bot/shared/handlers/exam-checker.handler.js
@@ -112,7 +112,16 @@ async function handleExamText(message, from, user) {
       if (response.interactive) {
         await WhatsAppService.sendInteractiveMessage(from, response.interactive);
       } else if (response.flow) {
-        await WhatsAppService.sendFlowMessage(from, response.flow.id, response.flow.data);
+        // data_exchange flow — pass the flow_token; the endpoint serves the
+        // screen data on INIT. (Previously called a method that did not exist.)
+        await WhatsAppService.sendFlow(from, {
+          flowId: response.flow.id,
+          flowToken: response.flow.flowToken,
+          header: response.flow.header,
+          body: response.flow.body,
+          buttonText: response.flow.buttonText || 'Open',
+          footer: 'Powered by Rumi',
+        });
       } else {
         await WhatsAppService.sendMessage(from, response.text);
       }
@@ -240,7 +249,16 @@ async function handleExamButton(buttonId, from, user) {
       if (response.interactive) {
         await WhatsAppService.sendInteractiveMessage(from, response.interactive);
       } else if (response.flow) {
-        await WhatsAppService.sendFlowMessage(from, response.flow.id, response.flow.data);
+        // data_exchange flow — pass the flow_token; the endpoint serves the
+        // screen data on INIT. (Previously called a method that did not exist.)
+        await WhatsAppService.sendFlow(from, {
+          flowId: response.flow.id,
+          flowToken: response.flow.flowToken,
+          header: response.flow.header,
+          body: response.flow.body,
+          buttonText: response.flow.buttonText || 'Open',
+          footer: 'Powered by Rumi',
+        });
       } else {
         await WhatsAppService.sendMessage(from, response.text);
       }
@@ -303,7 +321,16 @@ async function handleExamFlow(flowId, flowResponse, from, user) {
       if (response.interactive) {
         await WhatsAppService.sendInteractiveMessage(from, response.interactive);
       } else if (response.flow) {
-        await WhatsAppService.sendFlowMessage(from, response.flow.id, response.flow.data);
+        // data_exchange flow — pass the flow_token; the endpoint serves the
+        // screen data on INIT. (Previously called a method that did not exist.)
+        await WhatsAppService.sendFlow(from, {
+          flowId: response.flow.id,
+          flowToken: response.flow.flowToken,
+          header: response.flow.header,
+          body: response.flow.body,
+          buttonText: response.flow.buttonText || 'Open',
+          footer: 'Powered by Rumi',
+        });
       } else {
         await WhatsAppService.sendMessage(from, response.text);
       }

--- a/bot/shared/handlers/flow-response.handler.js
+++ b/bot/shared/handlers/flow-response.handler.js
@@ -123,6 +123,24 @@ async function handleFlowResponse(message, phoneNumber, userId) {
       return await handleAttendanceMarkingFlow(message, phoneNumber, userId);
     }
 
+    // Exam-checker "confirm students" — an endpoint flow whose NFM completion
+    // must DRIVE the orchestrator forward (confirm → detect questions → grade),
+    // not just ack. The endpoint put the confirmed student objects into the
+    // completion payload; parse them and hand to the exam handler.
+    const EXAM_CONFIRM_FLOW_ID = process.env.EXAM_CHECKER_STUDENTS_FLOW_ID || '';
+    if (flowId && EXAM_CONFIRM_FLOW_ID && flowId === EXAM_CONFIRM_FLOW_ID) {
+      const ExamCheckerHandler = require('./exam-checker.handler');
+      let flowResponse = {};
+      try {
+        flowResponse = JSON.parse(message.interactive?.nfm_reply?.response_json || '{}');
+      } catch (parseErr) {
+        logToFile('⚠️ exam-confirm response_json parse failed', { flowId, error: parseErr.message });
+      }
+      // handleExamFlow only reads user.id, so a minimal shape avoids a DB round-trip.
+      const result = await ExamCheckerHandler.handleExamFlow(flowId, flowResponse, phoneNumber, { id: userId });
+      return result?.handled !== false;
+    }
+
     // Endpoint-only flows: the corresponding `/api/flows/<path>` route has
     // ALREADY persisted the teacher's input by the time we see NFM_REPLY.
     // We log completion (useful when debugging "did the teacher actually

--- a/bot/shared/routes/exam-confirm-endpoint.js
+++ b/bot/shared/routes/exam-confirm-endpoint.js
@@ -1,0 +1,102 @@
+/**
+ * Exam-Checker "Confirm Students" Flow endpoint handlers.
+ *
+ * data_exchange (data_api_version 3.0) flow, modelled on the attendance-marking
+ * endpoint. The flow_token IS the exam session id (set at launch by the
+ * orchestrator via sendFlow({ flowId, flowToken: session.id })).
+ *
+ *   INIT          → load the session's detected_students, render them as a
+ *                   CheckboxGroup on the CONFIRM_STUDENTS screen.
+ *   data_exchange → the teacher submitted the form. `confirmed_students` is the
+ *                   array of selected option ids (stringified detected-student
+ *                   indices). Map them back to the full detected-student objects
+ *                   and return them in the SUCCESS screen's
+ *                   extension_message_response so the completion NFM carries the
+ *                   confirmed student objects the grader needs.
+ *
+ * The completion NFM is routed by flow-response.handler → ExamCheckerHandler
+ * .handleExamFlow → orchestrator.handleStudentConfirmation, which reads
+ * message.flowResponse.confirmed_students.
+ */
+
+const FlowEncryptionService = require('../services/flow-encryption.service');
+const { logToFile } = require('../utils/logger');
+
+const SCREEN = 'CONFIRM_STUDENTS';
+
+/** Load the session's detected students (or null). */
+async function _loadDetectedStudents(sessionId) {
+  if (!sessionId) return null;
+  const ExamSessionService = require('../services/exam-checker/exam-session.service');
+  const session = await ExamSessionService.getById(sessionId);
+  if (!session) return null;
+  return session.detected_students || [];
+}
+
+/** Render the CONFIRM_STUDENTS screen from the session's detected students. */
+async function handleExamConfirmInit(flow_token) {
+  const detected = await _loadDetectedStudents(flow_token);
+  if (!detected) {
+    return FlowEncryptionService.createErrorResponse('Exam session not found or expired');
+  }
+  if (detected.length === 0) {
+    return FlowEncryptionService.createErrorResponse('No students were detected in these exams');
+  }
+
+  // CheckboxGroup options: id = stringified index (stable handle back to the
+  // detected-student object), title = "N. Name".
+  const students = detected.map((s, i) => ({
+    id: String(i),
+    title: `${i + 1}. ${s.name || 'Unnamed student'}`,
+  }));
+
+  return {
+    screen: SCREEN,
+    data: {
+      heading: `I found ${students.length} student${students.length !== 1 ? 's' : ''}`,
+      subheading: "Uncheck any name that isn't a real student, then tap Confirm & Grade.",
+      students,
+    },
+  };
+}
+
+/**
+ * Handle the form submission. Passes the selected option ids straight through
+ * in the completion payload as a STRING ARRAY (WhatsApp Flow completion params
+ * round-trip reliably for string arrays — same shape attendance uses for
+ * absent_students; arrays of objects are risky). The orchestrator maps these
+ * ids back to the full detected-student objects via session.detected_students.
+ */
+async function handleExamConfirmDataExchange(flow_token, screen, screenData = {}) {
+  const selectedIds = Array.isArray(screenData?.confirmed_students)
+    ? screenData.confirmed_students.map(String)
+    : [];
+
+  logToFile('📋 Exam confirm-students submission', {
+    sessionId: flow_token,
+    confirmed: selectedIds.length,
+  });
+
+  return {
+    screen: 'SUCCESS',
+    data: {
+      extension_message_response: {
+        params: {
+          flow_token,
+          confirmed_students: selectedIds,
+        },
+      },
+    },
+  };
+}
+
+/** BACK re-renders the confirm screen. */
+async function handleExamConfirmBack(flow_token) {
+  return handleExamConfirmInit(flow_token);
+}
+
+module.exports = {
+  handleExamConfirmInit,
+  handleExamConfirmDataExchange,
+  handleExamConfirmBack,
+};

--- a/bot/shared/routes/flow-endpoint.routes.js
+++ b/bot/shared/routes/flow-endpoint.routes.js
@@ -64,6 +64,11 @@ const {
   handleQuizFlowDataExchange,
   handleQuizFlowBack
 } = require('./quiz-flow-endpoint');
+const {
+  handleExamConfirmInit,
+  handleExamConfirmDataExchange,
+  handleExamConfirmBack
+} = require('./exam-confirm-endpoint');
 
 /**
  * Handle attendance marking flow data requests
@@ -848,6 +853,40 @@ async function handleEditClassRequest(data) {
   if (action === 'data_exchange')             return await handleEditClassDataExchange(userId, screen, screenData, flow_token);
   if (action === 'BACK')                      return await handleEditClassBack(userId, screen, flow_token);
   logToFile('Unknown edit-class flow action', { action });
+  return FlowEncryptionService.createErrorResponse('Unknown action');
+}
+
+// ============================================================
+// EXAM-CHECKER "CONFIRM STUDENTS" FLOW ENDPOINT
+// flow_token IS the exam session id (set by the orchestrator at launch).
+// ============================================================
+
+router.post('/exam-confirm-students', async (req, res) => {
+  try {
+    if (!FlowEncryptionService.isConfigured()) {
+      logToFile('Flow encryption not configured', { endpoint: 'exam-confirm-students' });
+      return res.status(500).json({ error: 'Flow encryption not configured' });
+    }
+    const encryptedResponse = await FlowEncryptionService.processEncryptedRequest(
+      req.body,
+      async (decryptedData) => await handleExamConfirmRequest(decryptedData)
+    );
+    res.set('Content-Type', 'text/plain');
+    res.send(encryptedResponse);
+  } catch (error) {
+    logToFile('Exam-confirm flow endpoint error', { endpoint: 'exam-confirm-students', error: error.message, stack: error.stack });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+async function handleExamConfirmRequest(data) {
+  const { action, flow_token, screen, data: screenData } = data;
+  logToFile('Handling exam-confirm request', { action, screen, hasFlowToken: !!flow_token });
+  if (action === 'ping') return FlowEncryptionService.handlePing();
+  if (action === 'INIT' || action === 'init') return await handleExamConfirmInit(flow_token);
+  if (action === 'data_exchange')             return await handleExamConfirmDataExchange(flow_token, screen, screenData);
+  if (action === 'BACK')                      return await handleExamConfirmBack(flow_token);
+  logToFile('Unknown exam-confirm flow action', { action });
   return FlowEncryptionService.createErrorResponse('Unknown action');
 }
 

--- a/bot/shared/services/exam-checker/exam-checker.orchestrator.js
+++ b/bot/shared/services/exam-checker/exam-checker.orchestrator.js
@@ -185,21 +185,32 @@ class ExamCheckerOrchestrator {
         questionsFound: questions.length
       });
 
-      // Launch WhatsApp Flow for student confirmation
-      return {
-        text: `✅ Found ${students.length} student${students.length !== 1 ? 's' : ''} in your exams!`,
-        flow: {
-          id: process.env.EXAM_CHECKER_STUDENTS_FLOW_ID || 'exam_checker_confirm_students',
-          data: {
-            students: students.map((s, i) => ({
-              id: i,
-              name: s.name,
-              pages: s.pageNumbers?.length || 1,
-              confidence: s.confidence
-            }))
-          }
-        }
-      };
+      // Launch the "confirm students" WhatsApp Flow when it's registered.
+      // It's a data_exchange flow — the endpoint (/api/flows/exam-confirm-students)
+      // serves the detected-student list on INIT keyed off the flow_token, which
+      // IS the session id. We pass NO inline data; just the token.
+      const confirmFlowId = process.env.EXAM_CHECKER_STUDENTS_FLOW_ID;
+      if (confirmFlowId) {
+        return {
+          flow: {
+            id: confirmFlowId,
+            flowToken: session.id,
+            header: 'Confirm Students',
+            body: `✅ I found ${students.length} student${students.length !== 1 ? 's' : ''} in your exams. Tap below to confirm the names before I grade them.`,
+            buttonText: 'Confirm Students',
+          },
+        };
+      }
+
+      // Graceful degrade: the confirm Flow isn't registered on this deployment
+      // (EXAM_CHECKER_STUDENTS_FLOW_ID unset). Rather than dead-end the teacher,
+      // auto-confirm every detected student and proceed straight to grading.
+      logToFile('ℹ️ EXAM_CHECKER_STUDENTS_FLOW_ID unset — auto-confirming detected students', {
+        sessionId: session.id, count: students.length,
+      });
+      await ExamSessionService.update(session.id, { confirmed_students: students });
+      await ExamSessionService.updateStatus(session.id, SESSION_STATES.DETECTING_QUESTIONS);
+      return this.handleQuestionDetection(session, userId);
     } catch (error) {
       logToFile('❌ OCR processing failed', { sessionId: session.id, error: error.message });
       await ExamSessionService.updateStatus(session.id, SESSION_STATES.ERROR, { error_message: error.message });
@@ -214,7 +225,25 @@ class ExamCheckerOrchestrator {
     const ExamSessionService = require('./exam-session.service');
 
     if (message.flowResponse) {
-      const confirmedStudents = message.flowResponse.confirmed_students;
+      const raw = message.flowResponse.confirmed_students || [];
+      const detected = session.detected_students || [];
+
+      // The confirm Flow returns the selected option ids (stringified
+      // detected-student indices — see exam-confirm-endpoint). Map them back
+      // to the full detected-student objects the grader needs. Be defensive:
+      // accept already-mapped objects too, and if nothing resolves (e.g. an
+      // unexpected payload shape) fall back to confirming all detected
+      // students rather than losing the session.
+      let confirmedStudents;
+      if (raw.length && typeof raw[0] === 'object') {
+        confirmedStudents = raw;
+      } else {
+        confirmedStudents = raw.map((id) => detected[Number(id)]).filter(Boolean);
+      }
+      if (confirmedStudents.length === 0) {
+        confirmedStudents = detected;
+      }
+
       await ExamSessionService.update(session.id, { confirmed_students: confirmedStudents });
       await ExamSessionService.updateStatus(session.id, SESSION_STATES.DETECTING_QUESTIONS);
 

--- a/docs/flows/exam-checker-confirm-students-flow.json
+++ b/docs/flows/exam-checker-confirm-students-flow.json
@@ -1,0 +1,88 @@
+{
+  "_comment": "WhatsApp Flow for Exam Checker — confirm the students detected in uploaded exam papers before grading.",
+  "_instructions": [
+    "1. Registered automatically by `npm run setup:flows` (flow-configs.js → 'Exam Checker Confirm Students').",
+    "2. The resulting Flow ID is written to EXAM_CHECKER_STUDENTS_FLOW_ID in your .env.",
+    "3. Endpoint (data_api_version 3.0, encrypted): POST /api/flows/exam-confirm-students.",
+    "4. The student list is populated dynamically by the endpoint's INIT from the exam session's detected_students.",
+    "5. Modelled on attendance-marking-flow.json (the proven dynamic-list data_exchange pattern in this repo)."
+  ],
+  "_notes": [
+    "CheckboxGroup shows every detected student; the teacher unchecks any mis-detected name.",
+    "Selected ids come back as confirmed_students; the bot maps them to the detected student objects."
+  ],
+  "version": "6.2",
+  "data_api_version": "3.0",
+  "routing_model": {},
+  "screens": [
+    {
+      "id": "CONFIRM_STUDENTS",
+      "title": "Confirm Students",
+      "terminal": true,
+      "refresh_on_back": true,
+      "data": {
+        "heading": {
+          "type": "string",
+          "__example__": "I found 3 students"
+        },
+        "subheading": {
+          "type": "string",
+          "__example__": "Uncheck any name that isn't a real student, then tap Confirm."
+        },
+        "students": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "title": { "type": "string" }
+            }
+          },
+          "__example__": [
+            { "id": "0", "title": "1. Ayesha Khan" },
+            { "id": "1", "title": "2. Bilal Ahmed" },
+            { "id": "2", "title": "3. Fatima Noor" }
+          ]
+        }
+      },
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "Form",
+            "name": "confirm_form",
+            "children": [
+              {
+                "type": "TextHeading",
+                "text": "${data.heading}"
+              },
+              {
+                "type": "TextBody",
+                "text": "${data.subheading}"
+              },
+              {
+                "type": "CheckboxGroup",
+                "name": "confirmed_students",
+                "label": "Students to grade",
+                "required": false,
+                "data-source": "${data.students}",
+                "min-selected-items": 0,
+                "max-selected-items": 100
+              },
+              {
+                "type": "Footer",
+                "label": "Confirm & Grade",
+                "on-click-action": {
+                  "name": "complete",
+                  "payload": {
+                    "confirmed_students": "${form.confirmed_students}"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/exam-checker/confirm-students-flow.test.js
+++ b/tests/exam-checker/confirm-students-flow.test.js
@@ -1,0 +1,113 @@
+/**
+ * Exam-checker "confirm students" Flow (bd-1875) — end-to-end wiring.
+ *
+ * Before this fix the feature was dead at the first interactive step (three
+ * stacked breaks: a nonexistent sendFlowMessage method, an unregistered Flow
+ * asset, and an unrouted NFM completion). These tests lock the three seams of
+ * the rebuilt data_exchange Flow:
+ *   1. endpoint INIT serves the session's detected students;
+ *   2. endpoint data_exchange echoes the selected ids in the completion payload;
+ *   3. the orchestrator maps those id-strings back to detected-student objects.
+ * (The flow-response routing seam is covered by flow-config-conformance +
+ * the endpoint mount; the NFM parse → handleExamFlow path is exercised in
+ * tests/flow-response/.)
+ */
+
+jest.mock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/services/flow-encryption.service', () => ({
+  createErrorResponse: (msg) => ({ error: msg }),
+  handlePing: () => ({ data: { status: 'active' } }),
+}));
+
+// Session store the endpoint + orchestrator read through.
+const mockSession = { current: null };
+jest.mock('../../bot/shared/services/exam-checker/exam-session.service', () => ({
+  getById: jest.fn(async () => mockSession.current),
+  update: jest.fn(async () => mockSession.current),
+  updateStatus: jest.fn(async () => mockSession.current),
+}));
+
+const {
+  handleExamConfirmInit,
+  handleExamConfirmDataExchange,
+} = require('../../bot/shared/routes/exam-confirm-endpoint');
+
+const DETECTED = [
+  { name: 'Ayesha Khan', pageNumbers: [1], confidence: 0.9 },
+  { name: 'Bilal Ahmed', pageNumbers: [2], confidence: 0.8 },
+  { name: 'Fatima Noor', pageNumbers: [3], confidence: 0.7 },
+];
+
+describe('exam-confirm endpoint', () => {
+  beforeEach(() => { mockSession.current = { id: 'sess-1', detected_students: DETECTED }; });
+
+  it('INIT renders the CONFIRM_STUDENTS screen from the session detected_students', async () => {
+    const res = await handleExamConfirmInit('sess-1');
+    expect(res.screen).toBe('CONFIRM_STUDENTS');
+    expect(res.data.students).toHaveLength(3);
+    expect(res.data.students[0]).toEqual({ id: '0', title: '1. Ayesha Khan' });
+    expect(res.data.heading).toMatch(/3 students/);
+  });
+
+  it('INIT errors cleanly when the session is gone', async () => {
+    mockSession.current = null;
+    const res = await handleExamConfirmInit('missing');
+    expect(res.error).toMatch(/not found|expired/i);
+  });
+
+  it('data_exchange echoes the selected ids as a string array in the completion payload', async () => {
+    const res = await handleExamConfirmDataExchange('sess-1', 'CONFIRM_STUDENTS', { confirmed_students: ['0', '2'] });
+    expect(res.screen).toBe('SUCCESS');
+    const params = res.data.extension_message_response.params;
+    expect(params.confirmed_students).toEqual(['0', '2']);
+    expect(params.flow_token).toBe('sess-1');
+  });
+});
+
+describe('orchestrator.handleStudentConfirmation — id→object mapping', () => {
+  beforeEach(() => { jest.resetModules(); });
+
+  it('maps the confirmed id-strings back to the detected-student objects', async () => {
+    jest.doMock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    const updates = [];
+    jest.doMock('../../bot/shared/services/exam-checker/exam-session.service', () => ({
+      update: jest.fn(async (id, patch) => { updates.push(patch); }),
+      updateStatus: jest.fn(async () => {}),
+    }));
+    // Stop the chain at question detection — we only assert the mapping.
+    const Orchestrator = require('../../bot/shared/services/exam-checker/exam-checker.orchestrator').ExamCheckerOrchestrator
+      || require('../../bot/shared/services/exam-checker/exam-checker.orchestrator');
+    const orch = Orchestrator.ExamCheckerOrchestrator || Orchestrator;
+    orch.handleQuestionDetection = jest.fn(async () => ({ text: 'questions next' }));
+
+    const session = { id: 'sess-1', detected_students: DETECTED };
+    const message = { type: 'flow', flowResponse: { confirmed_students: ['0', '2'] } };
+    await orch.handleStudentConfirmation(session, message, 'user-1');
+
+    const confirmedPatch = updates.find((u) => u.confirmed_students);
+    expect(confirmedPatch).toBeDefined();
+    expect(confirmedPatch.confirmed_students.map((s) => s.name)).toEqual(['Ayesha Khan', 'Fatima Noor']);
+  });
+
+  it('falls back to all detected students when the payload resolves to nothing', async () => {
+    jest.doMock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    const updates = [];
+    jest.doMock('../../bot/shared/services/exam-checker/exam-session.service', () => ({
+      update: jest.fn(async (id, patch) => { updates.push(patch); }),
+      updateStatus: jest.fn(async () => {}),
+    }));
+    const mod = require('../../bot/shared/services/exam-checker/exam-checker.orchestrator');
+    const orch = mod.ExamCheckerOrchestrator || mod;
+    orch.handleQuestionDetection = jest.fn(async () => ({ text: 'questions next' }));
+
+    const session = { id: 'sess-1', detected_students: DETECTED };
+    const message = { type: 'flow', flowResponse: { confirmed_students: [] } };
+    await orch.handleStudentConfirmation(session, message, 'user-1');
+
+    const confirmedPatch = updates.find((u) => u.confirmed_students);
+    expect(confirmedPatch.confirmed_students).toHaveLength(3);
+  });
+});

--- a/tests/flow-response/exam-confirm-routing.test.js
+++ b/tests/flow-response/exam-confirm-routing.test.js
@@ -1,0 +1,75 @@
+/**
+ * flow-response routes the exam-checker confirm-students NFM completion to the
+ * exam handler — NOT the "Unknown flow ID" fallthrough (bd-1875).
+ *
+ * This is the third of the three breaks the exam-checker had: the completion
+ * NFM was never routed, so the orchestrator never advanced past
+ * CONFIRMING_STUDENTS. The branch now parses response_json and hands the
+ * confirmed_students to ExamCheckerHandler.handleExamFlow.
+ */
+
+jest.mock('../../bot/shared/config/supabase', () => ({}));
+jest.mock('../../bot/shared/services/whatsapp.service', () => ({ sendMessage: jest.fn() }));
+jest.mock('../../bot/shared/services/reading/passage-generation.service', () => ({}));
+jest.mock('../../bot/shared/services/reading/auto-level-orchestrator.service', () => ({}));
+jest.mock('../../bot/shared/handlers/attendance-flow.handler', () => ({}));
+jest.mock('../../bot/shared/services/attendance-delivery.service', () => ({}));
+
+const mockLogSpy = jest.fn();
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: (...a) => mockLogSpy(...a) }));
+
+const mockHandleExamFlow = jest.fn(async () => ({ handled: true }));
+jest.mock('../../bot/shared/handlers/exam-checker.handler', () => ({
+  handleExamFlow: (...a) => mockHandleExamFlow(...a),
+}));
+
+const EXAM_FLOW_ID = '909090';
+
+function buildFlowMessage(flowId, responseJson) {
+  return {
+    interactive: {
+      type: 'nfm_reply',
+      nfm_reply: { name: `flow_${flowId}`, response_json: responseJson, body: 'Submitted' },
+    },
+  };
+}
+
+describe('flow-response — exam-confirm NFM routing (bd-1875)', () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv, EXAM_CHECKER_STUDENTS_FLOW_ID: EXAM_FLOW_ID };
+    mockLogSpy.mockClear();
+    mockHandleExamFlow.mockClear();
+  });
+  afterAll(() => { process.env = originalEnv; });
+
+  it('routes the exam-confirm completion to handleExamFlow with parsed confirmed_students', async () => {
+    const { handleFlowResponse } = require('../../bot/shared/handlers/flow-response.handler');
+    const ok = await handleFlowResponse(
+      buildFlowMessage(EXAM_FLOW_ID, '{"flow_token":"sess-1","confirmed_students":["0","2"]}'),
+      '923001234567',
+      'user-uuid'
+    );
+
+    expect(ok).toBe(true);
+    expect(mockHandleExamFlow).toHaveBeenCalledTimes(1);
+    const [flowId, flowResponse, from, user] = mockHandleExamFlow.mock.calls[0];
+    expect(flowId).toBe(EXAM_FLOW_ID);
+    expect(flowResponse.confirmed_students).toEqual(['0', '2']);
+    expect(from).toBe('923001234567');
+    expect(user).toEqual({ id: 'user-uuid' });
+
+    const unknown = mockLogSpy.mock.calls.filter(([m]) => typeof m === 'string' && m.includes('Unknown flow ID'));
+    expect(unknown).toEqual([]);
+  });
+
+  it('still falls through to "Unknown flow ID" for an unrelated unconfigured flow id', async () => {
+    const { handleFlowResponse } = require('../../bot/shared/handlers/flow-response.handler');
+    const ok = await handleFlowResponse(buildFlowMessage('not-a-real-flow', '{}'), '923001234567', 'user-uuid');
+    expect(ok).toBe(false);
+    expect(mockHandleExamFlow).not.toHaveBeenCalled();
+    const unknown = mockLogSpy.mock.calls.filter(([m]) => typeof m === 'string' && m.includes('Unknown flow ID'));
+    expect(unknown.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/setup/register-all-flows.test.js
+++ b/tests/setup/register-all-flows.test.js
@@ -93,9 +93,9 @@ describe('register-all-flows', () => {
   // FLOW_CONFIGS
   // -----------------------------------------------------------------------
   describe('FLOW_CONFIGS', () => {
-    it('exports an array of all 11 registerable flow configurations', () => {
+    it('exports an array of all 12 registerable flow configurations', () => {
       expect(Array.isArray(FLOW_CONFIGS)).toBe(true);
-      expect(FLOW_CONFIGS).toHaveLength(11);
+      expect(FLOW_CONFIGS).toHaveLength(12);
     });
 
     it('includes Reading Assessment as a navigate type with no endpointPath', () => {
@@ -361,10 +361,10 @@ describe('register-all-flows', () => {
       expect(Array.isArray(result.errors)).toBe(true);
     });
 
-    it('registers all 11 flows when none exist and endpointBase is provided', async () => {
+    it('registers all flows when none exist and endpointBase is provided', async () => {
       const result = await registerAllFlows(DEFAULT_OPTS);
 
-      expect(result.registered).toHaveLength(11);
+      expect(result.registered).toHaveLength(FLOW_CONFIGS.length);
       expect(result.skipped).toHaveLength(0);
       expect(result.errors).toHaveLength(0);
     });
@@ -406,7 +406,7 @@ describe('register-all-flows', () => {
 
       expect(result.skipped).toHaveLength(1);
       expect(result.skipped[0].name).toBe('Reading Assessment');
-      expect(result.registered).toHaveLength(10);
+      expect(result.registered).toHaveLength(FLOW_CONFIGS.length - 1);
     });
 
     it('skips all flows when all already exist', async () => {
@@ -417,7 +417,7 @@ describe('register-all-flows', () => {
 
       const result = await registerAllFlows(DEFAULT_OPTS);
 
-      expect(result.skipped).toHaveLength(11);
+      expect(result.skipped).toHaveLength(FLOW_CONFIGS.length);
       expect(result.registered).toHaveLength(0);
       expect(result.errors).toHaveLength(0);
     });
@@ -449,7 +449,7 @@ describe('register-all-flows', () => {
       // Reading Assessment should register, attendance flows should be skipped
       expect(result.registered).toHaveLength(1);
       expect(result.registered[0].name).toBe('Reading Assessment');
-      expect(result.skipped).toHaveLength(10);
+      expect(result.skipped).toHaveLength(FLOW_CONFIGS.length - 1);
       expect(result.skipped.map((s) => s.name)).toContain('Attendance Setup');
       expect(result.skipped.map((s) => s.name)).toContain('Attendance Marking');
     });
@@ -479,7 +479,7 @@ describe('register-all-flows', () => {
 
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0].name).toBe('Reading Assessment');
-      expect(result.registered).toHaveLength(10);
+      expect(result.registered).toHaveLength(FLOW_CONFIGS.length - 1);
     });
 
     it('collects errors with flow name and error message', async () => {
@@ -491,7 +491,7 @@ describe('register-all-flows', () => {
 
       const result = await registerAllFlows(DEFAULT_OPTS);
 
-      expect(result.errors).toHaveLength(11);
+      expect(result.errors).toHaveLength(FLOW_CONFIGS.length);
       for (const err of result.errors) {
         expect(err).toHaveProperty('name');
         expect(err).toHaveProperty('error');
@@ -504,7 +504,7 @@ describe('register-all-flows', () => {
     it('calls state.setFlow for each successfully registered flow', async () => {
       await registerAllFlows(DEFAULT_OPTS);
 
-      expect(mockState.setFlow).toHaveBeenCalledTimes(11);
+      expect(mockState.setFlow).toHaveBeenCalledTimes(FLOW_CONFIGS.length);
     });
 
     it('calls state.setFlow for skipped (existing) flows too', async () => {
@@ -515,7 +515,7 @@ describe('register-all-flows', () => {
 
       await registerAllFlows(DEFAULT_OPTS);
 
-      expect(mockState.setFlow).toHaveBeenCalledTimes(11);
+      expect(mockState.setFlow).toHaveBeenCalledTimes(FLOW_CONFIGS.length);
     });
 
     it('does not call state.setFlow for errored flows', async () => {

--- a/tests/setup/validate-flows.test.js
+++ b/tests/setup/validate-flows.test.js
@@ -84,6 +84,10 @@ function buildCompleteState(overrides = {}) {
         flowId: 'flow_reg_11', status: 'PUBLISHED', envVar: 'REGISTRATION_FLOW_ID',
         type: 'endpoint', endpointPath: '/api/flows/registration', registeredAt: now,
       },
+      'Exam Checker Confirm Students': {
+        flowId: 'flow_exam_12', status: 'PUBLISHED', envVar: 'EXAM_CHECKER_STUDENTS_FLOW_ID',
+        type: 'endpoint', endpointPath: '/api/flows/exam-confirm-students', registeredAt: now,
+      },
     },
     templates: {
       welcome_message: { templateId: 'tpl_1', status: 'APPROVED', registeredAt: now },
@@ -150,7 +154,7 @@ describe('validateSetup', () => {
   // Valid setup — all flows PUBLISHED, encryption configured
   // -----------------------------------------------------------------------
   describe('valid setup', () => {
-    it('returns valid=true when all 3 flows are PUBLISHED and encryption is configured', async () => {
+    it('returns valid=true when all flows are PUBLISHED and encryption is configured', async () => {
       fs.writeFileSync(statePath, JSON.stringify(buildCompleteState()));
 
       mockGetFlowDetails.mockResolvedValue({
@@ -184,7 +188,7 @@ describe('validateSetup', () => {
         statePath,
       });
 
-      expect(mockGetFlowDetails).toHaveBeenCalledTimes(11);
+      expect(mockGetFlowDetails).toHaveBeenCalledTimes(Object.keys(buildCompleteState().flows).length);
       expect(mockGetFlowDetails).toHaveBeenCalledWith('flow_ra_1');
       expect(mockGetFlowDetails).toHaveBeenCalledWith('flow_as_2');
       expect(mockGetFlowDetails).toHaveBeenCalledWith('flow_am_3');


### PR DESCRIPTION
## Why

The exam-checker **stalled permanently at student confirmation** — dead at its first interactive step via **three stacked breaks**:

① The orchestrator called `WhatsAppService.sendFlowMessage(...)` — a method that **does not exist** (the real one is `sendFlow`); the TypeError was swallowed by a try/catch so the teacher just saw *"something went wrong, start over."*
② The "confirm students" Flow was **not a registered asset** (absent from `flow-configs.js` and `docs/flows/`), and the orchestrator's return shape (`{flow:{id,data}}`) didn't match `sendFlow`'s (`{flowId,…}`) — proof it had never run end-to-end.
③ Even if launched, the completion **NFM_REPLY was unrouted** in `flow-response.handler` (the only `*_FLOW_ID` not handled there).

Operator chose the **full build (Option A)**: a real `data_exchange` endpoint Flow, modelled exactly on the proven **attendance-marking** flow (the repo's established dynamic-per-session-list pattern).

## What's added

| File | Purpose |
|------|---------|
| `docs/flows/exam-checker-confirm-students-flow.json` | `data_api_version` 3.0, terminal `CONFIRM_STUDENTS` screen, `CheckboxGroup` bound to `${data.students}`, `complete` → `confirmed_students` |
| `bot/scripts/setup/flow-configs.js` | `'Exam Checker Confirm Students'` (endpoint, `/api/flows/exam-confirm-students`, `EXAM_CHECKER_STUDENTS_FLOW_ID`) — now registered by `npm run setup:flows` |
| `bot/shared/routes/exam-confirm-endpoint.js` | INIT loads the session's `detected_students` (flow_token = session id) + renders the screen; data_exchange echoes selected ids (round-trip-safe string array, like attendance) |
| `bot/shared/routes/flow-endpoint.routes.js` | mounts `POST /api/flows/exam-confirm-students` |

## What's rewired

- **`exam-checker.orchestrator.js`**: OCR-complete launches the flow via the correct `data_exchange` shape **when `EXAM_CHECKER_STUDENTS_FLOW_ID` is set**; when it's **not** set it degrades gracefully (auto-confirms detected students → proceeds to grading, no dead-end). `handleStudentConfirmation` maps confirmed id-strings → detected-student objects (with all-detected fallback).
- **`exam-checker.handler.js`**: the 3 `response.flow` sends now call the real `WhatsAppService.sendFlow({flowId, flowToken, header, body, buttonText})`. `sendFlowMessage` is gone.
- **`flow-response.handler.js`**: routes the exam-confirm completion NFM → `ExamCheckerHandler.handleExamFlow` with parsed `confirmed_students`, so the orchestrator advances confirm → detect questions → grade.

## Tests

- `tests/exam-checker/confirm-students-flow.test.js` — endpoint INIT renders detected students; data_exchange echoes selected ids; orchestrator maps ids→objects + all-detected fallback.
- `tests/flow-response/exam-confirm-routing.test.js` — completion NFM routes to `handleExamFlow` (not "Unknown flow ID"); unrelated ids still fall through.
- `register-all-flows.test.js` / `validate-flows.test.js` — count assertions made **dynamic** against `FLOW_CONFIGS.length` (12 flows now) so future flow additions don't break them; canonical count pin → 12.

## Verification

- `node tests/run.js`: **128 suites / 1319 tests pass**
- `flow-config-conformance` green (registered + endpoint mounted + type consistent); source-hygiene green

> **Staging gate (honest caveat):** the encrypted `data_exchange` round-trip against Meta can't be exercised from the OSS checkout. This flow is structurally identical to the verified attendance-marking flow and every seam is unit-tested, but a staging round-trip should be the final gate before trusting it in production — same as any new WhatsApp Flow.

> **Side discovery (deferred → bd-1881):** building the `no-undefined-whatsapp-methods` ratchet for this work surfaced **3 pre-existing latent calls to nonexistent WhatsApp methods** unrelated to exam-checker (`voice-message.handler` `getMediaUrl` ×2, `report-generator` `sendImageFromUrl`, `quiz-delivery` `sendTemplate`). They're the same bug class but need their own fixes (one is an unimplemented template-send path) — deferred to a dedicated PR rather than mixed in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)