### PR TITLE
fix(whatsapp): repair 3 latent calls to nonexistent WhatsAppService methods + lock the contract

### DIFF
--- a/bot/shared/handlers/voice-message.handler.js
+++ b/bot/shared/handlers/voice-message.handler.js
@@ -72,8 +72,7 @@ async function handleVoiceMessage(message, from, user = null) {
           const userLanguage = user.preferred_language || 'en';
 
           // Download and transcribe the audio to get the name
-          const audioUrl = await WhatsAppService.getMediaUrl(audioId);
-          const audioBuffer = await WhatsAppService.downloadMedia(audioUrl);
+          const audioBuffer = await WhatsAppService.downloadMedia(audioId);
 
           // Transcribe with OpenAI Whisper
           const transcriptText = await AudioService.transcribeAudio(audioBuffer, userLanguage);
@@ -126,8 +125,7 @@ async function handleVoiceMessage(message, from, user = null) {
           logToFile('📋 Attendance voice input detected', { userId: user.id, sessionState: attendanceState.state });
 
           // Download the audio
-          const audioUrl = await WhatsAppService.getMediaUrl(audioId);
-          const audioBuffer = await WhatsAppService.downloadMedia(audioUrl);
+          const audioBuffer = await WhatsAppService.downloadMedia(audioId);
 
           // Save to temp file for processing
           const tempAudioPath = path.join(TEMP_DIR, `attendance_${user.id}_${Date.now()}.ogg`);

--- a/bot/shared/services/__mocks__/whatsapp.service.js
+++ b/bot/shared/services/__mocks__/whatsapp.service.js
@@ -16,6 +16,7 @@ const WhatsAppService = {
   sendMessage: jest.fn().mockResolvedValue({ success: true, messageId: 'mock_msg_id' }),
   sendVoiceMessage: jest.fn().mockResolvedValue({ success: true }),
   sendImage: jest.fn().mockResolvedValue({ success: true }),
+  sendImageFromUrl: jest.fn().mockResolvedValue(true),
   sendDocument: jest.fn().mockResolvedValue({ success: true }),
   sendVideo: jest.fn().mockResolvedValue({ success: true }),
   sendSticker: jest.fn().mockResolvedValue({ success: true }),
@@ -39,7 +40,6 @@ const WhatsAppService = {
   // Media handling
   downloadMedia: jest.fn().mockResolvedValue(Buffer.from('mock audio data')),
   uploadMedia: jest.fn().mockResolvedValue({ id: 'mock_media_id' }),
-  getMediaUrl: jest.fn().mockResolvedValue('https://mock-url.com/media'),
 
   // Message marking
   markAsRead: jest.fn().mockResolvedValue({ success: true }),

--- a/bot/shared/services/whatsapp.service.js
+++ b/bot/shared/services/whatsapp.service.js
@@ -446,6 +446,110 @@ class WhatsAppService {
   }
 
   /**
+   * Send an image from a (typically R2) URL via WhatsApp.
+   * R2 URLs are private — WhatsApp can't fetch them directly (see the R2 note
+   * in sendImageWithButtons) — so we download the bytes and hand the temp file
+   * to sendImage, which uploads it to the Media API. Mirrors sendDocumentFromUrl
+   * and sendAudioFromUrl.
+   * @param {string} to - Recipient phone number
+   * @param {string} imageUrl - URL of the image in R2 storage
+   * @param {string} caption - Optional caption
+   * @returns {Promise<boolean>}
+   */
+  static async sendImageFromUrl(to, imageUrl, caption = '') {
+    const path = require('path');
+    const tempDir = path.join(__dirname, '../../temp');
+
+    try {
+      // Extract R2 key from URL and download using R2 client
+      logToFile('Downloading image from R2', { imageUrl });
+      const key = extractKeyFromUrl(imageUrl);
+      const imageBuffer = await downloadFromR2(key);
+
+      // Save to temp file
+      if (!fs.existsSync(tempDir)) {
+        fs.mkdirSync(tempDir, { recursive: true });
+      }
+      const tempFilePath = path.join(tempDir, `img_${Date.now()}.png`);
+      fs.writeFileSync(tempFilePath, imageBuffer);
+
+      logToFile('Image downloaded from R2, sending to WhatsApp', { tempFilePath, size: imageBuffer.length });
+
+      // tempFilePath contains '/' so sendImage takes the upload-file branch.
+      const result = await this.sendImage(to, tempFilePath, caption);
+
+      // Clean up temp file
+      if (fs.existsSync(tempFilePath)) {
+        fs.unlinkSync(tempFilePath);
+      }
+
+      return result;
+    } catch (error) {
+      logToFile('❌ Error sending image from URL', {
+        error: error.message,
+        imageUrl,
+        stack: error.stack
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Send an approved WhatsApp template message.
+   * Used for paid utility/marketing sends outside the 24h customer-service
+   * window (e.g. the quiz invite to cold parents). The template must already be
+   * approved in the WABA — a clone without it registered gets a clear Meta
+   * "template not found" error logged here and a false return (the caller
+   * continues); it is a deployment-config gap, not a code bug.
+   * @param {string} to - Recipient phone number
+   * @param {string} templateName - Approved template name
+   * @param {string} languageCode - Template language code (e.g. 'en', 'ur')
+   * @param {Array} components - Template components (header/body/button params)
+   * @returns {Promise<boolean>}
+   */
+  static async sendTemplate(to, templateName, languageCode, components = []) {
+    try {
+      const payload = {
+        messaging_product: 'whatsapp',
+        to,
+        type: 'template',
+        template: {
+          name: templateName,
+          language: { code: languageCode },
+          ...(components && components.length ? { components } : {}),
+        },
+      };
+
+      const response = await axios.post(
+        `${GRAPH_API_BASE}/${PHONE_NUMBER_ID}/messages`,
+        payload,
+        {
+          headers: {
+            'Authorization': `Bearer ${WHATSAPP_TOKEN}`,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+
+      logToFile('✅ Template message sent', {
+        to: to.slice(-4),
+        templateName,
+        languageCode,
+        response: response.data,
+      });
+      return true;
+    } catch (error) {
+      logToFile('❌ Error sending template message', {
+        error: error.message,
+        errorDetails: error.response?.data,
+        templateName,
+        languageCode,
+      });
+      return false;
+    }
+  }
+
+  /**
    * Send a video message via WhatsApp
    * @param {string} to - Recipient phone number
    * @param {Buffer} videoBuffer - Video file buffer

--- a/bot/tests/bug-005-audio-document.test.js
+++ b/bot/tests/bug-005-audio-document.test.js
@@ -28,7 +28,6 @@ jest.mock('../shared/config/supabase', () => ({
 jest.mock('../shared/services/whatsapp.service', () => ({
   sendMessage: jest.fn(),
   downloadMedia: jest.fn().mockResolvedValue(Buffer.from('fake audio data')),
-  getMediaUrl: jest.fn().mockResolvedValue('https://example.com/audio.ogg'),
   startContinuousTypingIndicator: jest.fn().mockReturnValue({ stop: jest.fn() }),
   sendAudio: jest.fn().mockResolvedValue(true)
 }));

--- a/tests/__mocks__/axios.js
+++ b/tests/__mocks__/axios.js
@@ -1,0 +1,28 @@
+/**
+ * Axios mock for OSS test suite.
+ * axios is a runtime dependency in bot/node_modules but not the root, and the
+ * root test job runs before bot deps install — so source files that require
+ * 'axios' (e.g. whatsapp.service) can't resolve it. This lightweight stub lets
+ * them load; tests configure axios.post/get per case (mockResolvedValue, etc.).
+ */
+
+const respond = () => Promise.resolve({ data: {}, status: 200 });
+
+const axios = jest.fn(respond);
+axios.request = jest.fn(respond);
+axios.get = jest.fn(respond);
+axios.post = jest.fn(respond);
+axios.put = jest.fn(respond);
+axios.patch = jest.fn(respond);
+axios.delete = jest.fn(respond);
+axios.head = jest.fn(respond);
+axios.create = jest.fn(() => axios);
+axios.defaults = { headers: { common: {} } };
+axios.interceptors = {
+  request: { use: jest.fn(), eject: jest.fn() },
+  response: { use: jest.fn(), eject: jest.fn() },
+};
+axios.isAxiosError = jest.fn(() => false);
+
+module.exports = axios;
+module.exports.default = axios;

--- a/tests/__mocks__/form-data.js
+++ b/tests/__mocks__/form-data.js
@@ -1,0 +1,20 @@
+/**
+ * form-data mock for OSS test suite.
+ * form-data lives in bot/node_modules but not the root, and the root test job
+ * runs before bot deps install — so source files that require 'form-data' (e.g.
+ * whatsapp.service) can't resolve it. This stub lets them load; the multipart
+ * upload paths that actually use it aren't exercised in the root suite.
+ */
+
+class FormData {
+  append() {}
+  getHeaders() {
+    return { 'content-type': 'multipart/form-data' };
+  }
+  getBuffer() {
+    return Buffer.from('');
+  }
+}
+
+module.exports = FormData;
+module.exports.default = FormData;

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -15,6 +15,12 @@ module.exports = {
   moduleNameMapper: {
     '^openai$': '<rootDir>/node_modules/openai',
     '^ioredis$': '<rootDir>/node_modules/ioredis',
+    // axios + form-data live in bot/node_modules (not root), and the root test
+    // job runs before bot deps install — so source that requires them can't
+    // resolve. Map to lightweight stubs (same pattern as pino/canvas above) so
+    // the real whatsapp.service can load in the root suite.
+    '^axios$': '<rootDir>/tests/__mocks__/axios.js',
+    '^form-data$': '<rootDir>/tests/__mocks__/form-data.js',
     // bot-only optional/native packages — use lightweight mocks for OSS test suite
     '^pino$': '<rootDir>/tests/__mocks__/pino.js',
     '^canvas$': '<rootDir>/tests/__mocks__/canvas.js',

--- a/tests/setup/no-undefined-whatsapp-methods.test.js
+++ b/tests/setup/no-undefined-whatsapp-methods.test.js
@@ -1,0 +1,103 @@
+/**
+ * No-undefined-WhatsAppService-methods conformance.
+ *
+ * A call to `WhatsAppService.<x>(...)` where `<x>` was never defined on the
+ * class throws `TypeError: WhatsAppService.<x> is not a function` the first
+ * time that branch runs. Depending on the surrounding try/catch the user sees
+ * a crash or silence — either way the feature is dead. This is the exact bug
+ * class that left the exam-checker's `sendFlowMessage` silently broken, and
+ * (per the audit that produced bd-1881) left voice name-capture, voice
+ * attendance, the coaching commitment card, and the out-of-window quiz invite
+ * dead too.
+ *
+ * This guard locks the contract: every `WhatsAppService.<method>(` call site
+ * in shipped bot source must name a real static member of the class.
+ *
+ * Method names are parsed off bot/shared/services/whatsapp.service.js:
+ *   - static methods:  ^\s*static\s+(?:async\s+)?(\w+)\s*\(
+ *   - static fields:   ^\s*static\s+(\w+)\s*=
+ *
+ * Scope is SOURCE only. Test files, __tests__ dirs, and the __mocks__ manual
+ * mock legitimately reference mock-only members (markAsRead, sendVoiceMessage,
+ * ...). The contract we lock is that PRODUCTION code only calls real members —
+ * matching how source-hygiene and the other ratchets scope. Files whose names
+ * end in .test.js, and anything under tests/ / __tests__/ / __mocks__/, are
+ * skipped.
+ *
+ * Allowlist is empty by design.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SERVICE = path.join(ROOT, 'bot/shared/services/whatsapp.service.js');
+const SCAN_ROOT = path.join(ROOT, 'bot');
+
+// Directories that legitimately reference mock-only or not-yet-real members.
+const SKIP_DIRS = new Set(['node_modules', '__tests__', '__mocks__', 'tests', 'coverage', '.git']);
+
+// Call sites allowed to name a non-member. Empty by design — a real undefined
+// call is a bug to fix, not to allowlist.
+const ALLOWLIST = new Set([
+  // None.
+]);
+
+function parseMembers(src) {
+  const members = new Set();
+  const methodRe = /^\s*static\s+(?:async\s+)?(\w+)\s*\(/gm;
+  const fieldRe = /^\s*static\s+(\w+)\s*=/gm;
+  let m;
+  while ((m = methodRe.exec(src))) members.add(m[1]);
+  while ((m = fieldRe.exec(src))) members.add(m[1]);
+  return members;
+}
+
+function findSourceJsFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.isDirectory()) {
+      if (SKIP_DIRS.has(e.name)) continue;
+      out.push(...findSourceJsFiles(path.join(dir, e.name)));
+    } else if (e.name.endsWith('.js') && !e.name.endsWith('.test.js')) {
+      out.push(path.join(dir, e.name));
+    }
+  }
+  return out;
+}
+
+describe('No undefined WhatsAppService methods', () => {
+  const members = parseMembers(fs.readFileSync(SERVICE, 'utf-8'));
+
+  it('parser found the real service members (not vacuously passing)', () => {
+    // If the parser regex breaks, members is empty and every call looks valid.
+    expect(members.has('sendMessage')).toBe(true);
+    expect(members.has('sendFlow')).toBe(true);
+  });
+
+  it('every WhatsAppService.<method>( call in bot source names a real member', () => {
+    const callRe = /WhatsAppService\.(\w+)\s*\(/g;
+    const offenders = [];
+    const files = findSourceJsFiles(SCAN_ROOT).filter((f) => f !== SERVICE);
+
+    for (const filePath of files) {
+      const rel = path.relative(ROOT, filePath);
+      if (ALLOWLIST.has(rel)) continue;
+      const txt = fs.readFileSync(filePath, 'utf-8');
+      let c;
+      while ((c = callRe.exec(txt))) {
+        const name = c[1];
+        if (!members.has(name)) {
+          const line = txt.slice(0, c.index).split('\n').length;
+          offenders.push(
+            `${rel}:${line} — WhatsAppService.${name}() is not a static member of `
+            + 'WhatsAppService. Add the method, or fix the call.'
+          );
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/whatsapp/send-image-from-url.test.js
+++ b/tests/whatsapp/send-image-from-url.test.js
@@ -1,0 +1,85 @@
+/**
+ * WhatsAppService.sendImageFromUrl — bd-1881.
+ *
+ * The coaching commitment-card path called WhatsAppService.sendImageFromUrl(...)
+ * but the method did not exist. The closest method, sendImage, treats any arg
+ * containing '/' as a file path (fs.createReadStream) — so handing it an R2
+ * URL would ENOENT. These tests lock the real method: download the (private)
+ * R2 bytes to a temp file and hand that PATH to sendImage (which uploads it),
+ * never the raw URL; clean up; and degrade to false (not throw) on failure.
+ */
+
+jest.mock('../../bot/shared/utils/constants', () => ({
+  WHATSAPP_TOKEN: 'test-token',
+  PHONE_NUMBER_ID: 'test-phone-id',
+}));
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/storage/r2', () => ({
+  downloadFromR2: jest.fn(),
+  extractKeyFromUrl: jest.fn(),
+}));
+jest.mock('fs', () => {
+  const real = jest.requireActual('fs');
+  return {
+    ...real,
+    existsSync: jest.fn(() => true),
+    mkdirSync: jest.fn(),
+    writeFileSync: jest.fn(),
+    unlinkSync: jest.fn(),
+  };
+});
+
+const fs = require('fs');
+const { downloadFromR2, extractKeyFromUrl } = require('../../bot/shared/storage/r2');
+const WhatsAppService = require('../../bot/shared/services/whatsapp.service');
+
+const R2_URL = 'https://acct.r2.cloudflarestorage.com/bucket/coaching-card-abc.png?sig=xyz';
+
+describe('WhatsAppService.sendImageFromUrl', () => {
+  let sendImageSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    extractKeyFromUrl.mockReturnValue('bucket/coaching-card-abc.png');
+    downloadFromR2.mockResolvedValue(Buffer.from('PNGDATA'));
+    // Spy on the sibling method so we assert the handoff without hitting axios.
+    sendImageSpy = jest.spyOn(WhatsAppService, 'sendImage').mockResolvedValue(true);
+  });
+
+  afterEach(() => sendImageSpy.mockRestore());
+
+  it('is a real static method (not undefined)', () => {
+    expect(typeof WhatsAppService.sendImageFromUrl).toBe('function');
+  });
+
+  it('downloads the R2 object and hands sendImage a FILE PATH, never the raw URL', async () => {
+    const result = await WhatsAppService.sendImageFromUrl('923001234567', R2_URL, 'Your next step');
+
+    expect(result).toBe(true);
+    expect(extractKeyFromUrl).toHaveBeenCalledWith(R2_URL);
+    expect(downloadFromR2).toHaveBeenCalledWith('bucket/coaching-card-abc.png');
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+
+    expect(sendImageSpy).toHaveBeenCalledTimes(1);
+    const [to, pathArg, caption] = sendImageSpy.mock.calls[0];
+    expect(to).toBe('923001234567');
+    expect(caption).toBe('Your next step');
+    // The whole point: sendImage receives a temp file path, not the URL.
+    expect(pathArg).not.toBe(R2_URL);
+    expect(pathArg).not.toMatch(/^https?:/);
+    expect(pathArg).toContain('/'); // a path → sendImage takes its upload-file branch
+  });
+
+  it('cleans up the temp file after sending', async () => {
+    await WhatsAppService.sendImageFromUrl('923001234567', R2_URL, 'cap');
+    const written = fs.writeFileSync.mock.calls[0][0];
+    expect(fs.unlinkSync).toHaveBeenCalledWith(written);
+  });
+
+  it('returns false (does not throw) when the R2 download fails', async () => {
+    downloadFromR2.mockRejectedValue(new Error('R2 403'));
+    const result = await WhatsAppService.sendImageFromUrl('923001234567', R2_URL, 'cap');
+    expect(result).toBe(false);
+    expect(sendImageSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/whatsapp/send-template.test.js
+++ b/tests/whatsapp/send-template.test.js
@@ -1,0 +1,82 @@
+/**
+ * WhatsAppService.sendTemplate — bd-1881.
+ *
+ * The quiz-delivery "cold parent, no 24h window" path called
+ * WhatsAppService.sendTemplate(...) but the method did not exist, so every
+ * out-of-window quiz invite threw a TypeError (swallowed by the per-student
+ * try/catch) and was never delivered. These tests lock the real method:
+ * a faithful WhatsApp `type:'template'` send that returns true on success and
+ * false (logged) on a Meta error — so the caller degrades gracefully.
+ */
+
+// axios + form-data resolve to tests/__mocks__ stubs via jest.config
+// moduleNameMapper (they live in bot/node_modules, absent during the root job).
+jest.mock('../../bot/shared/utils/constants', () => ({
+  WHATSAPP_TOKEN: 'test-token',
+  PHONE_NUMBER_ID: 'test-phone-id',
+}));
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/storage/r2', () => ({
+  downloadFromR2: jest.fn(),
+  extractKeyFromUrl: jest.fn(),
+}));
+
+const axios = require('axios'); // the mapped stub — axios.post is a jest.fn
+const WhatsAppService = require('../../bot/shared/services/whatsapp.service');
+
+describe('WhatsAppService.sendTemplate', () => {
+  beforeEach(() => {
+    axios.post.mockReset();
+    axios.post.mockResolvedValue({ data: {}, status: 200 });
+  });
+
+  it('is a real static method (not undefined)', () => {
+    expect(typeof WhatsAppService.sendTemplate).toBe('function');
+  });
+
+  it('POSTs a type:template payload to the messages endpoint and returns true', async () => {
+    axios.post.mockResolvedValue({ data: { messages: [{ id: 'wamid.X' }] } });
+
+    const components = [
+      { type: 'body', parameters: [{ type: 'text', text: 'Ali' }, { type: 'text', text: 'Fractions' }] },
+    ];
+    const result = await WhatsAppService.sendTemplate('923001234567', 'quiz_invitation_en', 'en', components);
+
+    expect(result).toBe(true);
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    const [url, payload, opts] = axios.post.mock.calls[0];
+    expect(url).toContain('/test-phone-id/messages');
+    expect(payload).toMatchObject({
+      messaging_product: 'whatsapp',
+      to: '923001234567',
+      type: 'template',
+      template: {
+        name: 'quiz_invitation_en',
+        language: { code: 'en' },
+        components,
+      },
+    });
+    expect(opts.headers.Authorization).toBe('Bearer test-token');
+  });
+
+  it('passes the language code through verbatim (ur)', async () => {
+    axios.post.mockResolvedValue({ data: {} });
+    await WhatsAppService.sendTemplate('923001234567', 'quiz_invitation_ur', 'ur', []);
+    expect(axios.post.mock.calls[0][1].template.language.code).toBe('ur');
+  });
+
+  it('omits the components key when none are given', async () => {
+    axios.post.mockResolvedValue({ data: {} });
+    await WhatsAppService.sendTemplate('923001234567', 'plain_template', 'en');
+    expect(axios.post.mock.calls[0][1].template).not.toHaveProperty('components');
+  });
+
+  it('returns false (does not throw) when Meta rejects the template', async () => {
+    axios.post.mockRejectedValue({
+      message: 'Request failed with status code 400',
+      response: { data: { error: { message: 'Template name does not exist' } } },
+    });
+    const result = await WhatsAppService.sendTemplate('923001234567', 'missing_template', 'en', []);
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

A static audit surfaced **three pre-existing calls to `WhatsAppService` methods that were never defined on the class** — the same bug class that recently left the exam-checker's `sendFlowMessage` silently dead. Each throws `TypeError: ... is not a function` the first time its branch runs; depending on the surrounding `try/catch` the user sees a crash or silence, but the feature never works. This PR fixes all three (each restores a path that is dead today) and adds a ratchet so the class can't come back.

## The three fixes

| # | Call site | Was | Now |
|---|-----------|-----|-----|
| 1 | `voice-message.handler.js:75` & `:129` | `getMediaUrl(audioId)` → `downloadMedia(audioUrl)` | `downloadMedia(audioId)` — `getMediaUrl` never existed, and `downloadMedia(mediaId)` already resolves the URL internally via `getMediaInfo`. Voice name-capture + voice attendance throw on the first line today. |
| 2 | `coaching/report-generator.service.js:260` | `sendImageFromUrl(from, cardUrl, caption)` | New `WhatsAppService.sendImageFromUrl` — downloads the (private) R2 bytes and hands the temp file to `sendImage`, mirroring `sendDocumentFromUrl`/`sendAudioFromUrl`. `sendImage` treats a `/`-containing arg as a file path, so the R2 URL would `ENOENT`. The commitment card uploads but never sends today. |
| 3 | `quiz/quiz-delivery.service.js:317` | `sendTemplate(...)` | New `WhatsAppService.sendTemplate` — a faithful WhatsApp `type:'template'` send (mirrors the existing carousel template payloads). Cold parents (no open 24h window) get **zero** quiz invites today. |

### Why implement `sendTemplate` rather than gate the path

The call site fully specifies the approved templates (names, language codes, component structure); `sendTemplate` was **already present in the test mock**; and there's already a `type:'template'` payload pattern in the file. A clone that hasn't registered the template **degrades gracefully** — the method logs the Meta error and returns `false`, and the caller's per-student `try/catch` continues — instead of throwing an opaque `TypeError`. Gating would discard a path that works in deployment.

## The ratchet

`tests/setup/no-undefined-whatsapp-methods.test.js` parses the static members off `whatsapp.service.js` and asserts **every `WhatsAppService.<m>(` call in bot source** names a real member. Source-scoped (tests/`__tests__`/`__mocks__` excluded — those legitimately reference mock-only members); empty allowlist; sanity-checks the parser found `sendMessage` + `sendFlow` so it can't pass vacuously. It was RED on the four sites above, GREEN after the fixes (TDD).

## Also

- Dropped the dead `getMediaUrl` mock from the manual mock; added `sendImageFromUrl` to it.
- Mapped `axios` in `jest.config` so the root suite can `jest.mock('axios')` (it lives in `bot/node_modules`; source already resolves it there, so this is a no-op for non-test code).

## Tests

`node tests/run.js` → **131 suites / 1330 tests green** (+1 ratchet suite, +2 method suites). New method tests cover the `sendImageFromUrl` R2-download → file-path handoff (never passing the raw URL) and the `sendTemplate` payload shape + graceful-on-error behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)