### PR TITLE
fix(tests): make orphan audit + image-path checks cross-platform (Windows)

### DIFF
--- a/tests/setup/_audit-helpers/require-graph.js
+++ b/tests/setup/_audit-helpers/require-graph.js
@@ -170,7 +170,7 @@ function* walkJs(dir) {
   }
   for (const e of entries) {
     const full = path.join(dir, e.name);
-    if (full.includes('/node_modules/')) continue;
+    if (full.includes(`${path.sep}node_modules${path.sep}`)) continue;
     if (e.isDirectory()) {
       yield* walkJs(full);
     } else if (e.isFile() && e.name.endsWith('.js')) {
@@ -383,7 +383,9 @@ function auditedFiles() {
   for (const d of AUDITED_DIRS) {
     if (!fs.existsSync(d)) continue;
     for (const f of walkJs(d)) {
-      if (f.includes('/__mocks__/') || f.includes('/__tests__/')) continue;
+      // path.sep, not '/': walkJs returns OS-separated paths, so a literal
+      // '/' would skip this exclusion on Windows and flag every mock as orphan.
+      if (f.includes(`${path.sep}__mocks__${path.sep}`) || f.includes(`${path.sep}__tests__${path.sep}`)) continue;
       out.push(path.resolve(f));
     }
   }

--- a/tests/whatsapp/send-image-from-url.test.js
+++ b/tests/whatsapp/send-image-from-url.test.js
@@ -67,7 +67,7 @@ describe('WhatsAppService.sendImageFromUrl', () => {
     // The whole point: sendImage receives a temp file path, not the URL.
     expect(pathArg).not.toBe(R2_URL);
     expect(pathArg).not.toMatch(/^https?:/);
-    expect(pathArg).toContain('/'); // a path → sendImage takes its upload-file branch
+    expect(pathArg).toMatch(/[\\/]/); // a path (POSIX `/` or Windows `\`) → sendImage takes its upload-file branch
   });
 
   it('cleans up the temp file after sending', async () => {


### PR DESCRIPTION
## Problem
Two test-harness assumptions hard-code the POSIX `/` separator, so `npm test`
fails on Windows even on a clean checkout (both pass on Linux CI):

1. `tests/setup/_audit-helpers/require-graph.js` — `walkJs` builds paths with
   `path.join()` (native separators), but the `node_modules` guard and the
   `__mocks__`/`__tests__` exclusion tested for the literal `/`. On Windows
   (paths use `\`) every Jest `__mocks__` file in the audited dirs (20) is
   wrongly reported as an orphan module.
2. `tests/whatsapp/send-image-from-url.test.js` — `expect(pathArg).toContain('/')`
   asserts a file path; Windows temp paths use `\`, so it fails although the
   code under test behaves correctly.

## Fix
- Match on `path.sep` instead of a hard-coded `/`, following the existing idiom
  in `tests/setup/source-hygiene.test.js`.
- Assert `/[\\/]/` instead of `toContain('/')`.

Test-only; no production code touched.

## Verification
`npm test` on Windows: **1320 passed, 1 skipped, 0 failed** (was 2 failed).
Behaviour on Linux is unchanged.