### PR TITLE
Add Slack and Discord as concurrent messaging channels

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -120,10 +120,58 @@ instead; and **they need a second phone number to message it from**, because Rum
 and `validate`; `WEBHOOK_VERIFY_TOKEN` has a `generate()`). Then `defaultProbes.whatsapp(env)`, then
 `META_REMAINING_STEPS` for what only they can do in Meta's console.
 
-### F. Finish
+### F. Connect Slack and Discord (optional, additive)
+
+Both run **alongside** WhatsApp, not instead of it — a teacher can reach Rumi on any combination of the
+three at once, on the same account. Neither is gated by `CHANNEL_DRIVER`; each turns on the moment its own
+env vars are present. Ask plainly:
+
+> Also connect Slack? Also connect Discord?
+
+If the answer is no to either, skip it — WhatsApp alone is a complete setup.
+
+**Slack.** Slack posts every event/interaction to a Request URL it calls, so the bot must be reachable at a
+public HTTPS address first (an `ngrok http <port>` tunnel while testing locally, the real host in
+production) — get that URL before starting the walkthrough. Then:
+
+```js
+const wizard = require('./bot/scripts/setup/interactive-setup');
+await wizard.walkSlackAppConfig(io, baseUrl);   // the app-creation checklist, one screen at a time
+```
+
+walks through creating the app, Bot Token Scopes, Event Subscriptions, Interactivity, and the 9 Slash
+Commands — each screen already has the exact values written into
+[bot/scripts/setup/fields.js](../../../bot/scripts/setup/fields.js) (`SLACK_BOT_SCOPES`,
+`SLACK_SLASH_COMMANDS`, `slackRequestUrls(baseUrl)`). Collect `SLACK_SIGNING_SECRET` and `SLACK_BOT_TOKEN`,
+write them, then verify with `defaultProbes.slack(env)` — it checks not just that the token authenticates
+but that it actually carries all 5 required scopes, naming any that are missing.
+
+**Discord.** No public URL needed at all — Discord uses a persistent Gateway connection the bot opens
+itself, not a webhook Discord calls. Shorter walkthrough:
+
+```js
+await wizard.walkDiscordAppConfig(io);   // create app, bot token, Message Content intent, invite, app id
+```
+
+Collect `DISCORD_BOT_TOKEN` and `DISCORD_APPLICATION_ID`, write them, verify with
+`defaultProbes.discord(env)` (lighter than Slack's — just confirms the token authenticates and the
+application id matches; Discord has no clean per-permission check the way Slack's `x-oauth-scopes` header
+gives one). Then register the slash commands — this is a script, not a manual per-command UI step like
+Slack's:
+
+```bash
+npm run discord:register-commands
+```
+
+Flag the one privileged setting explicitly: **Message Content Intent** must be turned on (Bot tab →
+Privileged Gateway Intents) or the bot will connect but never see what a teacher actually types. It's
+self-togglable with no review below 100 servers.
+
+### G. Finish
 
 Run `rumi doctor` and read it back in plain language. Then tell them: `rumi start`, message the number from
-their **second** number, and try `Hi`, `/menu`, `/reading test`.
+their **second** number, and try `Hi`, `/menu`, `/reading test` — and the same on Slack/Discord if either
+was connected, each in its own DM with the bot.
 
 ### What you add that the wizard cannot
 

--- a/.env.template
+++ b/.env.template
@@ -108,6 +108,24 @@ WABA_ID=CHANGEME-waba-id
 # ███  OPTIONAL — set a block's keys to switch that feature on  █████████████
 # ============================================================================
 
+# --- ENABLES: Slack channel — runs ALONGSIDE your WhatsApp driver above ------
+# Not selected via CHANNEL_DRIVER — Slack is additive, works in BOTH sandbox
+# and production, and can run at the same time as WhatsApp. Set BOTH vars to
+# turn it on; leave both blank and the bot is WhatsApp-only, unaffected.
+#
+# Setup: create a Slack app at https://api.slack.com/apps, enable
+# Interactivity & Event Subscriptions, point both Request URLs at
+# https://<your-host>/api/slack/events and https://<your-host>/api/slack/interactions,
+# add the chat:write / files:write / reactions:write bot scopes, then install
+# the app to your workspace.
+
+# Signing secret (Basic Information -> App Credentials) — verifies every
+# request actually came from Slack.
+SLACK_SIGNING_SECRET=
+
+# Bot User OAuth Token (OAuth & Permissions), starts with xoxb-
+SLACK_BOT_TOKEN=
+
 # --- LLM: advanced (optional) -----------------------------------------------
 
 # LLM provider: 'openrouter' (default, recommended) or 'openai' (direct)

--- a/.env.template
+++ b/.env.template
@@ -126,6 +126,31 @@ SLACK_SIGNING_SECRET=
 # Bot User OAuth Token (OAuth & Permissions), starts with xoxb-
 SLACK_BOT_TOKEN=
 
+# --- ENABLES: Discord channel — runs ALONGSIDE your WhatsApp driver above ----
+# Not selected via CHANNEL_DRIVER — Discord is additive, works in BOTH sandbox
+# and production, and can run at the same time as WhatsApp and Slack. Set BOTH
+# vars to turn it on; leave both blank and the bot is unaffected.
+#
+# Setup: create an application at https://discord.com/developers/applications,
+# add a Bot, enable the "Message Content" privileged intent, generate an
+# invite URL (OAuth2 -> URL Generator, scopes: bot + applications.commands),
+# add the bot to a server, then run: npm run discord:register-commands
+#
+# Unlike Slack, there is no Request URL to configure — this bot uses Discord's
+# Gateway (a persistent connection), which also delivers slash commands and
+# button/select interactions, so no separate signed HTTP endpoint is needed.
+
+# Bot Token (Bot tab -> Reset Token)
+DISCORD_BOT_TOKEN=
+
+# Application ID (General Information tab) — used to register slash commands
+DISCORD_APPLICATION_ID=
+
+# Optional: a test server's guild id, for guild-scoped slash command
+# registration (instant propagation, vs up to ~1hr for global). Only used by
+# `npm run discord:register-commands` — leave blank to register globally.
+DISCORD_TEST_GUILD_ID=
+
 # --- LLM: advanced (optional) -----------------------------------------------
 
 # LLM provider: 'openrouter' (default, recommended) or 'openai' (direct)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,15 @@ jobs:
         run: npm ci
 
       - name: Run unit tests
-        run: npm test
+        # --maxWorkers is forced well above the runner's core count: this repo's
+        # test suite has dozens of files that mock bot/shared/config/supabase
+        # per-file (jest.mock inside the test rather than a shared __mocks__),
+        # and under low worker counts too many of those pile into one worker
+        # process, where the per-file mock intercept becomes unreliable —
+        # confirmed locally as a real, reproducible dose-response (33-50%
+        # failure rate at 1-2 workers, 0/8+ runs at 8 workers). More workers
+        # means fewer files share a process, not more raw parallelism per se.
+        run: npm test -- --maxWorkers=8
 
       - name: Install canvas system dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev libpixman-1-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,12 @@ jobs:
         # and under low worker counts too many of those pile into one worker
         # process, where the per-file mock intercept becomes unreliable —
         # confirmed locally as a real, reproducible dose-response (33-50%
-        # failure rate at 1-2 workers, 0/8+ runs at 8 workers). More workers
-        # means fewer files share a process, not more raw parallelism per se.
-        run: npm test -- --maxWorkers=8
+        # failure rate at 1-2 workers, occasional residual flakes still seen
+        # at 8 workers, 0/5+ runs at 16 workers). More workers means fewer
+        # files share a process, not more raw parallelism per se — safe to
+        # over-provision well past the runner's core count for a suite this
+        # lightweight (full run finishes in ~17s even at 16 workers).
+        run: npm test -- --maxWorkers=16
 
       - name: Install canvas system dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev libpixman-1-dev

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -22,6 +22,7 @@
         "baileys": "^7.0.0-rc14",
         "bcryptjs": "^3.0.3",
         "bullmq": "^5.67.1",
+        "discord.js": "^14.27.0",
         "dotenv": "^17.2.3",
         "ejs": "^3.1.10",
         "exceljs": "^4.4.0",
@@ -1190,6 +1191,136 @@
       "dependencies": {
         "hashery": "^1.5.1",
         "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.3.tgz",
+      "integrity": "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.50",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "^6.27.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2873,6 +3004,39 @@
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
@@ -3343,6 +3507,15 @@
       "integrity": "sha512-JGAJC/ZZDhcrrmepU4sPLQLIOIAgs5oIK+Ieq90K8fdaNMhfdfqmYatJdgif1NDQtvrSlTOGJDUYHIDunuufOg==",
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -3715,6 +3888,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
@@ -5234,6 +5417,42 @@
       "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
       "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.53",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.53.tgz",
+      "integrity": "sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.27.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
+      "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.5",
+        "discord-api-types": "^0.38.49",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "^6.27.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -7740,6 +7959,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -7813,6 +8038,12 @@
       "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
       "license": "MIT"
     },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
@@ -7860,6 +8091,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.1.tgz",
+      "integrity": "sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==",
+      "license": "MIT"
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -10187,6 +10424,12 @@
         "node": "*"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10289,6 +10532,15 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "8.3.0",

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -15,6 +15,7 @@
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@ffprobe-installer/ffprobe": "^2.1.2",
         "@google/generative-ai": "^0.24.1",
+        "@slack/web-api": "^7.19.0",
         "@supabase/supabase-js": "^2.78.0",
         "aws-sdk": "^2.1691.0",
         "axios": "^1.13.1",
@@ -2899,6 +2900,105 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@slack/logger": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+      "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/logger/node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.22.0.tgz",
+      "integrity": "sha512-sZ9lIgJhPX2qft/tKWiklFlc0o1FWeI7QtciZJfW1+ErH1eGGHvOZ8e73sleTCFEFJp1q/R0WeS8Oa7AsiDprg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.19.0.tgz",
+      "integrity": "sha512-ItjyjEZml+LDH8CjcCLRLJHh7VZtevPKExrRN3l5KWyBliyDnGAeoO4Y+K+fFBmRpKLYVPgqWMX4THldv2HVtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.21.0",
+        "@types/node": ">=18",
+        "@types/retry": "0.12.0",
+        "axios": "^1.16.0",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/@slack/web-api/node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@smithy/core": {
       "version": "3.24.5",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
@@ -3222,6 +3322,12 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
@@ -6491,6 +6597,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -8386,6 +8498,15 @@
       "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8444,6 +8565,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-timeout": {
@@ -9181,6 +9315,15 @@
       "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
       "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
       "license": "MIT"
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/rimraf": {
       "version": "2.7.1",
@@ -10145,6 +10288,12 @@
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unicode-properties": {

--- a/bot/package.json
+++ b/bot/package.json
@@ -39,6 +39,7 @@
     "baileys": "^7.0.0-rc14",
     "bcryptjs": "^3.0.3",
     "bullmq": "^5.67.1",
+    "discord.js": "^14.27.0",
     "dotenv": "^17.2.3",
     "ejs": "^3.1.10",
     "exceljs": "^4.4.0",

--- a/bot/package.json
+++ b/bot/package.json
@@ -32,6 +32,7 @@
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.1.2",
     "@google/generative-ai": "^0.24.1",
+    "@slack/web-api": "^7.19.0",
     "@supabase/supabase-js": "^2.78.0",
     "aws-sdk": "^2.1691.0",
     "axios": "^1.13.1",

--- a/bot/scripts/setup/discord-register-commands.js
+++ b/bot/scripts/setup/discord-register-commands.js
@@ -1,0 +1,107 @@
+/**
+ * Registers Discord slash commands via the REST API.
+ *
+ * Unlike Meta (no slash-command concept) or Slack (a manual app-config-UI
+ * step, one command entered by hand at a time), Discord slash-command
+ * registration is a single REST call: `PUT /applications/{id}/commands`
+ * (global) or `PUT /applications/{id}/guilds/{guildId}/commands`
+ * (guild-scoped — instant propagation, vs up to ~1hr for global). This
+ * script is what the setup wizard actually runs, not a manual UI step.
+ *
+ * The command LIST is not a second hardcoded copy — it reuses
+ * fields.js's SLACK_SLASH_COMMANDS as the single shared source of truth,
+ * stripping the leading "/" (Discord's registration API wants bare names).
+ * All 9 existing command names are already Discord-legal (lowercase, no
+ * spaces) — confirmed, no renaming needed.
+ *
+ * @module discord-register-commands
+ */
+
+const { SLACK_SLASH_COMMANDS } = require('./fields');
+
+// One-line description per command, shown to the user in Discord's slash
+// command autocomplete UI (Discord requires a non-empty description, unlike
+// Slack which has no such requirement for its own commands).
+const COMMAND_DESCRIPTIONS = {
+  portal: 'Open your Rumi teacher portal',
+  readingtest: 'Start a reading assessment for a student',
+  quiz: 'Create a quiz for your class',
+  video: 'Generate a short teaching video',
+  menu: 'See everything Rumi can do',
+  register: 'Register your teacher profile',
+  language: 'Change your reply language',
+  settings: 'Update your language and observation framework',
+  status: 'Check your account and feature status',
+};
+
+/**
+ * Strips the leading "/" and builds Discord's bare command list, e.g.
+ * ['/portal', '/readingtest', ...] -> ['portal', 'readingtest', ...].
+ * Exported so a test can diff this against SLACK_SLASH_COMMANDS directly,
+ * structurally guaranteeing the two lists cannot drift apart.
+ */
+function bareCommandNames() {
+  return SLACK_SLASH_COMMANDS.map((cmd) => cmd.replace(/^\//, ''));
+}
+
+/**
+ * Builds the JSON body every command list needs for the PUT call —
+ * {name, description} pairs, one per command. Uses discord.js's
+ * SlashCommandBuilder for the same validation Discord's own API applies
+ * (name/description length + charset), rather than hand-building plain
+ * objects that could pass a typo straight through to a rejected API call.
+ * @returns {Array<object>} JSON command definitions, ready for REST#put
+ */
+function buildCommandDefinitions() {
+  const { SlashCommandBuilder } = require('discord.js');
+  return bareCommandNames().map((name) => {
+    const description = COMMAND_DESCRIPTIONS[name] || `Run the /${name} command`;
+    return new SlashCommandBuilder().setName(name).setDescription(description).toJSON();
+  });
+}
+
+/**
+ * Registers every command from fields.js's SLACK_SLASH_COMMANDS list.
+ * @param {object} [options]
+ * @param {string} [options.token] - defaults to process.env.DISCORD_BOT_TOKEN
+ * @param {string} [options.applicationId] - defaults to process.env.DISCORD_APPLICATION_ID
+ * @param {string} [options.guildId] - if set, registers guild-scoped (instant propagation,
+ *   for fast local iteration); omitted registers globally (production, ~1hr propagation)
+ * @returns {Promise<{registered: number, guildScoped: boolean, commands: string[]}>}
+ */
+async function registerDiscordCommands(options = {}) {
+  const { REST, Routes } = require('discord.js');
+
+  const token = options.token || process.env.DISCORD_BOT_TOKEN;
+  const applicationId = options.applicationId || process.env.DISCORD_APPLICATION_ID;
+  const guildId = options.guildId || process.env.DISCORD_TEST_GUILD_ID || null;
+
+  if (!token) throw new Error('discord-register-commands: DISCORD_BOT_TOKEN is required');
+  if (!applicationId) throw new Error('discord-register-commands: DISCORD_APPLICATION_ID is required');
+
+  const commands = buildCommandDefinitions();
+  const rest = new REST({ version: '10' }).setToken(token);
+  const route = guildId
+    ? Routes.applicationGuildCommands(applicationId, guildId)
+    : Routes.applicationCommands(applicationId);
+
+  await rest.put(route, { body: commands });
+
+  return { registered: commands.length, guildScoped: Boolean(guildId), commands: commands.map((c) => c.name) };
+}
+
+module.exports = { registerDiscordCommands, buildCommandDefinitions, bareCommandNames, COMMAND_DESCRIPTIONS };
+
+if (require.main === module) {
+  registerDiscordCommands()
+    .then((result) => {
+      const scope = result.guildScoped ? 'guild (instant)' : 'global (~1hr propagation)';
+      // eslint-disable-next-line no-console -- CLI script, not application logging
+      console.log(`✅ Registered ${result.registered} Discord slash commands (${scope}): ${result.commands.map((c) => `/${c}`).join(', ')}`);
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console -- CLI script, not application logging
+      console.error(`❌ Failed to register Discord slash commands: ${error.message}`);
+      process.exitCode = 1;
+    });
+}

--- a/bot/scripts/setup/doctor.js
+++ b/bot/scripts/setup/doctor.js
@@ -253,6 +253,29 @@ const defaultProbes = {
 
     return { ok: true, detail: `connected as ${body.team || 'your workspace'}, all required scopes present` };
   },
+  /**
+   * Lighter than the Slack probe — confirms the bot token authenticates (and,
+   * as a bonus, that the returned application id matches DISCORD_APPLICATION_ID)
+   * with no per-permission breakdown. Discord has no clean single-call
+   * equivalent to Slack's x-oauth-scopes response header, so this is close
+   * to the only cheap verification option available, not just a shortcut.
+   */
+  async discord(env) {
+    const res = await fetch('https://discord.com/api/v10/applications/@me', {
+      headers: { Authorization: `Bot ${env.DISCORD_BOT_TOKEN}` },
+    });
+    if (!res.ok) return { ok: false, detail: `HTTP ${res.status}` };
+
+    const body = await res.json();
+    if (env.DISCORD_APPLICATION_ID && body.id && body.id !== env.DISCORD_APPLICATION_ID) {
+      return {
+        ok: false,
+        detail: `token authenticates, but its application id (${body.id}) does not match DISCORD_APPLICATION_ID (${env.DISCORD_APPLICATION_ID})`,
+      };
+    }
+
+    return { ok: true, detail: `connected as ${body.name || 'your application'}` };
+  },
   async redis(env) {
     // Lazy require so the bot's redis lib is optional at doctor time.
     const IORedis = require('ioredis');

--- a/bot/scripts/setup/doctor.js
+++ b/bot/scripts/setup/doctor.js
@@ -26,6 +26,7 @@ const fs = require('fs');
 const path = require('path');
 const {
   REQUIRED_VARS, CHANNEL_REQUIRED_VARS, FEATURES, isSet, requiredVarsFor, resolveChannelDriver,
+  resolveActiveChannels,
 } = require('../../shared/config/feature-availability');
 const { DRIVERS, isProductionTier } = require('../../shared/services/messaging/channel-registry');
 const { FLOW_CONFIGS } = require('./flow-configs');
@@ -99,6 +100,11 @@ function analyzeEnv(env) {
   const requiredPresent = requiredVars.filter((k) => isSet(env[k]));
   const missingRequired = requiredVars.filter((k) => !isSet(env[k]));
 
+  // Additive channels (Slack, Discord, ...) run ALONGSIDE the one resolved
+  // `channel` above — never boot-blocking, purely informational here, same
+  // presence-gate shape as FEATURES.
+  const activeChannels = resolveActiveChannels(env);
+
   const features = FEATURES.map((f) => {
     // Features may declare keys two ways:
     //   - `keys`     → ALL required (the default, conjunctive)
@@ -125,7 +131,7 @@ function analyzeEnv(env) {
   });
 
   return {
-    requiredPresent, missingRequired, features, channel, channelDriverTypo,
+    requiredPresent, missingRequired, features, channel, channelDriverTypo, activeChannels,
   };
 }
 
@@ -316,6 +322,7 @@ async function runDoctor({
     flowResults,
     channel: analysis.channel,
     channelDriverTypo: analysis.channelDriverTypo,
+    activeChannels: analysis.activeChannels,
   };
 }
 
@@ -344,6 +351,9 @@ function formatReport(result) {
       `⚠️  CHANNEL_DRIVER="${result.channelDriverTypo}" is not a recognized driver (valid: meta | baileys) —`
       + ` falling back to ${result.channel}.`
     );
+  }
+  if (result.activeChannels && result.activeChannels.length) {
+    lines.push(`Additional channels active: ${result.activeChannels.join(', ')}`);
   }
   lines.push('');
   if (result.missingRequired.length) {

--- a/bot/scripts/setup/doctor.js
+++ b/bot/scripts/setup/doctor.js
@@ -53,6 +53,8 @@ const KEY_SOURCES = {
   AZURE_SPEECH_REGION: 'portal.azure.com → Speech resource',
   KIE_API_KEY: 'kie.ai → API Key',
   MISTRAL_API_KEY: 'console.mistral.ai → API Keys',
+  SLACK_SIGNING_SECRET: 'api.slack.com/apps → your app → Basic Information → App Credentials',
+  SLACK_BOT_TOKEN: 'api.slack.com/apps → your app → OAuth & Permissions → Bot User OAuth Token',
   AXIOM_DATASET: 'axiom.co → Datasets',
   AXIOM_TOKEN: 'axiom.co → Settings → API tokens',
 };
@@ -215,6 +217,41 @@ const defaultProbes = {
       `https://graph.facebook.com/v21.0/${env.PHONE_NUMBER_ID}?access_token=${env.WHATSAPP_TOKEN}`,
     );
     return { ok: res.ok, detail: `HTTP ${res.status}` };
+  },
+  /**
+   * Checks the bot token AND that it actually carries every scope Rumi's
+   * Slack driver needs (chat:write, im:write, reactions:write, files:read,
+   * files:write). A token that authenticates but lacks one is the single most
+   * common Slack setup failure — the scope error only ever surfaces later,
+   * mid-conversation, as an opaque "missing_scope" with no indication of
+   * which of the five is absent. auth.test succeeding is not enough on its
+   * own: Slack reports the token's granted scopes in the `x-oauth-scopes`
+   * response header, not in the JSON body, so that header is what this reads.
+   */
+  async slack(env) {
+    const REQUIRED_SCOPES = ['chat:write', 'im:write', 'reactions:write', 'files:read', 'files:write'];
+    const res = await fetch('https://slack.com/api/auth.test', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${env.SLACK_BOT_TOKEN}` },
+    });
+    if (!res.ok) return { ok: false, detail: `HTTP ${res.status}` };
+
+    const body = await res.json();
+    if (!body.ok) {
+      return { ok: false, detail: `Slack rejected the token: ${body.error || 'unknown error'}` };
+    }
+
+    const granted = (res.headers.get('x-oauth-scopes') || '').split(',').map((s) => s.trim()).filter(Boolean);
+    const missing = REQUIRED_SCOPES.filter((s) => !granted.includes(s));
+    if (missing.length) {
+      return {
+        ok: false,
+        detail: `token works, but is missing ${missing.length === 1 ? 'scope' : 'scopes'}: ${missing.join(', ')} `
+          + '— add them under OAuth & Permissions → Scopes → Bot Token Scopes, then reinstall the app',
+      };
+    }
+
+    return { ok: true, detail: `connected as ${body.team || 'your workspace'}, all required scopes present` };
   },
   async redis(env) {
     // Lazy require so the bot's redis lib is optional at doctor time.

--- a/bot/scripts/setup/env-file.js
+++ b/bot/scripts/setup/env-file.js
@@ -26,6 +26,26 @@ function keyOf(line) {
   return trimmed.slice(0, eq).trim();
 }
 
+// Returns the KEY for a COMMENTED-OUT `# KEY=VALUE` line specifically (e.g.
+// `.env.template`'s own placeholders, or a var a user temporarily disabled by
+// prefixing it with `#`) — distinct from an ordinary prose comment line, which
+// has no `=` at all right after its own leading `#`. Used only to find where
+// to UNCOMMENT + patch a key that has no active line, instead of appending a
+// second, live copy at the end of the file while the commented placeholder
+// sits above it, stale and confusing to read.
+function commentedKeyOf(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('#')) return null;
+  const withoutHash = trimmed.slice(1).trim();
+  const eq = withoutHash.indexOf('=');
+  if (eq === -1) return null;
+  const key = withoutHash.slice(0, eq).trim();
+  // A real KEY is a plain identifier (letters/digits/underscore) — this is
+  // what actually distinguishes `# SLACK_BOT_TOKEN=xoxb-...` from prose like
+  // `# note: this only applies if CHANNEL_DRIVER=meta`.
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(key) ? key : null;
+}
+
 /**
  * @param {string} envPath
  * @returns {Record<string,string>} parsed KEY=VALUE pairs (best-effort; lines
@@ -75,22 +95,43 @@ function writeEnvVars(envPath, updates, opts = {}) {
   const lines = readLines(envPath);
   const remaining = new Set(Object.keys(updates));
 
+  // An ACTIVE line always wins over a commented-out one for a given key — if
+  // both exist (e.g. a stale disabled copy above a real one below), the
+  // active line is where dotenv's value actually comes from, so that is the
+  // one patched; the commented line is left alone as ordinary text.
   const lastIndexForKey = new Map();
+  const lastCommentedIndexForKey = new Map();
   lines.forEach((line, i) => {
     const key = keyOf(line);
-    if (key !== null && remaining.has(key)) lastIndexForKey.set(key, i);
+    if (key !== null && remaining.has(key)) { lastIndexForKey.set(key, i); return; }
+    const commentedKey = commentedKeyOf(line);
+    if (commentedKey !== null && remaining.has(commentedKey)) lastCommentedIndexForKey.set(commentedKey, i);
   });
 
   const patched = [];
   lines.forEach((line, i) => {
     const key = keyOf(line);
-    if (key === null || !remaining.has(key)) {
-      patched.push(line);
+    if (key !== null && remaining.has(key)) {
+      if (i !== lastIndexForKey.get(key)) return; // drop an earlier duplicate of this key
+      patched.push(`${key}=${updates[key]}`);
+      remaining.delete(key);
       return;
     }
-    if (i !== lastIndexForKey.get(key)) return; // drop an earlier duplicate of this key
-    patched.push(`${key}=${updates[key]}`);
-    remaining.delete(key);
+
+    // No active line for this key anywhere in the file, but THIS is its
+    // commented-out placeholder — uncomment it in place instead of appending
+    // a second, live copy at the end while the disabled one sits above it.
+    const commentedKey = commentedKeyOf(line);
+    if (
+      commentedKey !== null && remaining.has(commentedKey)
+      && !lastIndexForKey.has(commentedKey) && i === lastCommentedIndexForKey.get(commentedKey)
+    ) {
+      patched.push(`${commentedKey}=${updates[commentedKey]}`);
+      remaining.delete(commentedKey);
+      return;
+    }
+
+    patched.push(line);
   });
 
   for (const key of remaining) {

--- a/bot/scripts/setup/fields.js
+++ b/bot/scripts/setup/fields.js
@@ -129,6 +129,15 @@ const OPTIONAL_EXTRAS = [
     where: 'console.mistral.ai → API Keys',
     secret: true,
   },
+  {
+    keys: ['SLACK_SIGNING_SECRET', 'SLACK_BOT_TOKEN'],
+    title: 'Also talk to teachers on Slack',
+    why: 'Runs alongside WhatsApp, not instead of it — a teacher can message Rumi on either. Works in both sandbox and production, no formal review process needed.',
+    where: 'api.slack.com/apps → create an app → Basic Information (signing secret) and OAuth & Permissions (bot token)',
+    // Both keys are real secrets (unlike e.g. AZURE_SPEECH_REGION, a plain
+    // region string) — mask both, not just the first.
+    secret: ['SLACK_SIGNING_SECRET', 'SLACK_BOT_TOKEN'],
+  },
 ];
 
 module.exports = {

--- a/bot/scripts/setup/fields.js
+++ b/bot/scripts/setup/fields.js
@@ -129,17 +129,62 @@ const OPTIONAL_EXTRAS = [
     where: 'console.mistral.ai → API Keys',
     secret: true,
   },
-  {
-    keys: ['SLACK_SIGNING_SECRET', 'SLACK_BOT_TOKEN'],
-    title: 'Also talk to teachers on Slack',
-    why: 'Runs alongside WhatsApp, not instead of it — a teacher can message Rumi on either. Works in both sandbox and production, no formal review process needed.',
-    where: 'api.slack.com/apps → create an app → Basic Information (signing secret) and OAuth & Permissions (bot token)',
-    // Both keys are real secrets (unlike e.g. AZURE_SPEECH_REGION, a plain
-    // region string) — mask both, not just the first.
-    secret: ['SLACK_SIGNING_SECRET', 'SLACK_BOT_TOKEN'],
-  },
+];
+
+// ── Slack (an additive messaging channel, not an "optional ability") ────────
+// Deliberately NOT in OPTIONAL_EXTRAS — unlike Soniox/Gamma/Azure/Mistral,
+// Slack is a whole second messaging channel with its own multi-part app-side
+// configuration (scopes, event subscriptions, interactivity, slash commands),
+// not a single key that switches a feature on. It gets its own wizard step
+// (stepMessagingChannels) so that configuration can be presented as one
+// ordered checklist instead of a single "Key" prompt that leaves the app-side
+// setup entirely undiscovered until something fails at runtime.
+
+/** Every OAuth scope the Slack driver's Web API calls actually need (see
+ * slack-channel.service.js) — chat.postMessage, conversations.open,
+ * reactions.add, files.info, files.uploadV2. Kept in one place so the
+ * checklist shown to the user and doctor.js's live scope probe can never
+ * silently drift apart. */
+const SLACK_BOT_SCOPES = ['chat:write', 'im:write', 'reactions:write', 'files:read', 'files:write'];
+
+/** Every Slash Command text-message.handler.js recognizes (see
+ * slack-events.adapter.js#mapSlashCommandToMetaShape) — registered as real
+ * Slack Slash Commands so they work with Slack's own `/` autocomplete,
+ * rather than being typed as plain text (which Slack intercepts and rejects
+ * before it ever reaches the bot). */
+const SLACK_SLASH_COMMANDS = [
+  '/portal', '/readingtest', '/quiz', '/video', '/menu', '/register', '/language', '/settings', '/status',
+];
+
+/**
+ * Builds the exact 3 Request URLs from one base, so the wizard can print
+ * them fully assembled instead of making the user append
+ * "/api/slack/events" etc. by hand three times.
+ *
+ * @param {string} baseUrl - e.g. an ngrok https URL, with or without a trailing slash
+ */
+function slackRequestUrls(baseUrl) {
+  const base = String(baseUrl || '').replace(/\/+$/, '');
+  return {
+    events: `${base}/api/slack/events`,
+    interactions: `${base}/api/slack/interactions`,
+    commands: `${base}/api/slack/commands`,
+  };
+}
+
+const SLACK_APP_WALKTHROUGH_INTRO = [
+  'Open https://api.slack.com/apps → Create New App → From scratch',
+  'Turn Socket Mode OFF (left sidebar) — Rumi is HTTP-webhook-based and never opens a Socket Mode connection; leaving it on silently stops events/interactions from ever reaching the bot',
 ];
 
 module.exports = {
-  META_FIELDS, META_WALKTHROUGH, META_REMAINING_STEPS, fieldsFor, OPTIONAL_EXTRAS,
+  META_FIELDS,
+  META_WALKTHROUGH,
+  META_REMAINING_STEPS,
+  fieldsFor,
+  OPTIONAL_EXTRAS,
+  SLACK_BOT_SCOPES,
+  SLACK_SLASH_COMMANDS,
+  SLACK_APP_WALKTHROUGH_INTRO,
+  slackRequestUrls,
 };

--- a/bot/scripts/setup/interactive-setup.js
+++ b/bot/scripts/setup/interactive-setup.js
@@ -731,13 +731,61 @@ async function walkSlackAppConfig(io, baseUrl) {
   await io.pressEnter('Press Enter once it is installed — the next two questions come from that page');
 }
 
+/**
+ * Walks the Discord application-configuration checklist, mirroring
+ * walkSlackAppConfig's one-section-at-a-time shape — but shorter: Discord's
+ * setup has no Request-URL-per-feature concept to configure at all, since
+ * this bot uses Discord's Gateway (a persistent connection) rather than a
+ * signed HTTP endpoint. Ends with registering the 9 slash commands directly
+ * (a REST call this wizard can make itself, unlike Slack's manual
+ * app-config-UI step for each command).
+ */
+async function walkDiscordAppConfig(io) {
+  console.log('');
+  console.log(ui.say('Discord apps are configured on Discord\'s own site too — this walks through it one section at a time.'));
+  console.log('');
+  console.log(ui.bold('  1. Create the application'));
+  console.log(ui.steps([
+    'Open https://discord.com/developers/applications → New Application',
+    'Give it any name',
+  ]));
+  await io.pressEnter('Press Enter once the application exists');
+
+  console.log('');
+  console.log(ui.bold('  2. Bot token'));
+  console.log(ui.steps(['Bot tab → Reset Token → copy it (this is the value the next question asks for)']));
+  await io.pressEnter('Press Enter once you have copied the token');
+
+  console.log('');
+  console.log(ui.bold('  3. Privileged Gateway Intents'));
+  console.log(ui.steps([
+    'Bot tab → Privileged Gateway Intents → enable "Message Content Intent"',
+  ]));
+  console.log(ui.aside('Self-togglable with no review while the bot is in under 100 servers — Discord requires its own Bot Verification above that threshold.'));
+  await io.pressEnter('Press Enter once Message Content Intent is enabled');
+
+  console.log('');
+  console.log(ui.bold('  4. Invite the bot to a server'));
+  console.log(ui.steps([
+    'OAuth2 → URL Generator → scopes: bot, applications.commands',
+    'Bot Permissions: Send Messages, Read Message History, Attach Files, Use Slash Commands, Embed Links',
+    'Copy the generated URL, open it, and add the bot to a test server',
+  ]));
+  await io.pressEnter('Press Enter once the bot is in a server');
+
+  console.log('');
+  console.log(ui.bold('  5. Application ID'));
+  console.log(ui.steps(['General Information tab → copy the Application ID (this is the value the question after next asks for)']));
+  await io.pressEnter('Press Enter once you have copied the Application ID');
+}
+
 async function stepMessagingChannels(io, env, save, opts = {}) {
   beginStep(6, 'Other places teachers can reach Rumi');
 
   const slackConfigured = hasAll(env, ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET']);
   if (slackConfigured && !opts.reconfigure) {
     const check = await checkLive('Checking the Slack connection you already have…', 'slack', env, (d) => `Slack already connected ${ui.dim(d)}`);
-    if (check.ok) return { slack: true };
+    if (check.ok) return { slack: true, ...(await stepDiscordChannel(io, env, save, opts)) };
     console.log(ui.say('That token is not working. Let\'s set Slack up again.'));
   }
 
@@ -745,7 +793,7 @@ async function stepMessagingChannels(io, env, save, opts = {}) {
   console.log('');
 
   const wantsSlack = await io.confirm('Also connect Slack?', false);
-  if (!wantsSlack) return { slack: false };
+  if (!wantsSlack) return { slack: false, ...(await stepDiscordChannel(io, env, save, opts)) };
 
   const baseUrl = await io.ask('Public URL Slack should send requests to', {
     hint: 'The https address your bot is reachable at — an ngrok URL while testing locally (run `ngrok http <port>` in another terminal), or your deployed address in production.',
@@ -773,10 +821,64 @@ async function stepMessagingChannels(io, env, save, opts = {}) {
 
     save({ SLACK_SIGNING_SECRET: signingSecret, SLACK_BOT_TOKEN: botToken });
     const check = await checkLive('Checking the token and its scopes…', 'slack', env, (d) => `Slack connected ${ui.dim(d)}`);
-    if (check.ok) return { slack: true };
+    if (check.ok) return { slack: true, ...(await stepDiscordChannel(io, env, save, opts)) };
     console.log(ui.aside(check.detail));
     const retry = await io.confirm('Try those two values again?', true);
-    if (!retry) return { slack: false };
+    if (!retry) return { slack: false, ...(await stepDiscordChannel(io, env, save, opts)) };
+  }
+}
+
+/**
+ * Discord's own confirm-then-configure-then-live-check block, structurally
+ * identical to the Slack block above but run as its own function — Discord
+ * is independent of Slack (a teacher's account can have neither, either, or
+ * both), so this always runs regardless of the Slack outcome above it.
+ */
+async function stepDiscordChannel(io, env, save, opts = {}) {
+  const discordConfigured = hasAll(env, ['DISCORD_BOT_TOKEN', 'DISCORD_APPLICATION_ID']);
+  if (discordConfigured && !opts.reconfigure) {
+    const check = await checkLive('Checking the Discord connection you already have…', 'discord', env, (d) => `Discord already connected ${ui.dim(d)}`);
+    if (check.ok) return { discord: true };
+    console.log(ui.say('That token is not working. Let\'s set Discord up again.'));
+  }
+
+  console.log('');
+  console.log(ui.say('A teacher can also reach Rumi on Discord, at the same time as WhatsApp and Slack — nobody has to choose.'));
+  console.log('');
+
+  const wantsDiscord = await io.confirm('Also connect Discord?', false);
+  if (!wantsDiscord) return { discord: false };
+
+  await walkDiscordAppConfig(io);
+
+  for (;;) {
+    const botToken = await io.ask('Bot Token', {
+      secret: true,
+      fallback: prefill(env, 'DISCORD_BOT_TOKEN'),
+      hint: 'Bot tab → Reset Token.',
+    });
+    const applicationId = await io.ask('Application ID', {
+      fallback: prefill(env, 'DISCORD_APPLICATION_ID'),
+      hint: 'General Information tab.',
+    });
+
+    save({ DISCORD_BOT_TOKEN: botToken, DISCORD_APPLICATION_ID: applicationId });
+    const check = await checkLive('Checking the bot token…', 'discord', env, (d) => `Discord connected ${ui.dim(d)}`);
+    if (check.ok) {
+      const spin = ui.spinner('Registering the 9 slash commands…');
+      try {
+        const { registerDiscordCommands } = require('./discord-register-commands');
+        const result = await registerDiscordCommands({ token: botToken, applicationId, guildId: env.DISCORD_TEST_GUILD_ID });
+        spin.succeed(`Registered ${result.registered} slash commands (${result.guildScoped ? 'guild-scoped, instant' : 'global, up to ~1hr to propagate'})`);
+      } catch (err) {
+        spin.fail(ui.paint('danger', `Slash command registration failed: ${err.message}`));
+        console.log(ui.aside('You can retry later with `npm run discord:register-commands`.'));
+      }
+      return { discord: true };
+    }
+    console.log(ui.aside(check.detail));
+    const retry = await io.confirm('Try those two values again?', true);
+    if (!retry) return { discord: false };
   }
 }
 
@@ -803,7 +905,7 @@ function welcome(env) {
 }
 
 async function finish(env, channelResult) {
-  const { channel, number, linked, slack } = channelResult;
+  const { channel, number, linked, slack, discord } = channelResult;
   console.log('');
   console.log(ui.rule());
   const spin = ui.spinner('One last check of everything…');
@@ -821,7 +923,7 @@ async function finish(env, channelResult) {
   console.log('');
   console.log(ui.rule());
   console.log('');
-  console.log(summary.renderNextSteps({ channel, number, slack }));
+  console.log(summary.renderNextSteps({ channel, number, slack, discord }));
   console.log('');
   if (!doctor.ok) {
     console.log(ui.aside('Run `rumi doctor` for the detail on what is not working yet.'));
@@ -882,9 +984,9 @@ if (require.main === module) {
 
 module.exports = {
   main, welcome, finish,
-  stepDatabase, stepBrain, stepMemory, stepExtras, stepChannel, stepMessagingChannels,
+  stepDatabase, stepBrain, stepMemory, stepExtras, stepChannel, stepMessagingChannels, stepDiscordChannel,
   ensureTables, chooseChannelDriver, collectMetaCredentials, linkSandbox, channelAlreadyWorking,
   createSaver, hasAll, isProvided, prefill, isTemplateSuggestion, startLocalRedis, dockerAvailable, probe,
-  beginStep, finishStep, walkSlackAppConfig,
+  beginStep, finishStep, walkSlackAppConfig, walkDiscordAppConfig,
   TOTAL_STEPS, LOCAL_REDIS,
 };

--- a/bot/scripts/setup/interactive-setup.js
+++ b/bot/scripts/setup/interactive-setup.js
@@ -488,8 +488,15 @@ async function stepExtras(io, env, save, opts = {}) {
       // The label is the env var only for the odd second field (a region, say)
       // where there is no plainer name for it than the thing itself.
       const label = key === extra.keys[0] ? 'Key' : key.replace(/_/g, ' ').toLowerCase();
+      // extra.secret may be a bare boolean (masks only the first key — the
+      // shape every single-secret extra uses today) or an array naming which
+      // keys are actually sensitive (an entry with MULTIPLE real secrets,
+      // e.g. Slack's signing secret AND bot token, both of which must never
+      // echo to the terminal — masking only the first would silently type
+      // the second one in the clear).
+      const isSecret = Array.isArray(extra.secret) ? extra.secret.includes(key) : Boolean(extra.secret) && key === extra.keys[0];
       // eslint-disable-next-line no-await-in-loop -- one question at a time, by design
-      const value = await io.ask(label, { secret: Boolean(extra.secret) && key === extra.keys[0], fallback: prefill(env, key) });
+      const value = await io.ask(label, { secret: isSecret, fallback: prefill(env, key) });
       if (!value) break;
       collected[key] = value;
     }

--- a/bot/scripts/setup/interactive-setup.js
+++ b/bot/scripts/setup/interactive-setup.js
@@ -50,7 +50,7 @@ const summary = require('./summary');
 const ROOT = path.resolve(__dirname, '../../..');
 const ENV_PATH = path.join(ROOT, '.env');
 const ENV_TEMPLATE_PATH = path.join(ROOT, '.env.template');
-const TOTAL_STEPS = 5;
+const TOTAL_STEPS = 6;
 const LOCAL_REDIS = { url: 'redis://localhost:6379', container: 'rumi-redis', image: 'redis:7-alpine' };
 
 // ── Shared plumbing ──────────────────────────────────────────────────────────
@@ -664,6 +664,122 @@ async function stepChannel(io, env, save, opts = {}) {
   return { channel, ...outcome };
 }
 
+// ── Step 6: additional messaging channels (Slack, later Discord) ────────────
+
+/**
+ * Walks the Slack app-configuration checklist one screen at a time, in the
+ * exact order the app's own sidebar is laid out — Press Enter to move from
+ * each section to the next, rather than a single screen listing every
+ * requirement at once.
+ *
+ * This exists because the alternative (discover each requirement from a live
+ * failure — Socket Mode, then App Home, then a missing scope, then another
+ * missing scope) is what actually happened testing this by hand: eight
+ * separate rounds of trial and error, each one a different error message with
+ * no indication of what else was still missing. One section per screen, done
+ * in order with nothing to skip ahead to, turns that into one pass.
+ */
+async function walkSlackAppConfig(io, baseUrl) {
+  const urls = fields.slackRequestUrls(baseUrl);
+
+  console.log('');
+  console.log(ui.say('Slack apps are configured on Slack\'s own site — nothing here can do that part for you. This walks through it one section at a time, in the order Slack\'s own sidebar lists them.'));
+  console.log('');
+  console.log(ui.bold('  1. Create the app'));
+  console.log(ui.steps(fields.SLACK_APP_WALKTHROUGH_INTRO));
+  await io.pressEnter('Press Enter once the app exists and Socket Mode is off');
+
+  console.log('');
+  console.log(ui.bold('  2. Bot Token Scopes') + ui.dim('  (OAuth & Permissions → Scopes → Bot Token Scopes)'));
+  console.log(ui.say('Click "Add an OAuth Scope" and add each of these:'));
+  console.log(ui.box(fields.SLACK_BOT_SCOPES, { role: 'accent' }));
+  await io.pressEnter('Press Enter once all five scopes are added');
+
+  console.log('');
+  console.log(ui.bold('  3. Event Subscriptions'));
+  console.log(ui.steps([
+    'Turn Event Subscriptions on',
+    'Set the Request URL below',
+    'Under "Subscribe to bot events", add: message.im — this one event covers both plain messages and file/voice uploads in a DM',
+  ]));
+  console.log(ui.box([urls.events], { title: 'Request URL', role: 'accent' }));
+  await io.pressEnter('Press Enter once the Request URL is verified and message.im is subscribed');
+
+  console.log('');
+  console.log(ui.bold('  4. Interactivity & Shortcuts'));
+  console.log(ui.steps([
+    'Turn Interactivity on',
+    'Set the Request URL below',
+  ]));
+  console.log(ui.box([urls.interactions], { title: 'Request URL', role: 'accent' }));
+  await io.pressEnter('Press Enter once that Request URL is saved');
+
+  console.log('');
+  console.log(ui.bold('  5. Slash Commands'));
+  console.log(ui.say('Add each of these as its own Slash Command, every one pointing at the same Request URL:'));
+  console.log(ui.box([urls.commands], { title: 'Request URL (same one, every time)', role: 'accent' }));
+  console.log(ui.table(fields.SLACK_SLASH_COMMANDS.map((cmd) => [cmd, ''])));
+  console.log(ui.aside('/readingtest is one word — Slack command names cannot contain a space.'));
+  await io.pressEnter('Press Enter once all nine commands are added');
+
+  console.log('');
+  console.log(ui.bold('  6. Install the app'));
+  console.log(ui.steps([
+    'Go to OAuth & Permissions',
+    'Click "Install to Workspace" (or "Reinstall" if you changed scopes after installing once already)',
+  ]));
+  await io.pressEnter('Press Enter once it is installed — the next two questions come from that page');
+}
+
+async function stepMessagingChannels(io, env, save, opts = {}) {
+  beginStep(6, 'Other places teachers can reach Rumi');
+
+  const slackConfigured = hasAll(env, ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET']);
+  if (slackConfigured && !opts.reconfigure) {
+    const check = await checkLive('Checking the Slack connection you already have…', 'slack', env, (d) => `Slack already connected ${ui.dim(d)}`);
+    if (check.ok) return { slack: true };
+    console.log(ui.say('That token is not working. Let\'s set Slack up again.'));
+  }
+
+  console.log(ui.say('WhatsApp is set up. A teacher can also reach Rumi on Slack, at the same time, on the same account — nobody has to choose.'));
+  console.log('');
+
+  const wantsSlack = await io.confirm('Also connect Slack?', false);
+  if (!wantsSlack) return { slack: false };
+
+  const baseUrl = await io.ask('Public URL Slack should send requests to', {
+    hint: 'The https address your bot is reachable at — an ngrok URL while testing locally (run `ngrok http <port>` in another terminal), or your deployed address in production.',
+    validate: (input) => {
+      const value = String(input || '').trim().replace(/\/+$/, '');
+      if (!value) return { ok: false, reason: 'This can\'t be empty.' };
+      if (!/^https:\/\//.test(value)) return { ok: false, reason: 'Slack requires https:// — an http:// or bare host will be rejected when you try to save it.' };
+      return { ok: true, value };
+    },
+  });
+
+  await walkSlackAppConfig(io, baseUrl);
+
+  for (;;) {
+    const signingSecret = await io.ask('Signing Secret', {
+      secret: true,
+      fallback: prefill(env, 'SLACK_SIGNING_SECRET'),
+      hint: 'Basic Information → App Credentials → Signing Secret.',
+    });
+    const botToken = await io.ask('Bot User OAuth Token', {
+      secret: true,
+      fallback: prefill(env, 'SLACK_BOT_TOKEN'),
+      hint: 'OAuth & Permissions → Bot User OAuth Token — starts with xoxb-.',
+    });
+
+    save({ SLACK_SIGNING_SECRET: signingSecret, SLACK_BOT_TOKEN: botToken });
+    const check = await checkLive('Checking the token and its scopes…', 'slack', env, (d) => `Slack connected ${ui.dim(d)}`);
+    if (check.ok) return { slack: true };
+    console.log(ui.aside(check.detail));
+    const retry = await io.confirm('Try those two values again?', true);
+    if (!retry) return { slack: false };
+  }
+}
+
 // ── Screens ──────────────────────────────────────────────────────────────────
 
 function welcome(env) {
@@ -687,7 +803,7 @@ function welcome(env) {
 }
 
 async function finish(env, channelResult) {
-  const { channel, number, linked } = channelResult;
+  const { channel, number, linked, slack } = channelResult;
   console.log('');
   console.log(ui.rule());
   const spin = ui.spinner('One last check of everything…');
@@ -705,7 +821,7 @@ async function finish(env, channelResult) {
   console.log('');
   console.log(ui.rule());
   console.log('');
-  console.log(summary.renderNextSteps({ channel, number }));
+  console.log(summary.renderNextSteps({ channel, number, slack }));
   console.log('');
   if (!doctor.ok) {
     console.log(ui.aside('Run `rumi doctor` for the detail on what is not working yet.'));
@@ -742,8 +858,10 @@ async function main(argv = process.argv) {
     await stepExtras(io, env, save, opts);
     finishStep('Optional abilities');
     const channelResult = await stepChannel(io, env, save, opts);
+    finishStep('Connecting WhatsApp');
+    const messagingResult = await stepMessagingChannels(io, env, save, opts);
 
-    await finish(env, channelResult);
+    await finish(env, { ...channelResult, ...messagingResult });
   } catch (err) {
     if (err instanceof PromptAbortError || err.aborted) {
       console.log('');
@@ -764,9 +882,9 @@ if (require.main === module) {
 
 module.exports = {
   main, welcome, finish,
-  stepDatabase, stepBrain, stepMemory, stepExtras, stepChannel,
+  stepDatabase, stepBrain, stepMemory, stepExtras, stepChannel, stepMessagingChannels,
   ensureTables, chooseChannelDriver, collectMetaCredentials, linkSandbox, channelAlreadyWorking,
   createSaver, hasAll, isProvided, prefill, isTemplateSuggestion, startLocalRedis, dockerAvailable, probe,
-  beginStep, finishStep,
+  beginStep, finishStep, walkSlackAppConfig,
   TOTAL_STEPS, LOCAL_REDIS,
 };

--- a/bot/scripts/setup/interactive-setup.js
+++ b/bot/scripts/setup/interactive-setup.js
@@ -718,9 +718,17 @@ async function walkSlackAppConfig(io, baseUrl) {
   console.log(ui.bold('  5. Slash Commands'));
   console.log(ui.say('Add each of these as its own Slash Command, every one pointing at the same Request URL:'));
   console.log(ui.box([urls.commands], { title: 'Request URL (same one, every time)', role: 'accent' }));
-  console.log(ui.table(fields.SLACK_SLASH_COMMANDS.map((cmd) => [cmd, ''])));
+  // /status is confirmed to be a Slack-reserved word — Slack rejects it
+  // outright ("is a reserved word") the moment you try to add it, no matter
+  // the Request URL. Skip it here rather than sending the user into a wall;
+  // the feature itself still works on Slack via the natural-language
+  // alternative text-message.handler.js added for exactly this reason
+  // ("my status" / "show status" / "what's running").
+  const slackAddableCommands = fields.SLACK_SLASH_COMMANDS.filter((cmd) => cmd !== '/status');
+  console.log(ui.table(slackAddableCommands.map((cmd) => [cmd, ''])));
   console.log(ui.aside('/readingtest is one word — Slack command names cannot contain a space.'));
-  await io.pressEnter('Press Enter once all nine commands are added');
+  console.log(ui.aside('/status is skipped — Slack reserves that name and refuses to register it. Teachers reach the same feature on Slack by typing "my status" instead.'));
+  await io.pressEnter(`Press Enter once all ${slackAddableCommands.length} commands are added`);
 
   console.log('');
   console.log(ui.bold('  6. Install the app'));

--- a/bot/scripts/setup/summary.js
+++ b/bot/scripts/setup/summary.js
@@ -64,6 +64,10 @@ function renderReadiness(doctor, opts = {}) {
     rows.push(['Slack', ui.paint('brand', 'connected')]);
   }
 
+  if (doctor.activeChannels && doctor.activeChannels.includes('discord')) {
+    rows.push(['Discord', ui.paint('brand', 'connected')]);
+  }
+
   const on = doctor.featureResults.filter((f) => f.status === 'on');
   const off = doctor.featureResults.filter((f) => f.status !== 'on');
 
@@ -105,6 +109,11 @@ function renderNextSteps(opts) {
 
   if (opts.slack) {
     lines.push(ui.aside('Slack is connected too — message the bot in a Slack DM the same way, on the same account.'));
+    lines.push('');
+  }
+
+  if (opts.discord) {
+    lines.push(ui.aside('Discord is connected too — message the bot in a Discord DM the same way, on the same account.'));
     lines.push('');
   }
 

--- a/bot/scripts/setup/summary.js
+++ b/bot/scripts/setup/summary.js
@@ -60,6 +60,10 @@ function renderReadiness(doctor, opts = {}) {
     else rows.push(['WhatsApp', ui.paint('brand', 'linked')]);
   }
 
+  if (doctor.activeChannels && doctor.activeChannels.includes('slack')) {
+    rows.push(['Slack', ui.paint('brand', 'connected')]);
+  }
+
   const on = doctor.featureResults.filter((f) => f.status === 'on');
   const off = doctor.featureResults.filter((f) => f.status !== 'on');
 
@@ -98,6 +102,12 @@ function detailSuffix(detail) {
  */
 function renderNextSteps(opts) {
   const lines = [];
+
+  if (opts.slack) {
+    lines.push(ui.aside('Slack is connected too — message the bot in a Slack DM the same way, on the same account.'));
+    lines.push('');
+  }
+
   lines.push(ui.bold('  Start Rumi'));
   // `rumi start` rather than `cd bot && npm start`: the latter runs the bot from
   // bot/, where a relative .env and a relative session folder both resolved to

--- a/bot/shared/config/discord-country-regions.js
+++ b/bot/shared/config/discord-country-regions.js
@@ -1,0 +1,119 @@
+/**
+ * Continent-ish buckets over registration-data.js's 164-country COUNTRIES_DROPDOWN,
+ * for Discord's 2-step country picker (pick a region bucket, then pick a
+ * country within it) — Discord's StringSelectMenuBuilder caps at 25 options
+ * (Slack's static_select caps at 100, so this chunking has no Slack
+ * equivalent). Every bucket below is sized under that cap.
+ *
+ * This is genuine new data, not derived from an existing table — unlike the
+ * Pakistan/India region picker (discord-views/registration.view.js's
+ * REGION_INFO screen), which reuses REGIONS_DROPDOWN's existing `in_`-prefixed
+ * ids directly and needs no bucket table of its own.
+ *
+ * Bucket membership is by ISO 3166-1 alpha-2 code, matching COUNTRIES_DROPDOWN's
+ * own `id` field — update this file if registration-data.js's COUNTRY_CODES
+ * list ever changes.
+ */
+
+const COUNTRY_REGION_BUCKETS = [
+  {
+    id: 'south_asia',
+    title: 'South Asia',
+    countryCodes: ['PK', 'IN', 'BD', 'LK', 'NP', 'AF', 'MV', 'BT'],
+  },
+  {
+    id: 'middle_east',
+    title: 'Middle East',
+    countryCodes: ['AE', 'SA', 'QA', 'KW', 'BH', 'OM', 'TR', 'IQ', 'SY', 'JO', 'LB', 'PS', 'YE', 'IR', 'CY'],
+  },
+  {
+    id: 'europe',
+    title: 'Europe',
+    countryCodes: [
+      'GB', 'DE', 'FR', 'IT', 'ES', 'NL', 'SE', 'NO', 'DK', 'FI', 'BE', 'AT',
+      'CH', 'PT', 'IE', 'PL', 'CZ', 'RO', 'HU', 'GR', 'BG',
+    ],
+  },
+  {
+    id: 'europe_other',
+    title: 'Europe (other)',
+    countryCodes: [
+      'HR', 'SK', 'SI', 'LT', 'LV', 'EE', 'RU', 'UA', 'BY', 'MD', 'RS', 'BA',
+      'ME', 'MK', 'AL', 'XK', 'MT', 'IS', 'LU', 'LI', 'MC', 'SM', 'AD', 'VA',
+    ],
+  },
+  {
+    id: 'east_southeast_asia',
+    title: 'East & Southeast Asia',
+    countryCodes: [
+      'MY', 'ID', 'TH', 'VN', 'PH', 'SG', 'MM', 'KH', 'LA', 'CN', 'JP', 'KR',
+      'TW', 'HK', 'MN', 'BN', 'TL',
+    ],
+  },
+  {
+    id: 'central_asia_caucasus',
+    title: 'Central Asia & Caucasus',
+    countryCodes: ['KZ', 'UZ', 'TJ', 'KG', 'TM', 'AZ', 'GE', 'AM'],
+  },
+  {
+    id: 'africa_north_west',
+    title: 'Africa (North & West)',
+    countryCodes: ['EG', 'MA', 'TN', 'DZ', 'LY', 'SD', 'NG', 'GH', 'SN', 'CI', 'CM'],
+  },
+  {
+    id: 'africa_east_south',
+    title: 'Africa (East & South)',
+    countryCodes: [
+      'ZA', 'KE', 'ET', 'TZ', 'UG', 'RW', 'CD', 'AO', 'MZ', 'ZW', 'MW', 'ZM',
+      'BW', 'NA', 'MG', 'MU', 'SC',
+    ],
+  },
+  {
+    id: 'americas_north',
+    title: 'Americas (North & Central)',
+    countryCodes: [
+      'US', 'CA', 'MX', 'CR', 'PA', 'GT', 'HN', 'SV', 'NI', 'CU', 'DO', 'HT',
+      'JM', 'TT', 'BB', 'BS', 'BZ',
+    ],
+  },
+  {
+    id: 'americas_south',
+    title: 'Americas (South)',
+    countryCodes: ['BR', 'AR', 'CO', 'CL', 'PE', 'VE', 'EC', 'BO', 'PY', 'UY', 'GY', 'SR'],
+  },
+  {
+    id: 'oceania',
+    title: 'Oceania',
+    countryCodes: [
+      'AU', 'NZ', 'FJ', 'PG', 'WS', 'TO', 'VU', 'SB', 'KI', 'MH', 'FM', 'PW', 'NR', 'TV',
+    ],
+  },
+];
+
+/**
+ * Builds the runtime bucket list from COUNTRIES_DROPDOWN, so titles/order
+ * always reflect the live registration data rather than a second hardcoded
+ * copy — only the ISO-code membership above is hand-maintained.
+ * @param {Array<{id: string, title: string}>} countriesDropdown - registration-data.js's COUNTRIES_DROPDOWN
+ * @returns {Array<{id: string, title: string, countries: Array<{id: string, title: string}>}>}
+ */
+function buildBuckets(countriesDropdown) {
+  const byCode = new Map(countriesDropdown.map((c) => [c.id, c]));
+  const buckets = COUNTRY_REGION_BUCKETS.map((bucket) => ({
+    id: bucket.id,
+    title: bucket.title,
+    countries: bucket.countryCodes.map((code) => byCode.get(code)).filter(Boolean),
+  }));
+
+  // Anything in COUNTRIES_DROPDOWN but not yet bucketed above lands in a
+  // catch-all bucket rather than silently vanishing from the picker.
+  const bucketedCodes = new Set(COUNTRY_REGION_BUCKETS.flatMap((b) => b.countryCodes));
+  const unbucketed = countriesDropdown.filter((c) => !bucketedCodes.has(c.id));
+  if (unbucketed.length) {
+    buckets.push({ id: 'other', title: 'Other', countries: unbucketed });
+  }
+
+  return buckets;
+}
+
+module.exports = { COUNTRY_REGION_BUCKETS, buildBuckets };

--- a/bot/shared/config/feature-availability.js
+++ b/bot/shared/config/feature-availability.js
@@ -42,12 +42,18 @@ const CHANNEL_REQUIRED_VARS = {
 // requiredVarsFor/missingRequired). A channel here turns on the moment every
 // one of its listed vars is present, same presence-gate shape as FEATURES.
 const ADDITIVE_CHANNEL_REQUIRED_VARS = {
-  // slack: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET'] — added once the Slack driver ships.
+  slack: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET'],
+  // discord: [...] — added in the Discord phase.
 };
 
 // Optional features → the env key(s) that switch each one on.
 const FEATURES = [
   { name: 'Voice notes (speech-to-text, Soniox)', keys: ['SONIOX_API_KEY'] },
+  {
+    name: 'Slack channel (Bot + Events API)',
+    keys: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET'],
+    notes: 'Runs alongside your WhatsApp driver, in both sandbox and production — set via `rumi setup`\'s optional Slack step.',
+  },
   { name: 'Spoken replies (text-to-speech, ElevenLabs)', keys: ['ELEVENLABS_API_KEY'] },
   { name: 'Urdu / regional voices (Uplift)', keys: ['UPLIFT_API_KEY'] },
   { name: 'Lesson-plan generation (Gamma)', keys: ['GAMMA_API_KEY'] },

--- a/bot/shared/config/feature-availability.js
+++ b/bot/shared/config/feature-availability.js
@@ -36,6 +36,15 @@ const CHANNEL_REQUIRED_VARS = {
   baileys: [],
 };
 
+// Additive channels (Slack, Discord, ...) run ALONGSIDE whichever
+// CHANNEL_DRIVER is resolved below — they are never selected by
+// CHANNEL_DRIVER, and their vars are never boot-blocking (never folded into
+// requiredVarsFor/missingRequired). A channel here turns on the moment every
+// one of its listed vars is present, same presence-gate shape as FEATURES.
+const ADDITIVE_CHANNEL_REQUIRED_VARS = {
+  // slack: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET'] — added once the Slack driver ships.
+};
+
 // Optional features → the env key(s) that switch each one on.
 const FEATURES = [
   { name: 'Voice notes (speech-to-text, Soniox)', keys: ['SONIOX_API_KEY'] },
@@ -121,12 +130,28 @@ function availableFeatures(env = process.env) {
   return FEATURES.filter((f) => isFeatureAvailable(f, env)).map((f) => f.name);
 }
 
+/**
+ * Which additive channels (Slack, Discord, ...) are active — i.e. every var
+ * ADDITIVE_CHANNEL_REQUIRED_VARS lists for that channel is present. Distinct
+ * from resolveChannelDriver: that resolves the ONE mutually-exclusive
+ * WhatsApp-family driver (meta|baileys); this resolves the SET of additional
+ * channels running concurrently alongside it. A deployment with none
+ * configured gets [] — byte-identical behavior to before this existed.
+ */
+function resolveActiveChannels(env = process.env) {
+  return Object.keys(ADDITIVE_CHANNEL_REQUIRED_VARS).filter((name) =>
+    ADDITIVE_CHANNEL_REQUIRED_VARS[name].every((k) => isSet(env[k]))
+  );
+}
+
 module.exports = {
   REQUIRED_VARS,
   CHANNEL_REQUIRED_VARS,
+  ADDITIVE_CHANNEL_REQUIRED_VARS,
   FEATURES,
   isSet,
   resolveChannelDriver,
+  resolveActiveChannels,
   requiredVarsFor,
   missingRequired,
   isFeatureAvailable,

--- a/bot/shared/config/feature-availability.js
+++ b/bot/shared/config/feature-availability.js
@@ -43,7 +43,15 @@ const CHANNEL_REQUIRED_VARS = {
 // one of its listed vars is present, same presence-gate shape as FEATURES.
 const ADDITIVE_CHANNEL_REQUIRED_VARS = {
   slack: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET'],
-  // discord: [...] — added in the Discord phase.
+  // Deliberately no DISCORD_PUBLIC_KEY here: that var (+ Ed25519 signature
+  // verification) is only needed for a bot using a separate HTTP
+  // "Interactions Endpoint URL" instead of the Gateway. This bot runs the
+  // Gateway (persistent WebSocket) for full message support, and with no
+  // Interactions Endpoint URL configured in the Developer Portal, Discord
+  // delivers slash commands/buttons/modals over that SAME Gateway
+  // connection too — see discord-events.adapter.js. There is no HTTP route
+  // to sign-verify at all for this driver, unlike Slack's webhook-based design.
+  discord: ['DISCORD_BOT_TOKEN', 'DISCORD_APPLICATION_ID'],
 };
 
 // Optional features → the env key(s) that switch each one on.
@@ -54,6 +62,14 @@ const FEATURES = [
     keys: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET'],
     notes: 'Runs alongside your WhatsApp driver, in both sandbox and production — set via `rumi setup`\'s messaging channels step.',
     probe: 'slack',
+  },
+  {
+    name: 'Discord channel (Gateway)',
+    keys: ['DISCORD_BOT_TOKEN', 'DISCORD_APPLICATION_ID'],
+    notes: 'Runs alongside your WhatsApp driver via a persistent Gateway connection — set via `rumi setup`\'s '
+      + 'messaging channels step. MESSAGE_CONTENT is a privileged intent; needs Discord\'s own Bot Verification '
+      + 'once the bot is in 100+ servers.',
+    probe: 'discord',
   },
   { name: 'Spoken replies (text-to-speech, ElevenLabs)', keys: ['ELEVENLABS_API_KEY'] },
   { name: 'Urdu / regional voices (Uplift)', keys: ['UPLIFT_API_KEY'] },

--- a/bot/shared/config/feature-availability.js
+++ b/bot/shared/config/feature-availability.js
@@ -52,7 +52,8 @@ const FEATURES = [
   {
     name: 'Slack channel (Bot + Events API)',
     keys: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET'],
-    notes: 'Runs alongside your WhatsApp driver, in both sandbox and production — set via `rumi setup`\'s optional Slack step.',
+    notes: 'Runs alongside your WhatsApp driver, in both sandbox and production — set via `rumi setup`\'s messaging channels step.',
+    probe: 'slack',
   },
   { name: 'Spoken replies (text-to-speech, ElevenLabs)', keys: ['ELEVENLABS_API_KEY'] },
   { name: 'Urdu / regional voices (Uplift)', keys: ['UPLIFT_API_KEY'] },

--- a/bot/shared/database/bot-helpers.js
+++ b/bot/shared/database/bot-helpers.js
@@ -84,6 +84,142 @@ async function getOrCreateUser(phoneNumber) {
 }
 
 /**
+ * Get or create a user by a channel-scoped identity (Slack user id, Discord
+ * user id, ...) — the multi-homed counterpart to getOrCreateUser, which stays
+ * untouched and channel === 'whatsapp' is delegated to it directly below.
+ *
+ * A person can be linked to more than one channel at once (WhatsApp AND Slack
+ * AND Discord), each tracked as its own row in user_channels pointing back to
+ * one shared `users` row — see infrastructure/supabase/00_complete-schema.sql.
+ * This function resolves IDENTITY only; conversation/session state must stay
+ * keyed by (channel, channelUserId), never by the returned user's id — see
+ * bot/shared/services/messaging/channel-registry.js's driverForIdentifier.
+ *
+ * @param {string} channel - 'whatsapp' | 'slack' | 'discord'
+ * @param {string} channelUserId - the bare identifier on that channel (a
+ *   WhatsApp phone number, a Slack user id, a Discord snowflake — never a
+ *   "channel:id"-prefixed string; that prefix is a messaging-router concern)
+ * @returns {Promise<object>} User record (the same shape getOrCreateUser returns)
+ */
+async function getOrCreateUserByChannel(channel, channelUserId) {
+  if (channel === 'whatsapp') {
+    // The legacy path is authoritative for WhatsApp — same lookup key
+    // (phone_number), same insert shape, zero behavior change. Only make sure
+    // a user_channels row exists for it (lazy backfill for any row a one-time
+    // migration missed, and so future multi-homing reads see it too).
+    const user = await getOrCreateUser(channelUserId);
+    await ensureUserChannelRow(user.id, channel, channelUserId, { isPrimary: true });
+    return user;
+  }
+
+  try {
+    const { data: existingLink } = await supabase
+      .from('user_channels')
+      .select('user_id')
+      .eq('channel', channel)
+      .eq('channel_user_id', channelUserId)
+      .single();
+
+    if (existingLink) {
+      const nowIso = new Date().toISOString();
+      try {
+        await supabase.from('user_channels').update({ last_message_at: nowIso }).eq('channel', channel).eq('channel_user_id', channelUserId);
+      } catch (stampErr) {
+        console.error('user_channels last_message_at update failed:', stampErr.message);
+      }
+
+      const { data: user, error: fetchUserError } = await supabase
+        .from('users')
+        .select('*')
+        .eq('id', existingLink.user_id)
+        .single();
+      if (fetchUserError) {
+        console.error('Error fetching user for existing channel link:', fetchUserError);
+        throw fetchUserError;
+      }
+      return user;
+    }
+
+    // No existing link — brand-new person on this channel. Create both the
+    // users row (no phone_number — see the schema's relaxed NOT NULL) and its
+    // first user_channels row together.
+    const { data: newUser, error: createUserError } = await supabase
+      .from('users')
+      .insert({
+        registration_completed: false,
+        created_at: new Date().toISOString(),
+        last_message_at: new Date().toISOString(),
+      })
+      .select()
+      .single();
+
+    if (createUserError) {
+      console.error('Error creating user for new channel identity:', createUserError);
+      throw createUserError;
+    }
+
+    await ensureUserChannelRow(newUser.id, channel, channelUserId, { isPrimary: true });
+    console.log(`✅ New user created via ${channel}: ${channelUserId}`);
+    return newUser;
+  } catch (error) {
+    console.error('Error in getOrCreateUserByChannel:', error);
+    throw error;
+  }
+}
+
+/**
+ * Insert a user_channels row if one doesn't already exist for (channel,
+ * channelUserId) — the lazy-backfill helper getOrCreateUserByChannel uses for
+ * both the whatsapp delegation path and brand-new channel identities.
+ */
+async function ensureUserChannelRow(userId, channel, channelUserId, { isPrimary = false } = {}) {
+  try {
+    const { data: existing } = await supabase
+      .from('user_channels')
+      .select('id')
+      .eq('channel', channel)
+      .eq('channel_user_id', channelUserId)
+      .single();
+    if (existing) return;
+
+    await supabase.from('user_channels').insert({
+      user_id: userId,
+      channel,
+      channel_user_id: channelUserId,
+      is_primary: isPrimary,
+      created_at: new Date().toISOString(),
+      last_message_at: new Date().toISOString(),
+    });
+  } catch (error) {
+    // Best-effort — a failed backfill must not break the calling inbound
+    // message; the row is retried on the next message from this identity.
+    console.error('ensureUserChannelRow failed:', error.message);
+  }
+}
+
+/**
+ * Every channel identity a user is reachable on — for async workers/services
+ * that need to proactively notify "this person," not reply to an in-request
+ * message. Loop the result and send once per row; never assume a single
+ * phone_number is the only destination once multi-channel is in play.
+ *
+ * @param {string} userId
+ * @returns {Promise<Array<{channel: string, channel_user_id: string}>>}
+ */
+async function getSendTargetsForUser(userId) {
+  const { data, error } = await supabase
+    .from('user_channels')
+    .select('channel, channel_user_id')
+    .eq('user_id', userId);
+
+  if (error) {
+    console.error('Error in getSendTargetsForUser:', error);
+    return [];
+  }
+  return data || [];
+}
+
+/**
  * Get or create a chat session for the user (30-minute timeout)
  * @param {string} userId - User's UUID
  * @param {number} timeoutMinutes - Session timeout in minutes (default: 30)
@@ -488,6 +624,8 @@ async function trackChatStart(user, phoneNumber, messageBody) {
 
 module.exports = {
   getOrCreateUser,
+  getOrCreateUserByChannel,
+  getSendTargetsForUser,
   getOrCreateSession,
   updateSessionType,
   storeConversation,

--- a/bot/shared/handlers/exam-checker.handler.js
+++ b/bot/shared/handlers/exam-checker.handler.js
@@ -12,6 +12,36 @@ const WhatsAppService = require('../services/whatsapp.service');
 const { uploadImageWithRetry } = require('../storage/r2');
 const { logToFile } = require('../utils/logger');
 const { runWithCorrelation, generateCorrelationId } = require('../utils/structured-logger');
+const { driverForIdentifier } = require('../services/messaging/channel-registry');
+
+/**
+ * Sends the exam-confirm student-confirmation screen on Slack/Discord's
+ * modal-workaround renderers, or falls through to the Meta sendFlow() path
+ * for WhatsApp/Baileys. Mirrors /settings's own driverForIdentifier() branch
+ * in text-message.handler.js — both channels' flow registries key
+ * exam_confirm's flowToken as the exam session's own session.id directly
+ * (never buildFlowToken()'s "userId:kind:timestamp"), matching how the Meta
+ * Flow already passes flowToken: session.id at sendFlow() time.
+ * @returns {Promise<boolean>} true if a Slack/Discord button was sent (caller should not also call sendFlow())
+ */
+async function trySendExamConfirmModalTrigger(from, flowResponse) {
+  const driverName = driverForIdentifier(from);
+  if (driverName !== 'slack' && driverName !== 'discord') return false;
+
+  const body = flowResponse.body || 'Tap below to confirm the student names before I grade them.';
+  if (driverName === 'slack') {
+    await WhatsAppService.sendInteractiveButtons(from, {
+      body,
+      buttons: [{ id: `open_modal:exam_confirm:${flowResponse.flowToken}`, title: flowResponse.buttonText || 'Confirm Students' }],
+    });
+  } else {
+    await WhatsAppService.sendInteractiveButtons(from, {
+      body,
+      buttons: [{ id: `discord_start_flow:exam_confirm:${flowResponse.flowToken}`, title: flowResponse.buttonText || 'Confirm Students' }],
+    });
+  }
+  return true;
+}
 
 // Trigger keywords for exam checking (English + Urdu + Arabic)
 const EXAM_CHECK_KEYWORDS = [
@@ -113,16 +143,22 @@ async function handleExamText(message, from, user) {
       if (response.interactive) {
         await WhatsAppService.sendInteractiveMessage(from, response.interactive);
       } else if (response.flow) {
-        // data_exchange flow — pass the flow_token; the endpoint serves the
-        // screen data on INIT. (Previously called a method that did not exist.)
-        await WhatsAppService.sendFlow(from, {
-          flowId: response.flow.id,
-          flowToken: response.flow.flowToken,
-          header: response.flow.header,
-          body: response.flow.body,
-          buttonText: response.flow.buttonText || 'Open',
-          footer: 'Powered by Rumi',
-        });
+        // Slack/Discord have a real modal-workaround renderer for
+        // exam_confirm — see the button-handler branch above for the full
+        // rationale (trySendExamConfirmModalTrigger's own doc comment).
+        const sentViaModal = await trySendExamConfirmModalTrigger(from, response.flow);
+        if (!sentViaModal) {
+          // data_exchange flow — pass the flow_token; the endpoint serves the
+          // screen data on INIT. (Previously called a method that did not exist.)
+          await WhatsAppService.sendFlow(from, {
+            flowId: response.flow.id,
+            flowToken: response.flow.flowToken,
+            header: response.flow.header,
+            body: response.flow.body,
+            buttonText: response.flow.buttonText || 'Open',
+            footer: 'Powered by Rumi',
+          });
+        }
       } else {
         await WhatsAppService.sendMessage(from, response.text);
       }
@@ -251,16 +287,24 @@ async function handleExamButton(buttonId, from, user) {
       if (response.interactive) {
         await WhatsAppService.sendInteractiveMessage(from, response.interactive);
       } else if (response.flow) {
-        // data_exchange flow — pass the flow_token; the endpoint serves the
-        // screen data on INIT. (Previously called a method that did not exist.)
-        await WhatsAppService.sendFlow(from, {
-          flowId: response.flow.id,
-          flowToken: response.flow.flowToken,
-          header: response.flow.header,
-          body: response.flow.body,
-          buttonText: response.flow.buttonText || 'Open',
-          footer: 'Powered by Rumi',
-        });
+        // Slack/Discord have a real modal-workaround renderer for
+        // exam_confirm (see slack-flow-registry.js / discord-flow-registry.js)
+        // — sendFlow()'s Meta/Baileys-shaped {flowId, flowToken} contract is a
+        // no-op stub on both. Tried first; falls through to sendFlow() only
+        // for WhatsApp/Baileys (or if the modal-workaround send itself fails).
+        const sentViaModal = await trySendExamConfirmModalTrigger(from, response.flow);
+        if (!sentViaModal) {
+          // data_exchange flow — pass the flow_token; the endpoint serves the
+          // screen data on INIT. (Previously called a method that did not exist.)
+          await WhatsAppService.sendFlow(from, {
+            flowId: response.flow.id,
+            flowToken: response.flow.flowToken,
+            header: response.flow.header,
+            body: response.flow.body,
+            buttonText: response.flow.buttonText || 'Open',
+            footer: 'Powered by Rumi',
+          });
+        }
       } else {
         await WhatsAppService.sendMessage(from, response.text);
       }
@@ -324,16 +368,22 @@ async function handleExamFlow(flowId, flowResponse, from, user) {
       if (response.interactive) {
         await WhatsAppService.sendInteractiveMessage(from, response.interactive);
       } else if (response.flow) {
-        // data_exchange flow — pass the flow_token; the endpoint serves the
-        // screen data on INIT. (Previously called a method that did not exist.)
-        await WhatsAppService.sendFlow(from, {
-          flowId: response.flow.id,
-          flowToken: response.flow.flowToken,
-          header: response.flow.header,
-          body: response.flow.body,
-          buttonText: response.flow.buttonText || 'Open',
-          footer: 'Powered by Rumi',
-        });
+        // Slack/Discord have a real modal-workaround renderer for
+        // exam_confirm — see the button-handler branch above for the full
+        // rationale (trySendExamConfirmModalTrigger's own doc comment).
+        const sentViaModal = await trySendExamConfirmModalTrigger(from, response.flow);
+        if (!sentViaModal) {
+          // data_exchange flow — pass the flow_token; the endpoint serves the
+          // screen data on INIT. (Previously called a method that did not exist.)
+          await WhatsAppService.sendFlow(from, {
+            flowId: response.flow.id,
+            flowToken: response.flow.flowToken,
+            header: response.flow.header,
+            body: response.flow.body,
+            buttonText: response.flow.buttonText || 'Open',
+            footer: 'Powered by Rumi',
+          });
+        }
       } else {
         await WhatsAppService.sendMessage(from, response.text);
       }

--- a/bot/shared/handlers/exam-checker.handler.js
+++ b/bot/shared/handlers/exam-checker.handler.js
@@ -103,7 +103,8 @@ async function handleExamText(message, from, user) {
     try {
       const response = await ExamCheckerOrchestrator.process(
         { type: 'text', text },
-        user.id
+        user.id,
+        from
       );
 
       typingController.stop();
@@ -191,7 +192,8 @@ async function handleExamImage(message, from, user) {
           mediaUrl: imageUrl,
           caption: message.image?.caption
         },
-        user.id
+        user.id,
+        from
       );
 
       typingController.stop();
@@ -312,7 +314,8 @@ async function handleExamFlow(flowId, flowResponse, from, user) {
     try {
       const response = await ExamCheckerOrchestrator.process(
         { type: 'flow', flowResponse },
-        user.id
+        user.id,
+        from
       );
 
       typingController.stop();

--- a/bot/shared/handlers/flow-response.handler.js
+++ b/bot/shared/handlers/flow-response.handler.js
@@ -47,11 +47,10 @@
  */
 
 const supabase = require('../config/supabase');
-const PassageGenerationService = require('../services/reading/passage-generation.service');
-const AutoLevelOrchestratorService = require('../services/reading/auto-level-orchestrator.service');
 const WhatsAppService = require('../services/whatsapp.service');
 const AttendanceFlowHandler = require('./attendance-flow.handler');
 const AttendanceDeliveryService = require('../services/attendance-delivery.service');
+const { startAssessment } = require('../routes/reading-assessment-endpoint');
 const { logToFile } = require('../utils/logger');
 
 // Flow IDs - configure via environment variables. Canonical list lives in
@@ -263,147 +262,20 @@ async function handleReadingAssessmentFlow(message, phoneNumber, userId) {
       throw new Error('Missing required field: Level/Grade');
     }
 
-    // Map level index to passage type
-    // levelIndex: 0→letters, 1→words, 2→sentences, 3→paragraph
-    // For auto mode: always start at story
-    let passageType, gradeNumeric;
-
-    if (isAutoMode) {
-      // Auto mode: Start at story level (highest complexity)
-      passageType = 'story';
-      gradeNumeric = 4; // Story level
-    } else {
-      // Manual mode: Use selected level
-      const levelMapping = {
-        '0': { passageType: 'letters', gradeNumeric: 0 },    // Kindergarten
-        '1': { passageType: 'words', gradeNumeric: 1 },      // Grade 1
-        '2': { passageType: 'sentences', gradeNumeric: 2 },  // Grade 1-2
-        '3': { passageType: 'paragraph', gradeNumeric: 3 }   // Grade 3-5
-      };
-
-      const mapped = levelMapping[levelIndex] || { passageType: 'paragraph', gradeNumeric: 2 };
-      passageType = mapped.passageType;
-      gradeNumeric = mapped.gradeNumeric;
-    }
-
-    logToFile('✅ Validated and mapped:', {
-      studentName,
-      language,
-      levelIndex,
-      levelRaw,
-      passageType,
-      gradeNumeric,
-      comprehensionRequired,
-      isAutoMode
+    logToFile('✅ Validated fields:', {
+      studentName, language, levelIndex, levelRaw, comprehensionRequired, isAutoMode,
     });
 
-    // Map passage type to word count (based on existing gradeMap)
-    const wordCountMap = {
-      'letters': 14,
-      'words': 14,
-      'sentences': 40,
-      'paragraph': 60,
-      'story': 100
-    };
-
-    const wordCount = wordCountMap[passageType] || 50;
-
-    // Create passageConfig for passage generation service
-    const passageConfig = {
-      type: passageType,
-      wordCount: wordCount,
-      grade: gradeNumeric
-    };
-
-    // Create assessment record FIRST (required for passage generation)
-    const { data: assessment, error: insertError } = await supabase
-      .from('reading_assessments')
-      .insert({
-        user_id: userId,
-        student_identifier: studentName,
-        grade_level: gradeNumeric,
-        language: language,
-        passage_type: passageType,
-        passage_word_count: wordCount,
-        passage_text: '', // Empty string (will be updated by generateAndSendPassage)
-        comprehension_requested: comprehensionRequired,
-        assessment_mode: isAutoMode ? 'auto' : 'manual',
-        starting_level: isAutoMode ? 'story' : passageType,
-        status: 'initiated',
-        created_at: new Date().toISOString()
-      })
-      .select()
-      .single();
-
-    if (insertError) {
-      logToFile('❌ Error creating assessment record', {
-        error: insertError.message
-      });
-      throw insertError;
-    }
-
-    logToFile('✅ Assessment record created', {
-      assessmentId: assessment.id,
-      studentName,
-      passageConfig,
-      isAutoMode
+    // Creates the assessment record + generates/delivers the first passage —
+    // the same pipeline Discord's onFinish hook (discord-flow-registry.js)
+    // triggers from its own modal-workaround screens, extracted so both
+    // channels share one implementation (see reading-assessment-endpoint.js's
+    // own header comment on why this split exists).
+    const { assessmentId } = await startAssessment(userId, phoneNumber, {
+      studentName, language, isAutoMode, levelIndex, comprehensionRequired,
     });
 
-    // For auto mode, use the auto-level orchestrator
-    if (isAutoMode) {
-      // Start auto-level assessment (sends welcome message and first passage)
-      const autoConfig = await AutoLevelOrchestratorService.startAutoAssessment(
-        assessment.id,
-        userId,
-        phoneNumber,
-        language,
-        gradeNumeric,
-        language // userLanguage
-      );
-
-      // Generate and send first passage (story level)
-      await PassageGenerationService.generateAndSendPassage(
-        assessment.id,
-        userId,
-        phoneNumber,
-        language,
-        { type: autoConfig.passageType, wordCount: autoConfig.wordCount, grade: autoConfig.gradeLevel },
-        language
-      );
-    } else {
-      // Manual mode: Generate and send passage directly
-      await PassageGenerationService.generateAndSendPassage(
-        assessment.id,
-        userId,
-        phoneNumber,
-        language,
-        passageConfig,
-        language // userLanguage for instructions
-      );
-    }
-
-    logToFile('✅ Passage generation and delivery complete', {
-      assessmentId: assessment.id
-    });
-
-    // Update conversation state. Comprehension/assessment context lives in Redis
-    // (see redis-comprehension.service), not a conversations column — writing a
-    // non-existent context_data column here previously failed the whole update,
-    // so current_state never persisted.
-    const { error: updateError } = await supabase
-      .from('conversations')
-      .update({
-        current_state: 'AWAITING_READING_AUDIO'
-      })
-      .eq('user_id', userId)
-      .order('created_at', { ascending: false })
-      .limit(1);
-
-    if (updateError) {
-      logToFile('⚠️ Warning: Could not update conversation state', {
-        error: updateError.message
-      });
-    }
+    logToFile('✅ Passage generation and delivery complete', { assessmentId });
 
     return true;
 

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -2016,6 +2016,21 @@ async function handleTextMessage(message, from, messageBody, user = null) {
     }
   }
 
+  // Quiz intent (deterministic regex priors — cheap, no LLM call, checked
+  // before the generic classifier below since its own prompt has no "quiz"
+  // category and would otherwise misroute "create a quiz on X for grade Y"
+  // into lesson_plan (see quiz-intent.detector.js's file header).
+  if (user) {
+    const { isQuizIntent } = require('../services/quiz/quiz-intent.detector');
+    if (isQuizIntent(messageBody)) {
+      logToFile('📝 Quiz intent detected (natural language)', { userId: user.id });
+      typingController.stop();
+      const QuizIntentRouter = require('../services/quiz/quiz-intent-router.service');
+      await QuizIntentRouter.promptQuizConfirmation(user, from, messageBody, responseLanguage);
+      return;
+    }
+  }
+
   // Detect intent (lesson plan, presentation, or general)
   const intent = await OpenAIService.detectIntent(messageBody);
   logToFile('Intent detected', { intent: intent.type });
@@ -2043,6 +2058,14 @@ async function handleTextMessage(message, from, messageBody, user = null) {
     typingController.stop();
     const topic = await VideoOrchestrator.extractTopicFromMessage(messageBody, responseLanguage);
     await VideoOrchestrator.initiateVideoRequest(user, from, sessionId, responseLanguage, topic);
+  } else if (intent.type === 'quiz') {
+    // Defense-in-depth: isQuizIntent()'s regex priors (checked above, before
+    // this LLM call) should already catch most phrasing — this branch only
+    // fires for wording the regexes missed but the LLM/fallback still
+    // recognized as a quiz request. Same confirmation flow either way.
+    typingController.stop();
+    const QuizIntentRouter = require('../services/quiz/quiz-intent-router.service');
+    await QuizIntentRouter.promptQuizConfirmation(user, from, messageBody, responseLanguage);
   } else {
     await handleGeneralConversation(from, messageBody, user, sessionId, responseLanguage, typingController);
   }

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -461,6 +461,20 @@ async function handleTextMessage(message, from, messageBody, user = null) {
         logToFile('📹 First-use intro video sent for reading assessment', { userId: user.id });
       }
 
+      // Discord has a real modal-workaround renderer for reading_assessment
+      // (see discord-flow-registry.js) — a Slack renderer is deliberately not
+      // built yet (see reading-assessment-endpoint.js's own header comment),
+      // so Slack falls through to sendFlow()'s text-conversation degrade below
+      // exactly as it did before this feature existed on Discord.
+      if (driverForIdentifier(from) === 'discord') {
+        await WhatsAppService.sendInteractiveButtons(from, {
+          body: 'Let\'s set up a reading assessment for your student. This will help measure their reading fluency and comprehension.',
+          buttons: [{ id: 'discord_start_flow:reading_assessment', title: 'Start Assessment' }],
+        });
+        await FeatureIntroService.markFeatureUsed(user.id, 'reading');
+        return;
+      }
+
       // Send WhatsApp Flow for reading assessment setup. On a channel with no
       // Flow support this becomes the equivalent text conversation (same
       // fields, same submission shape) — see messaging/text-flow-definitions.js.
@@ -1196,6 +1210,19 @@ async function handleTextMessage(message, from, messageBody, user = null) {
       return;
     }
 
+    // Slack/Discord have a real modal-workaround registration form (see
+    // feature-registration.service.js#sendNameQuestion) that works fine on
+    // its own, with no need to have used a feature first — that gate below
+    // exists only for WhatsApp's plain-text fallback, where asking for a name
+    // out of nowhere reads as spam. Without this branch, a brand-new
+    // Slack/Discord user typing /register with zero feature usage fell
+    // through to that WhatsApp-flavored "try a feature first" guide message
+    // instead of ever seeing the actual registration form.
+    if (user?.id && (driverForIdentifier(from) === 'slack' || driverForIdentifier(from) === 'discord')) {
+      await FeatureRegistrationService.sendNameQuestion(user.id, from, responseLanguage, 'text');
+      return;
+    }
+
     // Check if user has features but missed registration (recovery path)
     // This handles users who used features but never got asked for name
     if (user?.id) {
@@ -1291,6 +1318,22 @@ async function handleTextMessage(message, from, messageBody, user = null) {
           sw: 'Sasisha mapendeleo yako ya lugha na zana ya uchunguzi.',
         })[responseLanguage] || 'Update your language and observation tool preferences.',
         buttons: [{ id: 'open_modal:settings', title: 'Open Settings' }],
+      });
+      return;
+    }
+
+    // Discord has no Slack-style trigger_id letting a button proactively open
+    // a modal — every flow (including its first screen) needs a real, current
+    // interaction to directly acknowledge. discord-modal-interactions.handler.js's
+    // tryHandleStartFlow() is what actually fires on this button's click,
+    // recognizing it by the "discord_start_flow:<kind>" customId prefix.
+    if (driverForIdentifier(from) === 'discord') {
+      await WhatsAppService.sendInteractiveButtons(from, {
+        body: ({
+          ur: 'اپنی زبان اور آبزرویشن ٹول کی ترجیحات اپ ڈیٹ کریں۔',
+          sw: 'Sasisha mapendeleo yako ya lugha na zana ya uchunguzi.',
+        })[responseLanguage] || 'Update your language and observation tool preferences.',
+        buttons: [{ id: 'discord_start_flow:settings', title: 'Open Settings' }],
       });
       return;
     }
@@ -1664,6 +1707,25 @@ async function handleTextMessage(message, from, messageBody, user = null) {
     logToFile('📋 Add class keyword detected', { userId: user.id, keyword: addClassDetection.keyword });
     typingController.stop();
 
+    // Slack/Discord have a real Flow-equivalent (attendance's modal-workaround
+    // renderer — see slack-flow-registry.js / discord-flow-registry.js), not
+    // sendFlow()'s Meta/Baileys-shaped {flowId, flowToken} contract. Same
+    // driverForIdentifier() branch shape as /settings above.
+    if (driverForIdentifier(from) === 'slack') {
+      await WhatsAppService.sendInteractiveButtons(from, {
+        body: "Let's set up a new class for attendance tracking!",
+        buttons: [{ id: 'open_modal:attendance', title: 'Add Class' }],
+      });
+      return;
+    }
+    if (driverForIdentifier(from) === 'discord') {
+      await WhatsAppService.sendInteractiveButtons(from, {
+        body: "Let's set up a new class for attendance tracking!",
+        buttons: [{ id: 'discord_start_flow:attendance', title: 'Add Class' }],
+      });
+      return;
+    }
+
     const addClassSent = await WhatsAppService.sendFlow(from, {
       flowId: ATTENDANCE_SETUP_FLOW_ID,
       flowKind: 'class-setup',
@@ -1692,6 +1754,24 @@ async function handleTextMessage(message, from, messageBody, user = null) {
       const result = await AttendanceConversationService.startAttendanceSession(user.id);
 
       if (result.action === 'SEND_SETUP_FLOW') {
+        // Slack/Discord have a real Flow-equivalent for attendance/class-setup
+        // — same driverForIdentifier() branch shape as /settings and the
+        // "add class" keyword branch above.
+        if (driverForIdentifier(from) === 'slack') {
+          await WhatsAppService.sendInteractiveButtons(from, {
+            body: result.message,
+            buttons: [{ id: 'open_modal:attendance', title: 'Set Up Class' }],
+          });
+          return;
+        }
+        if (driverForIdentifier(from) === 'discord') {
+          await WhatsAppService.sendInteractiveButtons(from, {
+            body: result.message,
+            buttons: [{ id: 'discord_start_flow:attendance', title: 'Set Up Class' }],
+          });
+          return;
+        }
+
         // User has no classes — set one up, as a Flow or as the text equivalent.
         const setupSent = await WhatsAppService.sendFlow(from, {
           flowId: ATTENDANCE_SETUP_FLOW_ID,
@@ -1738,6 +1818,14 @@ async function handleTextMessage(message, from, messageBody, user = null) {
     if (user?.first_name) {
       // User already registered - confirm and guide to menu
       await WhatsAppService.sendMessage(from, `✅ You're already registered, ${user.first_name}! Type /menu to see what I can help you with.`);
+      return;
+    }
+
+    // Slack/Discord's registration form works standalone, with no need to
+    // have used a feature first — see the identical branch on the /register
+    // command above for the full rationale.
+    if (user?.id && (driverForIdentifier(from) === 'slack' || driverForIdentifier(from) === 'discord')) {
+      await FeatureRegistrationService.sendNameQuestion(user.id, from, responseLanguage, 'text');
       return;
     }
 

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -1279,6 +1279,22 @@ async function handleTextMessage(message, from, messageBody, user = null) {
       }
     }
 
+    // Slack has a real Flow-equivalent (a Block Kit modal, opened by button
+    // click — see slack-flow-registry.js / slack-modal-interactions.handler.js),
+    // not sendFlow()'s Meta/Baileys-shaped {flowId, flowToken} contract. A
+    // button whose action_id is "open_modal:settings" is all the modal
+    // renderer needs — it mints its own flowToken once the click arrives.
+    if (driverForIdentifier(from) === 'slack') {
+      await WhatsAppService.sendInteractiveButtons(from, {
+        body: ({
+          ur: 'اپنی زبان اور آبزرویشن ٹول کی ترجیحات اپ ڈیٹ کریں۔',
+          sw: 'Sasisha mapendeleo yako ya lugha na zana ya uchunguzi.',
+        })[responseLanguage] || 'Update your language and observation tool preferences.',
+        buttons: [{ id: 'open_modal:settings', title: 'Open Settings' }],
+      });
+      return;
+    }
+
     // Tried as a Meta Flow when one is published, and as the equivalent text
     // conversation otherwise — both driven by the SAME settings endpoint, so
     // preferences are written identically either way. The old code returned

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -35,13 +35,25 @@ const { detectRequestedLanguage, parseSubjectAndGrade } = require('../utils/lang
 const path = require('path');
 const {
   getOrCreateUser,
+  getOrCreateUserByChannel,
   getOrCreateSession,
   updateSessionType,
   storeConversation,
   storeLessonPlan
 } = require('../database/bot-helpers');
+const { driverForIdentifier } = require('../services/messaging/channel-registry');
 const supabase = require('../config/supabase');
 const fs = require('fs');
+
+const CHANNEL_FAMILY = { slack: 'slack', discord: 'discord' };
+
+/** Mirrors whatsapp-bot.js's resolveChannelIdentity — see that file for the full rationale. */
+function resolveChannelIdentity(from) {
+  const driverName = driverForIdentifier(from);
+  if (!driverName) return null;
+  const prefix = `${driverName}:`;
+  return { channel: CHANNEL_FAMILY[driverName] || driverName, channelUserId: String(from).slice(prefix.length) };
+}
 
 /**
  * Curriculum pre-gen intercept. If the teacher's region enables curriculum LPs
@@ -151,7 +163,10 @@ async function handleTextMessage(message, from, messageBody, user = null) {
     // ============================================================
   if (!user) {
     try {
-      user = await getOrCreateUser(from);
+      const channelIdentity = resolveChannelIdentity(from);
+      user = channelIdentity
+        ? await getOrCreateUserByChannel(channelIdentity.channel, channelIdentity.channelUserId)
+        : await getOrCreateUser(from);
       logToFile('User retrieved/created', { userId: user.id, phoneNumber: from });
     } catch (error) {
       logToFile('⚠️ Error with database user operation', { error: error.message });

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -1371,8 +1371,22 @@ async function handleTextMessage(message, from, messageBody, user = null) {
 
   // ============================================================
   // /status COMMAND: cross-feature snapshot of what's running + cancel
+  //
+  // "/status" is confirmed live to be a Slack-reserved word — Slack rejects
+  // it outright if registered as a Slash Command ("is a reserved word"),
+  // AND its own client intercepts any plain message starting with "/"
+  // client-side before it ever reaches the bot, the same way it rejected
+  // "/settings" before that command existed in this Slack app's config (see
+  // the live test that first surfaced this). Net effect: a Slack user had
+  // NO way to ever reach this feature at all — not via a registered
+  // command (Slack blocks the name), and not as typed text either (Slack
+  // blocks anything starting with "/"). The natural-language alternative
+  // below is what makes this reachable on Slack; Discord/WhatsApp keep
+  // using the real "/status" slash command unaffected (Discord has no such
+  // reservation — confirmed via discord-register-commands.js already
+  // registering it with zero rename needed).
   // ============================================================
-  if (/^\/status\b/i.test(trimmedMessage)) {
+  if (/^\/status\b/i.test(trimmedMessage) || /^(my status|show (my )?status|what'?s running)$/i.test(trimmedMessage)) {
     logToFile('📋 /status command detected', { userId: user?.id, phoneNumber: from });
     if (!user) {
       await WhatsAppService.sendMessage(from,

--- a/bot/shared/handlers/voice-message.handler.js
+++ b/bot/shared/handlers/voice-message.handler.js
@@ -1173,10 +1173,12 @@ async function handleVoiceMessage(message, from, user = null) {
     if (error.userNotified) {
       logToFile('↩️ Voice failure already reported to the user — not repeating it', {});
     } else {
-      await WhatsAppService.sendMessage(
-        from,
-        'معذرت، آواز پیغام پر کارروائی کرتے وقت خرابی آ گئی۔' // Sorry, error processing voice message
-      );
+      const errorMessages = {
+        en: 'Sorry, there was an error processing your voice message.',
+        ur: 'معذرت، آواز پیغام پر کارروائی کرتے وقت خرابی آ گئی۔'
+      };
+      const userLanguage = user?.preferred_language || 'en';
+      await WhatsAppService.sendMessage(from, errorMessages[userLanguage] || errorMessages.en);
     }
   } finally {
     // CRITICAL: Always stop typing indicator, even if function exits early or throws

--- a/bot/shared/routes/discord-flow-registry.js
+++ b/bot/shared/routes/discord-flow-registry.js
@@ -1,0 +1,191 @@
+/**
+ * Discord Flow-equivalent registry — maps a Discord modal-workaround's `kind`
+ * ('registration', 'settings', ...) to the renderer built for that endpoint.
+ * Mirrors slack-flow-registry.js's register()/get()/ensureRegistered() shape
+ * exactly; buildFlowToken() uses the same "userId:kind:timestamp" convention
+ * (kept duplicated per this codebase's per-driver-file convention rather than
+ * shared, matching how Slack/Baileys never share driver-adjacent code either).
+ *
+ * Lazily registered (first use, not at require time) to avoid a require cycle
+ * through supabase / whatsapp.service — same rationale as
+ * slack-flow-registry.js's own ensureRegistered().
+ *
+ * Exception: 'exam_confirm' does NOT use buildFlowToken() — its flow token is
+ * the exam session's own session.id, unchanged, since the endpoint already
+ * keys everything off that id. Callers triggering exam_confirm must pass the
+ * session id directly as the flowToken, not call buildFlowToken() for it.
+ */
+
+const { buildEndpointModal } = require('../services/messaging/discord-modal-flow');
+const discordChannel = require('../services/messaging/discord-channel.service');
+
+const registry = new Map();
+
+function register(kind, renderer) {
+  registry.set(kind, renderer);
+}
+
+function get(kind) {
+  return registry.get(kind);
+}
+
+function registerAll() {
+  const registration = require('./registration-endpoint');
+  const registrationView = require('./discord-views/registration.view');
+  register('registration', buildEndpointModal({
+    kind: 'registration',
+    init: (ctx) => registration.handleRegistrationInit(ctx.userId),
+    exchange: (ctx, screen, screenData) =>
+      registration.handleRegistrationDataExchange(ctx.userId, screen, screenData, ctx.flowToken),
+    back: (ctx, screen) => registration.handleRegistrationBack(ctx.userId, screen, ctx.flowToken),
+    screenToSteps: registrationView.screenToSteps,
+    mergeScreenData: registrationView.mergeScreenData,
+    onFinish: async (response, ctx) => {
+      const { welcome_message: welcome, portal_message: portal } = response.data || {};
+      const text = [welcome, portal].filter(Boolean).join('\n\n');
+      if (text) await discordChannel.sendMessage(`discord:${ctx.discordUserId}`, text);
+    },
+  }));
+
+  const settings = require('./settings-endpoint');
+  const settingsView = require('./discord-views/settings.view');
+  register('settings', buildEndpointModal({
+    kind: 'settings',
+    init: (ctx) => settings.handleSettingsInit(ctx.userId),
+    exchange: (ctx, screen, screenData) =>
+      settings.handleSettingsDataExchange(ctx.userId, screen, screenData, ctx.flowToken),
+    back: (ctx, screen) => settings.handleSettingsBack(ctx.userId, screen, ctx.flowToken),
+    screenToSteps: settingsView.screenToSteps,
+    mergeScreenData: settingsView.mergeScreenData,
+    onFinish: async (response, ctx) => {
+      const { confirmation_message: confirmation, details_message: details } = response.data || {};
+      const text = [confirmation, details].filter(Boolean).join('\n');
+      if (text) await discordChannel.sendMessage(`discord:${ctx.discordUserId}`, text);
+    },
+  }));
+
+  // ADD_STUDENT loops back to itself after each student is added — the
+  // generic runScreen()->showModal() auto-recursion is unsafe here (it would
+  // reuse an already-acked modal-submit interaction, which Discord's
+  // showModal() forbids). onScreenLoop sends a fresh "Add Another"/"I'm Done"
+  // button message instead — a real button click gives the NEXT interaction
+  // showModal() (Add Another) or exchange() (I'm Done) needs to directly ack.
+  // See discord-modal-interactions.handler.js's own handling of these buttons.
+  const attendance = require('./attendance-setup-endpoint');
+  const attendanceView = require('./discord-views/attendance.view');
+  register('attendance', buildEndpointModal({
+    kind: 'attendance',
+    init: (ctx) => attendance.handleSetupInit(ctx.userId),
+    exchange: (ctx, screen, screenData) => attendance.handleSetupDataExchange(ctx.userId, screen, screenData),
+    screenToSteps: attendanceView.screenToSteps,
+    mergeScreenData: attendanceView.mergeScreenData,
+    loopScreens: new Set(['ADD_STUDENT']),
+    onScreenLoop: async (response, ctx) => {
+      const { students_list: studentsList, class_info: classInfo } = response.data || {};
+      const body = [classInfo, studentsList, 'Add another student?'].filter(Boolean).join('\n');
+      await discordChannel.sendInteractiveButtons(`discord:${ctx.discordUserId}`, {
+        body,
+        buttons: [
+          { id: `discord_attendance_add:${ctx.flowToken}`, title: 'Add Another' },
+          { id: `discord_attendance_done:${ctx.flowToken}`, title: "I'm Done" },
+        ],
+      });
+    },
+    onFinish: async (response, ctx) => {
+      const { success_message: success } = response.data || {};
+      if (success) await discordChannel.sendMessage(`discord:${ctx.discordUserId}`, success);
+    },
+  }));
+
+  // exam_confirm is the one kind whose flowToken IS the exam session's own
+  // session.id (set by the orchestrator at sendFlow-time), never a
+  // buildFlowToken() "userId:kind:timestamp" token — the endpoint keys
+  // everything off that id directly, matching how the Meta flow already works.
+  //
+  // Unlike registration/settings/attendance, exam-confirm-endpoint.js's own
+  // exchange() does NOT drive the workflow forward — it only returns the
+  // selected student ids in extension_message_response, matching the Meta
+  // Flow's NFM_REPLY shape. On Meta, flow-response.handler.js's
+  // EXAM_CONFIRM_FLOW_ID branch is what actually feeds that payload into
+  // ExamCheckerOrchestrator.process(), which drives confirm -> detect
+  // questions -> grade. onFinish here replicates that exact hand-off for
+  // Discord, looking the session back up by id to recover the userId/from
+  // ExamCheckerOrchestrator.process() needs (ctx only carries the session id).
+  const examConfirm = require('./exam-confirm-endpoint');
+  const examConfirmView = require('./discord-views/exam-confirm.view');
+  register('exam_confirm', buildEndpointModal({
+    kind: 'exam_confirm',
+    init: (ctx) => examConfirm.handleExamConfirmInit(ctx.flowToken),
+    exchange: (ctx, screen, screenData) => examConfirm.handleExamConfirmDataExchange(ctx.flowToken, screen, screenData),
+    back: (ctx) => examConfirm.handleExamConfirmBack(ctx.flowToken),
+    screenToSteps: examConfirmView.screenToSteps,
+    mergeScreenData: examConfirmView.mergeScreenData,
+    onFinish: async (response, ctx) => {
+      const confirmedStudents = response?.data?.extension_message_response?.params?.confirmed_students || [];
+      const ExamSessionService = require('../services/exam-checker/exam-session.service');
+      const { ExamCheckerOrchestrator } = require('../services/exam-checker/exam-checker.orchestrator');
+      const session = await ExamSessionService.getById(ctx.flowToken);
+      if (!session) return;
+      await ExamCheckerOrchestrator.process(
+        { type: 'flow', flowResponse: { confirmed_students: confirmedStudents } },
+        session.user_id,
+        session.recipient_identifier,
+      );
+    },
+  }));
+
+  // reading-assessment-endpoint.js's own exchange() does NOT create the
+  // assessment record or generate a passage (see that file's header comment
+  // for why) — onFinish here calls its startAssessment() directly, the same
+  // extracted pipeline flow-response.handler.js's Meta NFM path now calls too,
+  // so both channels share one implementation instead of duplicating it.
+  const readingAssessment = require('./reading-assessment-endpoint');
+  const readingAssessmentView = require('./discord-views/reading-assessment.view');
+  register('reading_assessment', buildEndpointModal({
+    kind: 'reading_assessment',
+    init: (ctx) => readingAssessment.handleReadingAssessmentInit(ctx.userId),
+    exchange: (ctx, screen, screenData) =>
+      readingAssessment.handleReadingAssessmentDataExchange(ctx.userId, screen, screenData, ctx.flowToken),
+    screenToSteps: readingAssessmentView.screenToSteps,
+    mergeScreenData: readingAssessmentView.mergeScreenData,
+    onFinish: async (response, ctx) => {
+      const data = response.data || {};
+      const isAutoMode = String(data.assessment_mode || '').includes('Auto');
+      const language = String(data.Language || '').includes('Urdu') ? 'ur' : 'en';
+      const levelMatch = String(data.select_the_reading_level || '').match(/^(\d+)_/);
+      try {
+        await readingAssessment.startAssessment(ctx.userId, `discord:${ctx.discordUserId}`, {
+          studentName: data.student_full_name,
+          language,
+          isAutoMode,
+          levelIndex: levelMatch ? levelMatch[1] : '0',
+          comprehensionRequired: String(data.scope_of_assessment_ || '').includes('Comprehension'),
+        });
+      } catch (error) {
+        const { logToFile } = require('../utils/logger');
+        logToFile('❌ Discord reading-assessment: startAssessment failed', { error: error.message, stack: error.stack });
+        await discordChannel.sendMessage(`discord:${ctx.discordUserId}`, 'Sorry, something went wrong setting up the reading assessment. Please try again.');
+      }
+    },
+  }));
+}
+
+let registered = false;
+function ensureRegistered() {
+  if (registered) return;
+  registerAll();
+  registered = true;
+}
+
+/** Test-only: forces registerAll() to run again on the next ensureRegistered() call. */
+function _resetForTests() {
+  registered = false;
+  registry.clear();
+}
+
+/** Builds a fresh flow-token in this codebase's existing "userId:kind:timestamp" convention. */
+function buildFlowToken(userId, kind) {
+  return `${userId}:${kind}:${Date.now()}`;
+}
+
+module.exports = { register, get, ensureRegistered, buildFlowToken, _resetForTests };

--- a/bot/shared/routes/discord-modal-interactions.handler.js
+++ b/bot/shared/routes/discord-modal-interactions.handler.js
@@ -1,0 +1,245 @@
+/**
+ * Discord modal-workaround interaction handling — the counterpart to
+ * slack-modal-interactions.handler.js, but for discord.js's interaction
+ * shapes instead of Slack's Interactivity payloads.
+ *
+ * Handles three interaction shapes discord-events.adapter.js routes here,
+ * none of which are ordinary chat button/select clicks (those stay
+ * discord-events.adapter.js's own job, mapped to Meta's button_reply/
+ * list_reply shape):
+ *   - a "Get started"-style button click — the Discord analogue of Slack's
+ *     `open_modal:<kind>` block_actions, opening the FIRST screen of a
+ *     registered flow kind.
+ *   - a modal submission (isModalSubmit()) — advances or completes the flow.
+ *   - a button/select click that belongs to an ACTIVE collectEnumAnswers()
+ *     collector — claimed here FIRST via tryHandleCollected() so
+ *     discord-events.adapter.js's own listener never double-acks or
+ *     mis-dispatches it as an ordinary chat interaction.
+ *
+ * Why tryHandleCollected() must exist at all (confirmed against the
+ * installed discord.js@14.27.0's own source, not assumed): Message#
+ * awaitMessageComponent builds an InteractionCollector that subscribes to
+ * Events.InteractionCreate on the SAME client discord-connection.js owns
+ * (see node_modules/discord.js/src/structures/InteractionCollector.js:120).
+ * Node's EventEmitter invokes EVERY listener registered for an event, not
+ * just one — so a matching interaction fires BOTH the collector's internal
+ * listener (which resolves collectEnumAnswers's own awaitMessageComponent
+ * Promise) AND discord-events.adapter.js's global interactionCreate
+ * listener, with no built-in "claiming" between them. Without this check,
+ * the global listener would race the collector: calling deferUpdate() on an
+ * interaction collectEnumAnswers's own loop is about to act on, and
+ * dispatching a spurious button_reply/list_reply chat message mid-flow.
+ * The active-collector registry itself lives in discord-modal-flow.js
+ * (collectEnumAnswers registers/deregisters each step's message id there
+ * directly) — this just reads it.
+ */
+
+const { logToFile } = require('../utils/logger');
+const flowRegistry = require('./discord-flow-registry');
+const { decodeCustomId, loadModalState, deleteModalState, isCollectorActiveForMessage } = require('../services/messaging/discord-modal-flow');
+const { getOrCreateUserByChannel } = require('../database/bot-helpers');
+
+const START_FLOW_PREFIX = 'discord_start_flow:';
+const LOOP_ADD_PREFIX = 'discord_attendance_add:';
+const LOOP_DONE_PREFIX = 'discord_attendance_done:';
+
+function isStartFlowAction(customId) {
+  return typeof customId === 'string' && customId.startsWith(START_FLOW_PREFIX);
+}
+
+/**
+ * Splits "discord_start_flow:<kind>" or "discord_start_flow:<kind>:<sessionId>"
+ * into its parts. The optional 3rd segment exists ONLY for exam_confirm,
+ * whose flowToken must be the exam session's own session.id (passed in by
+ * whoever sent this button — see exam-checker.handler.js's
+ * trySendExamConfirmModalTrigger) rather than a freshly-minted
+ * "userId:kind:timestamp" token. Every other kind's customId has no 3rd
+ * segment at all — sessionId is null for those.
+ */
+function parseStartFlowAction(customId) {
+  const rest = customId.slice(START_FLOW_PREFIX.length);
+  const idx = rest.indexOf(':');
+  if (idx === -1) return { kind: rest, sessionId: null };
+  return { kind: rest.slice(0, idx), sessionId: rest.slice(idx + 1) };
+}
+
+function kindFromStartFlowAction(customId) {
+  return parseStartFlowAction(customId).kind;
+}
+
+/**
+ * Claims a button/select interaction that belongs to an in-flight
+ * collectEnumAnswers() collector, so discord-events.adapter.js's own
+ * listener skips it entirely (no deferUpdate(), no chat-shape dispatch) —
+ * collectEnumAnswers's own awaitMessageComponent() call already handles
+ * reading and acking it. Returns true if this interaction was claimed here.
+ */
+function tryHandleCollected(interaction) {
+  return isCollectorActiveForMessage(interaction.message?.id);
+}
+
+/**
+ * A button click starting a registered flow from scratch — the Discord
+ * analogue of Slack's handleOpenModal. Every Discord flow (including its
+ * very first screen) needs a real, current interaction to directly
+ * acknowledge: there is no Slack-style trigger_id letting a flow open a
+ * modal out of the blue, so feature-registration.service.js and friends
+ * must first send a plain "Get started" button message, and this only
+ * fires once that button is actually clicked.
+ *
+ * customId shape: "discord_start_flow:<kind>" for userId-keyed kinds
+ * (registration/settings/attendance/reading_assessment), or
+ * "discord_start_flow:<kind>:<sessionId>" for exam_confirm specifically —
+ * see parseStartFlowAction()'s own doc comment.
+ * @returns {Promise<boolean>} true if this interaction was handled here
+ */
+async function tryHandleStartFlow(interaction) {
+  if (!interaction.isButton?.() || !isStartFlowAction(interaction.customId)) return false;
+
+  const { kind, sessionId } = parseStartFlowAction(interaction.customId);
+  flowRegistry.ensureRegistered();
+  const renderer = flowRegistry.get(kind);
+  if (!renderer) {
+    logToFile('⚠️ Discord modal: no renderer registered for kind', { kind });
+    await interaction.deferUpdate();
+    return true;
+  }
+
+  const discordUserId = interaction.user.id;
+
+  try {
+    let ctx;
+    if (sessionId) {
+      // exam_confirm: flowToken IS the exam session's own session.id,
+      // unchanged — never buildFlowToken()'s minted token. userId isn't
+      // resolvable from discordUserId alone for this kind anyway; the
+      // renderer's endpoint calls key everything off flowToken (the session
+      // id) directly, and onFinish looks the session's own user_id back up.
+      ctx = { userId: null, discordUserId, flowToken: sessionId };
+    } else {
+      // registration/settings/attendance/reading_assessment key everything
+      // off the DB user's UUID (flowToken = "userId:kind:timestamp", parsed
+      // via flowToken.split(':')[0], the same convention
+      // flow-endpoint.routes.js uses for Meta) — never the Discord snowflake.
+      const user = await getOrCreateUserByChannel('discord', discordUserId);
+      ctx = { userId: user.id, discordUserId, flowToken: flowRegistry.buildFlowToken(user.id, kind) };
+    }
+
+    const result = await renderer.startFlow(ctx, interaction);
+    if (result === 'timed_out') {
+      // runScreen() gives up silently after 2 minutes with no reply from the
+      // teacher on a select menu — without this, they're just left staring
+      // at a menu that stopped working, with zero indication anything ended.
+      const discordChannel = require('../services/messaging/discord-channel.service');
+      await discordChannel.sendMessage(`discord:${discordUserId}`, 'That took too long to answer, so I\'ve stopped waiting. Send the command again whenever you\'re ready.');
+    }
+  } catch (error) {
+    logToFile('❌ Discord modal: failed to start flow', { kind, error: error.message, stack: error.stack });
+  }
+  return true;
+}
+
+/**
+ * The "Add Another"/"I'm Done" buttons attendance's onScreenLoop hook sends
+ * after each student is added (see discord-flow-registry.js's own comment on
+ * why the ADD_STUDENT loop can't use the generic modal-reopening
+ * auto-recursion). customId shape: "discord_attendance_add:<flowToken>" /
+ * "discord_attendance_done:<flowToken>".
+ *   - "Add Another" resumes the ADD_STUDENT screen via renderer.resumeLoopScreen(),
+ *     which re-opens a fresh modal directly acking THIS button click.
+ *   - "I'm Done" calls exchange() directly with `_action: 'done'` — no modal
+ *     needed for this action at all, matching the endpoint's own
+ *     screenData._action contract.
+ * @returns {Promise<boolean>} true if this interaction was handled here
+ */
+async function tryHandleAttendanceLoopButton(interaction) {
+  if (!interaction.isButton?.()) return false;
+  const customId = interaction.customId;
+  const isAdd = typeof customId === 'string' && customId.startsWith(LOOP_ADD_PREFIX);
+  const isDone = typeof customId === 'string' && customId.startsWith(LOOP_DONE_PREFIX);
+  if (!isAdd && !isDone) return false;
+
+  flowRegistry.ensureRegistered();
+  const renderer = flowRegistry.get('attendance');
+  if (!renderer) {
+    logToFile('⚠️ Discord modal: no renderer registered for attendance');
+    await interaction.deferUpdate();
+    return true;
+  }
+
+  const flowToken = customId.slice((isAdd ? LOOP_ADD_PREFIX : LOOP_DONE_PREFIX).length);
+  const ctx = { userId: flowToken.split(':')[0] || null, discordUserId: interaction.user.id, flowToken };
+
+  try {
+    if (isAdd) {
+      const result = await renderer.resumeLoopScreen(ctx, interaction);
+      if (result === 'timed_out') {
+        const discordChannel = require('../services/messaging/discord-channel.service');
+        await discordChannel.sendMessage(`discord:${interaction.user.id}`, 'That took too long to answer, so I\'ve stopped waiting. Send the command again whenever you\'re ready.');
+      }
+    } else {
+      // "I'm Done" needs the same {list_id, class_display} the loop screen
+      // was showing — recover it the same way resumeLoopScreen() would,
+      // since exchange() expects ADD_STUDENT's screenData shape either way.
+      const { loadLoopScreenData, deleteLoopScreenData } = require('../services/messaging/discord-modal-flow');
+      const stored = await loadLoopScreenData(flowToken);
+      await deleteLoopScreenData(flowToken);
+      await interaction.deferUpdate();
+      if (!stored) {
+        logToFile('⚠️ Discord modal: attendance "I\'m Done" arrived after its loop state expired', { flowToken });
+        return true;
+      }
+      await renderer._advance(ctx, interaction, 'ADD_STUDENT', {
+        _action: 'done',
+        _list_id: stored.data?.list_id,
+        _class_display: stored.data?.class_display,
+      });
+    }
+  } catch (error) {
+    logToFile('❌ Discord modal: attendance loop button handling failed', { flowToken, isAdd, error: error.message, stack: error.stack });
+  }
+  return true;
+}
+
+/**
+ * A modal submission (isModalSubmit()). Recovers {kind, screen, flowToken,
+ * collectedEnumAnswers} from Redis via the token embedded in customId
+ * ("<kind>:<token>"), merges in this submission's text-field answers, and
+ * advances the flow. The Redis entry is deleted either way — a modal can
+ * only be submitted once.
+ */
+async function handleModalSubmit(interaction) {
+  const { kind, token } = decodeCustomId(interaction.customId);
+  flowRegistry.ensureRegistered();
+  const renderer = flowRegistry.get(kind);
+  if (!renderer) {
+    logToFile('⚠️ Discord modal: no renderer registered for modal-submit kind', { kind });
+    await interaction.deferUpdate();
+    return;
+  }
+
+  const state = await loadModalState(token);
+  await deleteModalState(token);
+  if (!state) {
+    logToFile('⚠️ Discord modal: submission arrived after its state expired', { kind });
+    await interaction.deferUpdate();
+    return;
+  }
+
+  try {
+    await renderer.handleModalSubmit(interaction, state);
+  } catch (error) {
+    logToFile('❌ Discord modal: handleModalSubmit failed', { kind, screen: state.screen, error: error.message, stack: error.stack });
+  }
+}
+
+module.exports = {
+  tryHandleStartFlow,
+  tryHandleAttendanceLoopButton,
+  tryHandleCollected,
+  handleModalSubmit,
+  isStartFlowAction,
+  kindFromStartFlowAction,
+  parseStartFlowAction,
+  START_FLOW_PREFIX,
+};

--- a/bot/shared/routes/discord-views/attendance.view.js
+++ b/bot/shared/routes/discord-views/attendance.view.js
@@ -1,0 +1,94 @@
+/**
+ * Discord screen mapping for the attendance/class-setup Flow-equivalent —
+ * the counterpart to slack-views/attendance.view.js, shaped for
+ * discord-modal-flow.js's screenToSteps()/mergeScreenData() contract.
+ *
+ * CLASS_INFO: one enum field (attendance_frequency: once/twice — a static
+ * 2-option list, confirmed against docs/flows/attendance-setup-flow.json)
+ * plus two text fields (class_name, section).
+ *
+ * ADD_STUDENT: both fields (first_name, last_name) are free text, zero enum
+ * — modal-only, no collector step. The Add/Done duality is handled OUTSIDE
+ * this file (in discord-modal-interactions.handler.js's post-submission
+ * message with two real buttons — "Add Another" / "I'm Done" — since a
+ * modal itself can carry no such choice; see that file's own doc comment).
+ * mergeScreenData reads `_action`/`_list_id`/`_class_display` from
+ * screenData exactly like the Slack/Meta renderers already do — these are
+ * carried through by discord-modal-interactions.handler.js, not collected
+ * from the teacher at all.
+ */
+
+const { StringSelectMenuBuilder } = require('discord.js');
+
+const FREQUENCY_OPTIONS = [
+  { id: 'once', title: 'Once per day' },
+  { id: 'twice', title: 'Twice (morning & afternoon)' },
+];
+
+function buildFrequencyMenu() {
+  return new StringSelectMenuBuilder()
+    .setCustomId('attendance_frequency')
+    .setPlaceholder('How often do you take attendance?')
+    .addOptions(FREQUENCY_OPTIONS.map((o) => ({ label: o.title, value: o.id })));
+}
+
+function screenToSteps(screen, data) {
+  if (screen === 'CLASS_INFO') {
+    return {
+      steps: [
+        { fieldName: 'attendance_frequency', promptText: 'How often do you take attendance?', buildMenu: buildFrequencyMenu },
+      ],
+      textFields: [
+        { name: 'class_name', label: 'Class / grade name', required: true },
+        { name: 'section', label: 'Section (optional)', required: false },
+      ],
+      title: 'Set up your class',
+    };
+  }
+
+  if (screen === 'ADD_STUDENT') {
+    return {
+      steps: [],
+      textFields: [
+        { name: 'first_name', label: 'Student first name', required: true },
+        { name: 'last_name', label: 'Student last name (optional)', required: false },
+      ],
+      title: data?.heading || 'Add a student',
+    };
+  }
+
+  throw new Error(`discord-views/attendance: no screen mapping for "${screen}"`);
+}
+
+/**
+ * @param {string} screen
+ * @param {object} enumAnswers
+ * @param {object} textAnswers
+ * @param {object} [carriedData] - ADD_STUDENT's previous response `data`
+ *   (list_id/class_display), never collected from the teacher — matching how
+ *   the Meta Flow round-trips these as hidden `_list_id`/`_class_display`
+ *   form fields (see docs/flows/attendance-setup-flow.json:188-190).
+ *   `_action` defaults to 'add' here; discord-modal-interactions.handler.js's
+ *   "I'm Done" button overrides it to 'done' before calling exchange() directly.
+ */
+function mergeScreenData(screen, enumAnswers, textAnswers, carriedData = {}) {
+  if (screen === 'CLASS_INFO') {
+    return {
+      class_name: textAnswers.class_name || '',
+      section: textAnswers.section || '',
+      attendance_frequency: enumAnswers.attendance_frequency || '',
+    };
+  }
+  if (screen === 'ADD_STUDENT') {
+    return {
+      first_name: textAnswers.first_name || '',
+      last_name: textAnswers.last_name || '',
+      _action: 'add',
+      _list_id: carriedData.list_id,
+      _class_display: carriedData.class_display,
+    };
+  }
+  return {};
+}
+
+module.exports = { screenToSteps, mergeScreenData, FREQUENCY_OPTIONS };

--- a/bot/shared/routes/discord-views/exam-confirm.view.js
+++ b/bot/shared/routes/discord-views/exam-confirm.view.js
@@ -1,0 +1,81 @@
+/**
+ * Discord screen mapping for the exam-checker student-confirmation
+ * Flow-equivalent — the counterpart to slack-views/exam-confirm.view.js,
+ * shaped for discord-modal-flow.js's screenToSteps()/mergeScreenData()
+ * contract.
+ *
+ * CONFIRM_STUDENTS is one multi-select field over exam-confirm-endpoint.js's
+ * dynamically-sized `data.students` array (stringified detected-student
+ * indices as ids — see that endpoint's handleExamConfirmInit). Real class
+ * sizes (20-40 students) routinely exceed Discord's 25-option
+ * StringSelectMenu cap, so this is NOT a rare edge case to special-case: when
+ * students.length > 25, the roster is split across 2 sequential select
+ * steps and both selections are merged before calling exchange() — matching
+ * the plan's explicit call-out that this needs handling as a first-class
+ * case, not deferred.
+ *
+ * No text-fields modal at all for this screen — it's one (or two) selects,
+ * nothing else.
+ */
+
+const { StringSelectMenuBuilder } = require('discord.js');
+
+const CHUNK_SIZE = 25;
+
+function toOption(row) {
+  // default: true pre-selects every student in the menu's rendered state —
+  // matching Slack/Meta's checkbox-group default (all checked; the teacher
+  // unchecks anyone who isn't a real student) as closely as a Discord
+  // StringSelectMenu allows.
+  return { label: String(row.title).slice(0, 100), value: String(row.id).slice(0, 100), default: true };
+}
+
+function chunkStudents(students) {
+  const chunks = [];
+  for (let i = 0; i < students.length; i += CHUNK_SIZE) {
+    chunks.push(students.slice(i, i + CHUNK_SIZE));
+  }
+  return chunks;
+}
+
+function buildChunkMenu(chunk, fieldName, placeholder) {
+  return new StringSelectMenuBuilder()
+    .setCustomId(fieldName)
+    .setPlaceholder(placeholder)
+    .setMinValues(0)
+    .setMaxValues(chunk.length)
+    .addOptions(chunk.map(toOption));
+}
+
+function screenToSteps(screen, data) {
+  if (screen === 'CONFIRM_STUDENTS') {
+    const students = data?.students || [];
+    const chunks = chunkStudents(students);
+
+    const steps = chunks.map((chunk, i) => ({
+      fieldName: `confirmed_students_chunk_${i}`,
+      promptText: chunks.length > 1
+        ? `${data.heading || 'Confirm students'} (${i + 1}/${chunks.length}) — uncheck anyone who isn't a real student:`
+        : `${data.heading || 'Confirm students'} — uncheck anyone who isn't a real student:`,
+      buildMenu: () => buildChunkMenu(chunk, `confirmed_students_chunk_${i}`, `Students ${i + 1}-${i + chunk.length} of ${students.length}`),
+      multi: true,
+    }));
+
+    return { steps, textFields: [], title: 'Confirm Students' };
+  }
+
+  throw new Error(`discord-views/exam-confirm: no screen mapping for "${screen}"`);
+}
+
+function mergeScreenData(screen, enumAnswers) {
+  if (screen === 'CONFIRM_STUDENTS') {
+    const confirmedStudents = Object.keys(enumAnswers)
+      .filter((key) => key.startsWith('confirmed_students_chunk_'))
+      .sort()
+      .flatMap((key) => enumAnswers[key] || []);
+    return { confirmed_students: confirmedStudents };
+  }
+  return {};
+}
+
+module.exports = { screenToSteps, mergeScreenData, chunkStudents, toOption, CHUNK_SIZE };

--- a/bot/shared/routes/discord-views/reading-assessment.view.js
+++ b/bot/shared/routes/discord-views/reading-assessment.view.js
@@ -1,0 +1,93 @@
+/**
+ * Discord screen mapping for the reading-assessment Flow-equivalent — the
+ * counterpart to reading-assessment-endpoint.js's {init, exchange} contract.
+ * No Slack renderer exists yet for this endpoint (explicitly deferred per
+ * the integration plan) — this is Discord-only for now, matching the
+ * endpoint's own renderer-agnostic design.
+ *
+ * BASIC_INFO: language + assessment_mode (both enums, 2 options each) plus
+ * one text field (student_full_name) — a collector step then a modal.
+ *
+ * OPTIONS (manual mode only): reading level + scope (both enums, 4 and 2
+ * options) — pure enum, no modal needed for this screen at all.
+ */
+
+const { StringSelectMenuBuilder } = require('discord.js');
+
+function toOption(row) {
+  return { label: String(row.title).slice(0, 100), value: String(row.id).slice(0, 100) };
+}
+
+function buildLanguageMenu(data) {
+  return new StringSelectMenuBuilder()
+    .setCustomId('assessment_mode_language')
+    .setPlaceholder('Assessment language')
+    .addOptions(data.languages.map(toOption));
+}
+
+function buildAssessmentModeMenu(data) {
+  return new StringSelectMenuBuilder()
+    .setCustomId('assessment_mode')
+    .setPlaceholder('Assessment type')
+    .addOptions(data.assessment_modes.map(toOption));
+}
+
+function buildLevelMenu(data) {
+  return new StringSelectMenuBuilder()
+    .setCustomId('select_the_reading_level')
+    .setPlaceholder('Reading level')
+    .addOptions(data.levels.map(toOption));
+}
+
+function buildScopeMenu(data) {
+  return new StringSelectMenuBuilder()
+    .setCustomId('scope_of_assessment')
+    .setPlaceholder('Assessment scope')
+    .addOptions(data.scopes.map(toOption));
+}
+
+function screenToSteps(screen, data) {
+  if (screen === 'BASIC_INFO') {
+    return {
+      steps: [
+        { fieldName: 'assessment_mode_language', promptText: 'Pick the assessment language:', buildMenu: () => buildLanguageMenu(data) },
+        { fieldName: 'assessment_mode', promptText: 'Pick the assessment type:', buildMenu: () => buildAssessmentModeMenu(data) },
+      ],
+      textFields: [{ name: 'student_full_name', label: 'Student name', required: true }],
+      title: 'Reading Assessment',
+    };
+  }
+
+  if (screen === 'OPTIONS') {
+    return {
+      steps: [
+        { fieldName: 'select_the_reading_level', promptText: 'Pick the reading level:', buildMenu: () => buildLevelMenu(data) },
+        { fieldName: 'scope_of_assessment', promptText: 'Pick the assessment scope:', buildMenu: () => buildScopeMenu(data) },
+      ],
+      textFields: [],
+      title: 'Assessment Options',
+    };
+  }
+
+  throw new Error(`discord-views/reading-assessment: no screen mapping for "${screen}"`);
+}
+
+function mergeScreenData(screen, enumAnswers, textAnswers, carriedData = {}) {
+  if (screen === 'BASIC_INFO') {
+    return {
+      student_full_name: textAnswers.student_full_name || '',
+      Language: enumAnswers.assessment_mode_language || '',
+      assessment_mode: enumAnswers.assessment_mode || '',
+    };
+  }
+  if (screen === 'OPTIONS') {
+    return {
+      ...carriedData,
+      select_the_reading_level: enumAnswers.select_the_reading_level || '',
+      scope_of_assessment_: enumAnswers.scope_of_assessment || '',
+    };
+  }
+  return {};
+}
+
+module.exports = { screenToSteps, mergeScreenData, toOption };

--- a/bot/shared/routes/discord-views/registration.view.js
+++ b/bot/shared/routes/discord-views/registration.view.js
@@ -1,0 +1,156 @@
+/**
+ * Discord screen mapping for the registration Flow-equivalent — the
+ * counterpart to slack-views/registration.view.js, shaped for
+ * discord-modal-flow.js's screenToSteps()/mergeScreenData() contract.
+ *
+ * Two genuinely new pieces with no Slack equivalent (Slack's static_select
+ * caps at 100 options, so it renders these as one dropdown each):
+ *   - PERSONAL_INFO's `country` field: 164 options, over Discord's 25-option
+ *     StringSelectMenu cap — resolved as a 2-step picker (pick a continent-ish
+ *     bucket from discord-country-regions.js, then a country within it).
+ *   - REGION_INFO's `region` field: 29 options (7 Pakistan + 22 India) — also
+ *     over the cap, but needs NO new lookup table: registration-data.js's
+ *     REGIONS_DROPDOWN already distinguishes the two by `in_`-prefixed ids,
+ *     so this is a clean 2-step "Pakistan or India?" picker over existing data.
+ *
+ * PROFESSIONAL_INFO's `subjects` field is a REAL multi-select
+ * (setMinValues/setMaxValues), matching WhatsApp/Slack's multi-select
+ * semantics exactly — not a text-degradation.
+ */
+
+const { StringSelectMenuBuilder } = require('discord.js');
+const { buildBuckets } = require('../../config/discord-country-regions');
+const { REGIONS_DROPDOWN } = require('../../config/registration-data');
+
+const BUCKET_FIELD = '_country_bucket';
+const PK_IN_FIELD = '_pk_or_india';
+
+function toOption(row) {
+  return { label: String(row.title).slice(0, 100), value: String(row.id).slice(0, 100) };
+}
+
+function buildBucketMenu() {
+  const buckets = buildBuckets(require('../../config/registration-data').COUNTRIES_DROPDOWN);
+  return new StringSelectMenuBuilder()
+    .setCustomId(BUCKET_FIELD)
+    .setPlaceholder('Pick a region')
+    .addOptions(buckets.map((b) => ({ label: b.title.slice(0, 100), value: b.id })));
+}
+
+function buildCountryMenu(answersSoFar) {
+  const bucketId = answersSoFar[BUCKET_FIELD];
+  const buckets = buildBuckets(require('../../config/registration-data').COUNTRIES_DROPDOWN);
+  const bucket = buckets.find((b) => b.id === bucketId) || buckets[0];
+  return new StringSelectMenuBuilder()
+    .setCustomId('country')
+    .setPlaceholder('Pick your country')
+    .addOptions(bucket.countries.map(toOption));
+}
+
+function buildPkOrIndiaMenu() {
+  return new StringSelectMenuBuilder()
+    .setCustomId(PK_IN_FIELD)
+    .setPlaceholder('Pakistan or India?')
+    .addOptions([{ label: 'Pakistan', value: 'PK' }, { label: 'India', value: 'IN' }]);
+}
+
+function buildRegionMenu(answersSoFar) {
+  const wantsIndia = answersSoFar[PK_IN_FIELD] === 'IN';
+  const rows = REGIONS_DROPDOWN.filter((r) => String(r.id).startsWith('in_') === wantsIndia);
+  return new StringSelectMenuBuilder()
+    .setCustomId('region')
+    .setPlaceholder('Pick your region')
+    .addOptions(rows.map(toOption));
+}
+
+function buildOrganizationMenu(data) {
+  return new StringSelectMenuBuilder()
+    .setCustomId('organization')
+    .setPlaceholder('Organization')
+    .addOptions(data.organizations.map(toOption));
+}
+
+function buildGradeMenu(data) {
+  return new StringSelectMenuBuilder()
+    .setCustomId('grade')
+    .setPlaceholder('Grade')
+    .addOptions(data.grades.map(toOption));
+}
+
+function buildSubjectsMenu(data) {
+  return new StringSelectMenuBuilder()
+    .setCustomId('subjects')
+    .setPlaceholder('Subjects (select all that apply)')
+    .setMinValues(1)
+    .setMaxValues(Math.min(data.subjects.length, 25))
+    .addOptions(data.subjects.slice(0, 25).map(toOption));
+}
+
+function screenToSteps(screen, data) {
+  if (screen === 'PERSONAL_INFO') {
+    return {
+      steps: [
+        { fieldName: BUCKET_FIELD, promptText: 'Let’s start with where you’re based. Pick a region:', buildMenu: buildBucketMenu },
+        { fieldName: 'country', promptText: 'Now pick your country:', buildMenu: buildCountryMenu },
+      ],
+      textFields: [{ name: 'full_name', label: 'Full name', required: true }],
+      title: 'Register with Rumi',
+    };
+  }
+
+  if (screen === 'REGION_INFO') {
+    return {
+      steps: [
+        { fieldName: PK_IN_FIELD, promptText: 'Which region are you registering from?', buildMenu: buildPkOrIndiaMenu },
+        { fieldName: 'region', promptText: 'Pick your region:', buildMenu: buildRegionMenu },
+      ],
+      textFields: [],
+      title: 'Register with Rumi',
+    };
+  }
+
+  if (screen === 'PROFESSIONAL_INFO') {
+    return {
+      steps: [
+        { fieldName: 'organization', promptText: 'Pick your organization:', buildMenu: () => buildOrganizationMenu(data) },
+        { fieldName: 'grade', promptText: 'Pick the grade you teach:', buildMenu: () => buildGradeMenu(data) },
+        { fieldName: 'subjects', promptText: 'Pick the subjects you teach:', buildMenu: () => buildSubjectsMenu(data), multi: true },
+      ],
+      textFields: [{ name: 'school_name', label: 'School name (optional)', required: false }],
+      title: 'Register with Rumi',
+    };
+  }
+
+  if (screen === 'ORG_DETAILS') {
+    return {
+      steps: [],
+      textFields: [{ name: 'organization_other', label: 'Organization name', required: true }],
+      title: 'Register with Rumi',
+    };
+  }
+
+  throw new Error(`discord-views/registration: no screen mapping for "${screen}"`);
+}
+
+function mergeScreenData(screen, enumAnswers, textAnswers) {
+  if (screen === 'PERSONAL_INFO') {
+    return { full_name: textAnswers.full_name || '', country: enumAnswers.country || '' };
+  }
+  if (screen === 'REGION_INFO') {
+    return { region: enumAnswers.region || null };
+  }
+  if (screen === 'PROFESSIONAL_INFO') {
+    return {
+      organization: enumAnswers.organization || '',
+      school_name: textAnswers.school_name || '',
+      grade: enumAnswers.grade || '',
+      subjects: enumAnswers.subjects || [],
+    };
+  }
+  if (screen === 'ORG_DETAILS') {
+    return { organization_other: textAnswers.organization_other || '' };
+  }
+  return {};
+}
+
+module.exports = { screenToSteps, mergeScreenData, toOption, BUCKET_FIELD, PK_IN_FIELD };

--- a/bot/shared/routes/discord-views/settings.view.js
+++ b/bot/shared/routes/discord-views/settings.view.js
@@ -1,0 +1,74 @@
+/**
+ * Discord screen mapping for the settings Flow-equivalent — the counterpart
+ * to slack-views/settings.view.js, but shaped for discord-modal-flow.js's
+ * screenToSteps()/mergeScreenData() contract instead of Slack's one-shot
+ * screenToView()/viewToScreenData().
+ *
+ * Both fields (language, observation_framework) are enums with zero free
+ * text — a REAL simplification over Slack's own settings renderer (which
+ * always opens a modal, even though it has nothing but selects): Discord's
+ * settings screen needs no modal at all, just two sequential
+ * collectEnumAnswers() steps followed directly by exchange().
+ */
+
+const { StringSelectMenuBuilder } = require('discord.js');
+
+function toOption(row) {
+  // Discord select option label caps at 100 chars, value at 100 chars.
+  return { label: String(row.title).slice(0, 100), value: String(row.id).slice(0, 100) };
+}
+
+/**
+ * Deliberately does NOT mark the current value as a pre-selected `default`
+ * option. Discord's own client treats re-picking an already-selected option
+ * as no change at all — it never sends a fresh interaction back to Discord's
+ * servers, so a teacher who wants to KEEP their current language and simply
+ * confirms it would produce no interaction, leaving awaitMessageComponent()
+ * waiting until it times out. Showing the current value in the placeholder
+ * instead still tells the teacher what they have, without ever letting a
+ * "no-op" selection silently stall the flow.
+ */
+function buildLanguageMenu(data) {
+  const current = data.languages.find((row) => row.id === data.current_language);
+  const placeholder = current ? `Reply language (current: ${current.title})` : 'Reply language';
+  return new StringSelectMenuBuilder()
+    .setCustomId('language')
+    .setPlaceholder(placeholder.slice(0, 150))
+    .addOptions(data.languages.map(toOption));
+}
+
+function buildFrameworkMenu(data) {
+  const current = data.frameworks.find((row) => row.id === data.current_framework);
+  const placeholder = current ? `Observation framework (current: ${current.title})` : 'Observation framework';
+  return new StringSelectMenuBuilder()
+    .setCustomId('observation_framework')
+    .setPlaceholder(placeholder.slice(0, 150))
+    .addOptions(data.frameworks.map(toOption));
+}
+
+function screenToSteps(screen, data) {
+  if (screen === 'SETTINGS_MAIN') {
+    return {
+      steps: [
+        { fieldName: 'language', promptText: 'Pick your reply language:', buildMenu: () => buildLanguageMenu(data) },
+        { fieldName: 'observation_framework', promptText: 'Pick your observation framework:', buildMenu: () => buildFrameworkMenu(data) },
+      ],
+      textFields: [],
+      title: 'Settings',
+    };
+  }
+
+  throw new Error(`discord-views/settings: no screen mapping for "${screen}"`);
+}
+
+function mergeScreenData(screen, enumAnswers) {
+  if (screen === 'SETTINGS_MAIN') {
+    return {
+      language: enumAnswers.language || 'en',
+      observation_framework: enumAnswers.observation_framework || 'oecd',
+    };
+  }
+  return {};
+}
+
+module.exports = { screenToSteps, mergeScreenData, toOption };

--- a/bot/shared/routes/reading-assessment-endpoint.js
+++ b/bot/shared/routes/reading-assessment-endpoint.js
@@ -1,0 +1,223 @@
+/**
+ * Reading Assessment endpoint — a from-scratch {init, exchange} file, unlike
+ * every other endpoint in this codebase. The Meta Flow
+ * (docs/flows/reading-assessment-flow-v2.json) is purely NAVIGATE-style —
+ * client-side screen transitions with a single completion NFM carrying every
+ * field at once, no server round-trip between BASIC_INFO and OPTIONS — so
+ * flow-response.handler.js's handleReadingAssessmentFlow() still does its
+ * own Meta-specific field-name parsing (v1 vs v2 field name formats, from
+ * the nfm_reply response_json) before calling this file's startAssessment()
+ * — the actual assessment-record creation and passage generation, extracted
+ * here so Discord's onFinish hook (in discord-flow-registry.js) can trigger
+ * the exact same pipeline once its own modal-workaround screens complete,
+ * without duplicating this logic a second time.
+ *
+ * No `back` is needed — the source Flow has no back-navigation at all (confirmed
+ * against reading-assessment-flow-v2.json: OPTIONS is `"terminal": true` with no
+ * back action), so this endpoint doesn't export one either.
+ *
+ * A Slack renderer is NOT built for this endpoint yet (explicitly deferred per
+ * the integration plan) — this contract is renderer-agnostic like every other
+ * endpoint, so adding slack-views/reading-assessment.view.js + a registry entry
+ * later is a pure additive follow-up, not a redesign.
+ */
+
+const LANGUAGE_OPTIONS = [
+  { id: '0_English', title: 'English' },
+  { id: '1_Urdu', title: 'Urdu / اردو' },
+];
+
+const ASSESSMENT_MODE_OPTIONS = [
+  { id: '0_Auto', title: 'Auto-Level (finds level)' },
+  { id: '1_Manual', title: 'Manual (select level)' },
+];
+
+const READING_LEVEL_OPTIONS = [
+  { id: '0_Letters_(KG)', title: 'Letters (KG)' },
+  { id: '1_Words_(Grade_1)', title: 'Words (Grade 1)' },
+  { id: '2_Sentences_(Grade_1-2)', title: 'Sentences (1-2)' },
+  { id: '3_Paragraph_(Grade_3-5)', title: 'Paragraph (3-5)' },
+];
+
+const SCOPE_OPTIONS = [
+  { id: '0_Fluency_Only', title: 'Fluency Only' },
+  { id: '1_Fluency_+_Comprehension', title: 'Fluency + Comprehension' },
+];
+
+// levelIndex ('0'-'3', parsed off an id like "2_Sentences_(Grade_1-2)")
+// -> passage config. Extracted from flow-response.handler.js's inline
+// levelMapping object literal (previously duplicated nowhere else). STRING
+// keys deliberately, not numeric — Number('') === 0 would otherwise make an
+// empty/missing levelIndex silently match key "0" (letters) instead of
+// falling through to the "unrecognized" default below.
+const LEVEL_MAPPING = {
+  '0': { passageType: 'letters', gradeNumeric: 0 },
+  '1': { passageType: 'words', gradeNumeric: 1 },
+  '2': { passageType: 'sentences', gradeNumeric: 2 },
+  '3': { passageType: 'paragraph', gradeNumeric: 3 },
+};
+
+// passageType -> word count. Extracted from flow-response.handler.js's
+// inline wordCountMap object literal.
+const WORD_COUNT_MAP = {
+  letters: 14,
+  words: 14,
+  sentences: 40,
+  paragraph: 60,
+  story: 100,
+};
+
+/**
+ * Maps a reading-level selection to {passageType, gradeNumeric}. Auto mode
+ * always starts at the highest-complexity "story" level regardless of
+ * levelIndex — manual mode uses the teacher's own selection.
+ * @param {string|number} levelIndex - '0'-'3' (or a number), from the
+ *   Select_the_reading_level dropdown's numeric prefix
+ * @param {boolean} isAutoMode
+ * @returns {{passageType: string, gradeNumeric: number}}
+ */
+function mapLevelToPassage(levelIndex, isAutoMode) {
+  if (isAutoMode) {
+    return { passageType: 'story', gradeNumeric: 4 };
+  }
+  return LEVEL_MAPPING[String(levelIndex)] || { passageType: 'paragraph', gradeNumeric: 2 };
+}
+
+/** Maps a passage type to its target word count, matching the existing gradeMap convention. */
+function wordCountFor(passageType) {
+  return WORD_COUNT_MAP[passageType] || 50;
+}
+
+function screen1Data() {
+  return { languages: LANGUAGE_OPTIONS, assessment_modes: ASSESSMENT_MODE_OPTIONS };
+}
+
+function screen2Data() {
+  return { levels: READING_LEVEL_OPTIONS, scopes: SCOPE_OPTIONS };
+}
+
+/** INIT — BASIC_INFO screen: student name (text), language + assessment mode (enums). */
+async function handleReadingAssessmentInit() {
+  return { screen: 'BASIC_INFO', data: screen1Data() };
+}
+
+/**
+ * data_exchange — BASIC_INFO submits to OPTIONS (manual mode only; auto mode
+ * has nothing left to ask and completes immediately, matching the Meta Flow's
+ * own client-side skip — the OPTIONS screen exists purely for the
+ * level/scope dropdowns manual mode needs). exchange() itself does NOT create
+ * the assessment record or generate a passage — see this file's header
+ * comment for why that stays flow-response.handler.js's job.
+ */
+async function handleReadingAssessmentDataExchange(userId, screen, screenData) {
+  if (screen === 'BASIC_INFO') {
+    const studentName = (screenData.student_full_name || screenData.Student_Full_Name || '').trim();
+    if (!studentName) {
+      return { data: { error: { message: 'Student name is required' } } };
+    }
+    const isAutoMode = String(screenData.assessment_mode || screenData.Assessment_Mode || '').includes('Auto');
+    if (isAutoMode) {
+      return { screen: 'SUCCESS', data: { ...screenData } };
+    }
+    return { screen: 'OPTIONS', data: { ...screenData, ...screen2Data() } };
+  }
+
+  if (screen === 'OPTIONS') {
+    return { screen: 'SUCCESS', data: { ...screenData } };
+  }
+
+  return { data: { error: { message: 'Unknown screen' } } };
+}
+
+/**
+ * Creates the assessment record and kicks off passage generation/delivery —
+ * the actual side-effecting work behind the SUCCESS screen, extracted from
+ * flow-response.handler.js's handleReadingAssessmentFlow() so both the Meta
+ * (WhatsApp/Baileys) NFM path and Discord's onFinish hook can trigger the
+ * exact same pipeline from already-parsed fields, instead of each
+ * channel re-implementing (or duplicating) this logic.
+ * @param {string} userId
+ * @param {string} recipientIdentifier - phone number, or a prefixed "discord:<id>" identifier
+ * @param {object} fields
+ * @param {string} fields.studentName
+ * @param {'en'|'ur'} fields.language
+ * @param {boolean} fields.isAutoMode
+ * @param {string|number} [fields.levelIndex] - required for manual mode
+ * @param {boolean} [fields.comprehensionRequired]
+ * @returns {Promise<{assessmentId: string}>}
+ */
+async function startAssessment(userId, recipientIdentifier, fields) {
+  const { studentName, language, isAutoMode, levelIndex, comprehensionRequired } = fields;
+  const supabase = require('../config/supabase');
+  const PassageGenerationService = require('../services/reading/passage-generation.service');
+  const AutoLevelOrchestratorService = require('../services/reading/auto-level-orchestrator.service');
+  const { logToFile } = require('../utils/logger');
+
+  const { passageType, gradeNumeric } = mapLevelToPassage(levelIndex, isAutoMode);
+  const wordCount = wordCountFor(passageType);
+  const passageConfig = { type: passageType, wordCount, grade: gradeNumeric };
+
+  const { data: assessment, error: insertError } = await supabase
+    .from('reading_assessments')
+    .insert({
+      user_id: userId,
+      student_identifier: studentName,
+      grade_level: gradeNumeric,
+      language,
+      passage_type: passageType,
+      passage_word_count: wordCount,
+      passage_text: '', // filled in by generateAndSendPassage
+      comprehension_requested: Boolean(comprehensionRequired),
+      assessment_mode: isAutoMode ? 'auto' : 'manual',
+      starting_level: isAutoMode ? 'story' : passageType,
+      status: 'initiated',
+      created_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (insertError) {
+    logToFile('❌ Error creating assessment record', { error: insertError.message });
+    throw insertError;
+  }
+
+  if (isAutoMode) {
+    const autoConfig = await AutoLevelOrchestratorService.startAutoAssessment(
+      assessment.id, userId, recipientIdentifier, language, gradeNumeric, language,
+    );
+    await PassageGenerationService.generateAndSendPassage(
+      assessment.id, userId, recipientIdentifier, language,
+      { type: autoConfig.passageType, wordCount: autoConfig.wordCount, grade: autoConfig.gradeLevel },
+      language,
+    );
+  } else {
+    await PassageGenerationService.generateAndSendPassage(
+      assessment.id, userId, recipientIdentifier, language, passageConfig, language,
+    );
+  }
+
+  const { error: updateError } = await supabase
+    .from('conversations')
+    .update({ current_state: 'AWAITING_READING_AUDIO' })
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  if (updateError) {
+    logToFile('⚠️ Warning: Could not update conversation state', { error: updateError.message });
+  }
+
+  return { assessmentId: assessment.id };
+}
+
+module.exports = {
+  handleReadingAssessmentInit,
+  handleReadingAssessmentDataExchange,
+  startAssessment,
+  mapLevelToPassage,
+  wordCountFor,
+  LANGUAGE_OPTIONS,
+  ASSESSMENT_MODE_OPTIONS,
+  READING_LEVEL_OPTIONS,
+  SCOPE_OPTIONS,
+};

--- a/bot/shared/routes/registration-endpoint.js
+++ b/bot/shared/routes/registration-endpoint.js
@@ -378,8 +378,14 @@ async function storeRegData(flowToken, data) {
 
 async function getRegData(flowToken) {
   try {
-    const raw = await redisService.get(`${REDIS_PREFIX}${flowToken}`);
-    return raw ? JSON.parse(raw) : {};
+    // railway-redis.service.js's get() already JSON.parses internally and
+    // returns the deserialized value — parsing it again here always threw
+    // ("[object Object]" is not valid JSON), silently discarding every
+    // teacher's full_name/country/region on every screen after PERSONAL_INFO.
+    // Confirmed live, not a guess: registration completed but greeted
+    // "Welcome, Teacher!" instead of the name actually collected.
+    const data = await redisService.get(`${REDIS_PREFIX}${flowToken}`);
+    return data || {};
   } catch (error) {
     logToFile('⚠️ Redis get failed for registration', { flowToken, error: error.message });
     return {};

--- a/bot/shared/routes/slack-flow-registry.js
+++ b/bot/shared/routes/slack-flow-registry.js
@@ -1,0 +1,78 @@
+/**
+ * Slack Flow-equivalent registry — maps a Slack view's `callback_id` (a
+ * kind: 'registration', 'settings', ...) to the renderer built for that
+ * endpoint. Mirrors flow-endpoint.routes.js's per-endpoint require block,
+ * collapsed into a lookup instead of N Express routes — Slack posts every
+ * interaction to the SAME Request URL (unlike Meta, which gives each Flow
+ * its own registered endpoint URL), so fan-out has to happen in code
+ * regardless of how many Flow-equivalents exist.
+ *
+ * Lazily registered (first use, not at require time) to avoid a require
+ * cycle through supabase / whatsapp.service — same rationale as
+ * text-flow-definitions.js's ensureRegistered().
+ */
+
+const { buildEndpointModal } = require('../services/messaging/slack-modal-flow');
+const slackWebClient = require('../services/messaging/slack-web-client');
+
+const registry = new Map();
+
+function register(kind, renderer) {
+  registry.set(kind, renderer);
+}
+
+function get(kind) {
+  return registry.get(kind);
+}
+
+function registerAll() {
+  const registration = require('./registration-endpoint');
+  const registrationView = require('./slack-views/registration.view');
+  register('registration', buildEndpointModal({
+    kind: 'registration',
+    init: (ctx) => registration.handleRegistrationInit(ctx.userId),
+    exchange: (ctx, screen, screenData) =>
+      registration.handleRegistrationDataExchange(ctx.userId, screen, screenData, ctx.flowToken),
+    back: (ctx, screen) => registration.handleRegistrationBack(ctx.userId, screen, ctx.flowToken),
+    screenToView: registrationView.screenToView,
+    viewToScreenData: registrationView.viewToScreenData,
+    firstInputBlockId: registrationView.FIRST_INPUT_BLOCK_ID,
+    onFinish: async (response, ctx) => {
+      const { welcome_message: welcome, portal_message: portal } = response.data || {};
+      const text = [welcome, portal].filter(Boolean).join('\n\n');
+      if (text) await slackWebClient.postMessage(ctx.slackUserId, text);
+    },
+  }));
+
+  const settings = require('./settings-endpoint');
+  const settingsView = require('./slack-views/settings.view');
+  register('settings', buildEndpointModal({
+    kind: 'settings',
+    init: (ctx) => settings.handleSettingsInit(ctx.userId),
+    exchange: (ctx, screen, screenData) =>
+      settings.handleSettingsDataExchange(ctx.userId, screen, screenData, ctx.flowToken),
+    back: (ctx, screen) => settings.handleSettingsBack(ctx.userId, screen, ctx.flowToken),
+    screenToView: settingsView.screenToView,
+    viewToScreenData: settingsView.viewToScreenData,
+    firstInputBlockId: settingsView.FIRST_INPUT_BLOCK_ID,
+    onFinish: async (response, ctx) => {
+      const { confirmation_message: confirmation, details_message: details } = response.data || {};
+      const text = [confirmation, details].filter(Boolean).join('\n');
+      if (text) await slackWebClient.postMessage(ctx.slackUserId, text);
+    },
+  }));
+}
+
+let registered = false;
+function ensureRegistered() {
+  if (registered) return;
+  registerAll();
+  registered = true;
+}
+
+/** Builds a fresh flow-token in this codebase's existing "userId:kind:timestamp" convention. */
+function buildFlowToken(userId, kind) {
+  return `${userId}:${kind}:${Date.now()}`;
+}
+
+module.exports = { register, get, ensureRegistered, buildFlowToken };

--- a/bot/shared/routes/slack-flow-registry.js
+++ b/bot/shared/routes/slack-flow-registry.js
@@ -61,6 +61,79 @@ function registerAll() {
       if (text) await slackWebClient.postMessage(ctx.slackUserId, text);
     },
   }));
+
+  // attendance-setup-endpoint.js's own exchange() drives ADD_STUDENT's "Add &
+  // Continue" loop by returning {screen: 'ADD_STUDENT', data: {...}} again
+  // (non-terminal) on every add — buildEndpointModal's generic handleSubmission
+  // already pushes that as the next view with no special-casing needed here,
+  // unlike Discord's modal-workaround (which needs onScreenLoop/loopScreens
+  // because showModal() must directly ack a fresh interaction, never a
+  // response_action push). The "I'm Done" action is NOT a view_submission at
+  // all — see slack-views/attendance.view.js's own header comment — it's a
+  // block_actions click on the `attendance_finish` button living inside the
+  // ADD_STUDENT view, handled by slack-modal-interactions.handler.js calling
+  // attendance.handleDoneAction(...) directly (bypassing exchange()'s
+  // screenData._action indirection entirely, since there's no view_submission
+  // state to read it from for a plain button click).
+  const attendance = require('./attendance-setup-endpoint');
+  const attendanceView = require('./slack-views/attendance.view');
+  register('attendance', buildEndpointModal({
+    kind: 'attendance',
+    init: (ctx) => attendance.handleSetupInit(ctx.userId),
+    exchange: (ctx, screen, screenData) => attendance.handleSetupDataExchange(ctx.userId, screen, screenData),
+    screenToView: attendanceView.screenToView,
+    viewToScreenData: attendanceView.viewToScreenData,
+    firstInputBlockId: attendanceView.FIRST_INPUT_BLOCK_ID,
+    metadataCarry: attendanceView.metadataCarry,
+    onFinish: async (response, ctx) => {
+      const { success_message: success } = response.data || {};
+      if (success) await slackWebClient.postMessage(ctx.slackUserId, success);
+    },
+  }));
+
+  // exam_confirm's flowToken IS the exam session's own session.id (embedded
+  // in the triggering button's action_id — see
+  // slack-modal-interactions.handler.js's parseOpenModalAction()), never
+  // buildFlowToken()'s minted "userId:kind:timestamp" token, matching
+  // discord-flow-registry.js's identical exception and how the Meta Flow
+  // already passes flowToken: session.id at sendFlow() time.
+  //
+  // exam-confirm-endpoint.js's own exchange() does NOT drive the exam
+  // workflow forward — it only returns the selected student ids in
+  // extension_message_response, matching the Meta Flow's NFM_REPLY shape. On
+  // Meta, flow-response.handler.js's EXAM_CONFIRM_FLOW_ID branch is what
+  // actually feeds that payload into ExamCheckerOrchestrator.process(), which
+  // drives confirm -> detect questions -> grade. onFinish here replicates
+  // that exact hand-off for Slack (mirroring discord-flow-registry.js's own
+  // exam_confirm onFinish verbatim), looking the session back up by id to
+  // recover the userId/from ExamCheckerOrchestrator.process() needs (ctx only
+  // carries the session id as flowToken).
+  const examConfirm = require('./exam-confirm-endpoint');
+  const examConfirmView = require('./slack-views/exam-confirm.view');
+  register('exam_confirm', buildEndpointModal({
+    kind: 'exam_confirm',
+    init: (ctx) => examConfirm.handleExamConfirmInit(ctx.flowToken),
+    exchange: (ctx, screen, screenData) => examConfirm.handleExamConfirmDataExchange(ctx.flowToken, screen, screenData),
+    back: (ctx) => examConfirm.handleExamConfirmBack(ctx.flowToken),
+    screenToView: examConfirmView.screenToView,
+    viewToScreenData: examConfirmView.viewToScreenData,
+    firstInputBlockId: examConfirmView.FIRST_INPUT_BLOCK_ID,
+    onFinish: async (response, ctx) => {
+      const confirmedStudents = response?.data?.extension_message_response?.params?.confirmed_students || [];
+      const ExamSessionService = require('../services/exam-checker/exam-session.service');
+      // exam-checker.orchestrator.js exports { ExamCheckerOrchestrator, SESSION_STATES }
+      // (a named export, not the class/object directly) — destructure it, or
+      // ExamCheckerOrchestrator.process below is undefined.
+      const { ExamCheckerOrchestrator } = require('../services/exam-checker/exam-checker.orchestrator');
+      const session = await ExamSessionService.getById(ctx.flowToken);
+      if (!session) return;
+      await ExamCheckerOrchestrator.process(
+        { type: 'flow', flowResponse: { confirmed_students: confirmedStudents } },
+        session.user_id,
+        session.recipient_identifier,
+      );
+    },
+  }));
 }
 
 let registered = false;

--- a/bot/shared/routes/slack-interactions.routes.js
+++ b/bot/shared/routes/slack-interactions.routes.js
@@ -105,6 +105,7 @@ function makeRoutedInteractionsHandler(dispatch) {
         modalInteractions.isOpenModalAction(action?.action_id)
         || modalInteractions.isBackAction(action?.action_id)
         || modalInteractions.isAttendanceFinishAction(action?.action_id)
+        || modalInteractions.isCountryBucketAction(action?.action_id)
       ) {
         res.status(200).send(''); // ack immediately — the modal update is a separate API call
         try {
@@ -112,6 +113,8 @@ function makeRoutedInteractionsHandler(dispatch) {
             await modalInteractions.handleOpenModal(payload);
           } else if (modalInteractions.isAttendanceFinishAction(action.action_id)) {
             await modalInteractions.handleAttendanceFinish(payload);
+          } else if (modalInteractions.isCountryBucketAction(action.action_id)) {
+            await modalInteractions.handleCountryBucketChange(payload);
           } else {
             await modalInteractions.handleBackButton(payload);
           }

--- a/bot/shared/routes/slack-interactions.routes.js
+++ b/bot/shared/routes/slack-interactions.routes.js
@@ -20,6 +20,7 @@ const router = express.Router();
 const SlackSignatureService = require('../services/slack-signature.service');
 const { logToFile } = require('../utils/logger');
 const { makeEventsHandler, makeInteractionsHandler } = require('../services/messaging/inbound/slack-events.adapter');
+const modalInteractions = require('./slack-modal-interactions.handler');
 
 /**
  * express.raw() (mounted by whatsapp-bot.js ahead of this router) leaves
@@ -52,9 +53,70 @@ function verifyAndParse(contentType) {
   };
 }
 
+/**
+ * Dispatches an already-verified Interactivity payload to the right place:
+ *   - view_submission            -> the modal renderer, response body carries
+ *                                    the response_action Slack itself reads
+ *   - block_actions "open_modal:<kind>" / "<kind>_back" -> the modal
+ *     renderer's open/back handling (fire-and-forget from Slack's POV — it
+ *     already got its 200 ack; the modal update happens via a separate
+ *     views.open/views.update API call)
+ *   - any other block_actions     -> ordinary chat button/select click,
+ *                                    the existing inbound adapter's job
+ */
+function makeRoutedInteractionsHandler(dispatch) {
+  const chatHandler = makeInteractionsHandler(dispatch);
+
+  return async function routeSlackInteraction(req, res) {
+    let payload;
+    try {
+      payload = JSON.parse(req.body.payload);
+    } catch (error) {
+      res.status(400).send('Bad payload');
+      return;
+    }
+
+    if (payload.type === 'view_submission') {
+      try {
+        const result = await modalInteractions.handleViewSubmission(payload);
+        if (result) {
+          res.status(200).json(result);
+        } else {
+          res.status(200).send('');
+        }
+      } catch (error) {
+        logToFile('❌ Slack interactions: view_submission dispatch failed', { error: error.message });
+        res.status(200).send('');
+      }
+      return;
+    }
+
+    if (payload.type === 'block_actions') {
+      const action = payload?.actions?.[0];
+      if (modalInteractions.isOpenModalAction(action?.action_id) || modalInteractions.isBackAction(action?.action_id)) {
+        res.status(200).send(''); // ack immediately — the modal update is a separate API call
+        try {
+          if (modalInteractions.isOpenModalAction(action.action_id)) {
+            await modalInteractions.handleOpenModal(payload);
+          } else {
+            await modalInteractions.handleBackButton(payload);
+          }
+        } catch (error) {
+          logToFile('❌ Slack interactions: modal block_actions dispatch failed', { error: error.message });
+        }
+        return;
+      }
+    }
+
+    // Not a modal-related payload — ordinary chat interactivity.
+    // req.body still holds the raw form-encoded body chatHandler expects.
+    await chatHandler(req, res);
+  };
+}
+
 function mount(dispatch) {
   router.post('/events', verifyAndParse('json'), makeEventsHandler(dispatch));
-  router.post('/interactions', verifyAndParse('form'), makeInteractionsHandler(dispatch));
+  router.post('/interactions', verifyAndParse('form'), makeRoutedInteractionsHandler(dispatch));
   return router;
 }
 

--- a/bot/shared/routes/slack-interactions.routes.js
+++ b/bot/shared/routes/slack-interactions.routes.js
@@ -101,11 +101,17 @@ function makeRoutedInteractionsHandler(dispatch) {
 
     if (payload.type === 'block_actions') {
       const action = payload?.actions?.[0];
-      if (modalInteractions.isOpenModalAction(action?.action_id) || modalInteractions.isBackAction(action?.action_id)) {
+      if (
+        modalInteractions.isOpenModalAction(action?.action_id)
+        || modalInteractions.isBackAction(action?.action_id)
+        || modalInteractions.isAttendanceFinishAction(action?.action_id)
+      ) {
         res.status(200).send(''); // ack immediately — the modal update is a separate API call
         try {
           if (modalInteractions.isOpenModalAction(action.action_id)) {
             await modalInteractions.handleOpenModal(payload);
+          } else if (modalInteractions.isAttendanceFinishAction(action.action_id)) {
+            await modalInteractions.handleAttendanceFinish(payload);
           } else {
             await modalInteractions.handleBackButton(payload);
           }

--- a/bot/shared/routes/slack-interactions.routes.js
+++ b/bot/shared/routes/slack-interactions.routes.js
@@ -1,0 +1,61 @@
+/**
+ * Slack routes — mounted at /api/slack in whatsapp-bot.js.
+ *
+ *   POST /api/slack/events        - Events API (plain messages)
+ *   POST /api/slack/interactions  - Interactivity (button clicks, select
+ *                                   menus, AND modal view_submission)
+ *
+ * Every request here is HMAC-signature-verified (slack-signature.service.js)
+ * BEFORE any dispatch — mirrors flow-endpoint.routes.js's own shape (route
+ * layer owns the platform-specific security/envelope concern; the actual
+ * business logic in the inbound adapter / endpoint functions never sees it).
+ *
+ * whatsapp-bot.js mounts a raw-body-capturing middleware ahead of this
+ * router (see its own header comment) so req.rawBody holds the exact bytes
+ * Slack signed — required for signature verification to succeed at all.
+ */
+
+const express = require('express');
+const router = express.Router();
+const SlackSignatureService = require('../services/slack-signature.service');
+const { logToFile } = require('../utils/logger');
+const { makeEventsHandler, makeInteractionsHandler } = require('../services/messaging/inbound/slack-events.adapter');
+
+/**
+ * express.raw() (mounted by whatsapp-bot.js ahead of this router) leaves
+ * req.body as a Buffer. Every handler below needs it parsed — as JSON for
+ * Events API, as an x-www-form-urlencoded `payload` field for
+ * Interactivity — so parse it once here, after signature verification.
+ */
+function verifyAndParse(contentType) {
+  return (req, res, next) => {
+    if (!SlackSignatureService.verify(req)) {
+      logToFile('⚠️ Slack signature verification failed', { path: req.path });
+      res.status(401).send('Invalid signature');
+      return;
+    }
+
+    const raw = req.rawBody ? req.rawBody.toString('utf8') : '';
+    try {
+      if (contentType === 'json') {
+        req.body = raw ? JSON.parse(raw) : {};
+      } else {
+        // application/x-www-form-urlencoded, Slack's Interactivity content type.
+        const params = new URLSearchParams(raw);
+        req.body = Object.fromEntries(params.entries());
+      }
+    } catch (error) {
+      res.status(400).send('Bad request body');
+      return;
+    }
+    next();
+  };
+}
+
+function mount(dispatch) {
+  router.post('/events', verifyAndParse('json'), makeEventsHandler(dispatch));
+  router.post('/interactions', verifyAndParse('form'), makeInteractionsHandler(dispatch));
+  return router;
+}
+
+module.exports = mount;

--- a/bot/shared/routes/slack-interactions.routes.js
+++ b/bot/shared/routes/slack-interactions.routes.js
@@ -4,6 +4,7 @@
  *   POST /api/slack/events        - Events API (plain messages)
  *   POST /api/slack/interactions  - Interactivity (button clicks, select
  *                                   menus, AND modal view_submission)
+ *   POST /api/slack/commands      - Slash Commands (/quiz, /settings, ...)
  *
  * Every request here is HMAC-signature-verified (slack-signature.service.js)
  * BEFORE any dispatch — mirrors flow-endpoint.routes.js's own shape (route
@@ -13,13 +14,20 @@
  * whatsapp-bot.js mounts a raw-body-capturing middleware ahead of this
  * router (see its own header comment) so req.rawBody holds the exact bytes
  * Slack signed — required for signature verification to succeed at all.
+ *
+ * /commands is a SEPARATE route from /interactions even though both carry
+ * form-encoded bodies: Slack's Slash Command payload puts command/text/
+ * user_id at the TOP LEVEL of the body, whereas /interactions' block_actions/
+ * view_submission payloads are JSON-encoded inside a single `payload` field.
+ * Each Slash Command is registered in the Slack app config with its own
+ * Request URL — point every one of them at this same /commands URL.
  */
 
 const express = require('express');
 const router = express.Router();
 const SlackSignatureService = require('../services/slack-signature.service');
 const { logToFile } = require('../utils/logger');
-const { makeEventsHandler, makeInteractionsHandler } = require('../services/messaging/inbound/slack-events.adapter');
+const { makeEventsHandler, makeInteractionsHandler, makeSlashCommandHandler } = require('../services/messaging/inbound/slack-events.adapter');
 const modalInteractions = require('./slack-modal-interactions.handler');
 
 /**
@@ -117,6 +125,7 @@ function makeRoutedInteractionsHandler(dispatch) {
 function mount(dispatch) {
   router.post('/events', verifyAndParse('json'), makeEventsHandler(dispatch));
   router.post('/interactions', verifyAndParse('form'), makeRoutedInteractionsHandler(dispatch));
+  router.post('/commands', verifyAndParse('form'), makeSlashCommandHandler(dispatch));
   return router;
 }
 

--- a/bot/shared/routes/slack-modal-interactions.handler.js
+++ b/bot/shared/routes/slack-modal-interactions.handler.js
@@ -18,6 +18,15 @@
  *     button click, NOT a view_submission — see slack-views/attendance.view.js's
  *     own header comment for why this can't just be the modal's native
  *     submit). Calls attendance-setup-endpoint.js's handleDoneAction directly.
+ *   - block_actions with a `country_bucket_select` action_id — registration's
+ *     PERSONAL_INFO screen's region-bucket picker (see
+ *     slack-views/registration.view.js's own header comment: Slack's
+ *     static_select caps at 100 options, so the 164-country field is split
+ *     into a region-bucket picker + a country picker filtered to that
+ *     bucket). Picking a region live-updates the SAME open modal via
+ *     views.update, re-rendering the country field's options — a real bug
+ *     fix (registration on Slack failed 100% of the time before this), not
+ *     a pre-emptive design choice.
  */
 
 const { logToFile } = require('../utils/logger');
@@ -25,6 +34,8 @@ const flowRegistry = require('./slack-flow-registry');
 const slackWebClient = require('./../services/messaging/slack-web-client');
 const { decodeMetadata } = require('../services/messaging/slack-modal-flow');
 const { getOrCreateUserByChannel } = require('../database/bot-helpers');
+const registrationView = require('./slack-views/registration.view');
+const { COUNTRIES_DROPDOWN } = require('../config/registration-data');
 
 const OPEN_MODAL_PREFIX = 'open_modal:';
 const BACK_ACTION_SUFFIX = '_back';
@@ -40,6 +51,10 @@ function isBackAction(actionId) {
 
 function isAttendanceFinishAction(actionId) {
   return actionId === ATTENDANCE_FINISH_ACTION;
+}
+
+function isCountryBucketAction(actionId) {
+  return actionId === registrationView.COUNTRY_BUCKET_ACTION_ID;
 }
 
 function kindFromBackAction(actionId) {
@@ -165,6 +180,43 @@ async function handleAttendanceFinish(payload) {
 }
 
 /**
+ * A `block_actions` payload whose action is registration's PERSONAL_INFO
+ * region-bucket picker (`country_bucket_select`). Live-updates the SAME open
+ * modal so the country field's options refresh to the newly-picked region —
+ * Slack's standard "dependent select menus" pattern. The countries list
+ * itself is a static, region-agnostic dropdown (registration-endpoint.js
+ * always returns COUNTRIES_DROPDOWN verbatim, never filtered per-user), so
+ * reading it directly here instead of re-calling init() is safe and matches
+ * what screenToView() would receive either way. The already-typed full_name
+ * value is preserved via payload.view.state.values, since Slack's
+ * views.update fully replaces the view — without this, picking a region
+ * would silently wipe out anything the teacher had already typed.
+ * Returns true if this payload was handled here.
+ */
+async function handleCountryBucketChange(payload) {
+  const action = payload?.actions?.[0];
+  if (!action || !isCountryBucketAction(action.action_id)) return false;
+
+  const { kind, screen, flowToken } = decodeMetadata(payload.view?.private_metadata);
+  if (kind !== 'registration' || screen !== 'PERSONAL_INFO') return true;
+
+  const ctx = buildCtx(payload.user?.id, flowToken);
+  const selectedCountryBucket = action.selected_option?.value || null;
+  const fullNameValue = payload.view?.state?.values?.full_name_block?.full_name?.value || '';
+
+  try {
+    const metadata = payload.view.private_metadata;
+    const view = registrationView.screenToView('PERSONAL_INFO', { countries: COUNTRIES_DROPDOWN }, {
+      ...ctx, metadata, selectedCountryBucket, fullNameValue,
+    });
+    await slackWebClient.updateView(payload.view.id, view);
+  } catch (error) {
+    logToFile('❌ Slack modal: country bucket change handling failed', { error: error.message, stack: error.stack });
+  }
+  return true;
+}
+
+/**
  * A `block_actions` payload whose action is a modal's own Back button
  * (`<kind>_back`). Returns true if this payload was handled here.
  */
@@ -220,10 +272,12 @@ module.exports = {
   handleOpenModal,
   handleBackButton,
   handleAttendanceFinish,
+  handleCountryBucketChange,
   handleViewSubmission,
   isOpenModalAction,
   isBackAction,
   isAttendanceFinishAction,
+  isCountryBucketAction,
   parseOpenModalAction,
   OPEN_MODAL_PREFIX,
   ATTENDANCE_FINISH_ACTION,

--- a/bot/shared/routes/slack-modal-interactions.handler.js
+++ b/bot/shared/routes/slack-modal-interactions.handler.js
@@ -3,7 +3,7 @@
  * flow-endpoint.routes.js's registration/settings blocks, but for Slack's
  * Interactivity payload shapes instead of Meta's encrypted Flow envelope.
  *
- * Handles the three modal-specific interaction shapes Slack sends, none of
+ * Handles the modal-specific interaction shapes Slack sends, none of
  * which are ordinary chat button/select clicks (those stay
  * slack-events.adapter.js's job):
  *   - block_actions with an `open_modal:<kind>` action_id — opens the FIRST
@@ -13,6 +13,11 @@
  *   - block_actions with a `<kind>_back` action_id — the modal's own Back
  *     button (not Slack's native stack pop — see slack-modal-flow.js's file
  *     header for why registration needs real server-side back navigation).
+ *   - block_actions with an `attendance_finish` action_id — the "I'm Done"
+ *     button living inside attendance's ADD_STUDENT modal view (a plain
+ *     button click, NOT a view_submission — see slack-views/attendance.view.js's
+ *     own header comment for why this can't just be the modal's native
+ *     submit). Calls attendance-setup-endpoint.js's handleDoneAction directly.
  */
 
 const { logToFile } = require('../utils/logger');
@@ -23,6 +28,7 @@ const { getOrCreateUserByChannel } = require('../database/bot-helpers');
 
 const OPEN_MODAL_PREFIX = 'open_modal:';
 const BACK_ACTION_SUFFIX = '_back';
+const ATTENDANCE_FINISH_ACTION = 'attendance_finish';
 
 function isOpenModalAction(actionId) {
   return typeof actionId === 'string' && actionId.startsWith(OPEN_MODAL_PREFIX);
@@ -32,8 +38,31 @@ function isBackAction(actionId) {
   return typeof actionId === 'string' && actionId.endsWith(BACK_ACTION_SUFFIX);
 }
 
+function isAttendanceFinishAction(actionId) {
+  return actionId === ATTENDANCE_FINISH_ACTION;
+}
+
 function kindFromBackAction(actionId) {
   return actionId.slice(0, -BACK_ACTION_SUFFIX.length);
+}
+
+/**
+ * Splits an `open_modal:<kind>` action_id into its parts. The optional
+ * sessionId segment ("open_modal:exam_confirm:<sessionId>") exists ONLY for
+ * exam_confirm, whose flowToken must be the exam session's own session.id
+ * (embedded here by whoever sent this button — see exam-checker.handler.js's
+ * trySendExamConfirmModalTrigger) rather than a freshly-minted
+ * "userId:kind:timestamp" token. Splitting on the FIRST colon after the
+ * prefix (not slicing the whole remainder as the kind) is what lets this
+ * 3rd segment coexist with every other kind's plain "open_modal:<kind>"
+ * action_id, which has no embedded session id at all — mirrors
+ * discord-modal-interactions.handler.js's parseStartFlowAction() exactly.
+ */
+function parseOpenModalAction(actionId) {
+  const rest = actionId.slice(OPEN_MODAL_PREFIX.length);
+  const idx = rest.indexOf(':');
+  if (idx === -1) return { kind: rest, sessionId: null };
+  return { kind: rest.slice(0, idx), sessionId: rest.slice(idx + 1) };
 }
 
 function buildCtx(slackUserId, flowToken) {
@@ -42,14 +71,15 @@ function buildCtx(slackUserId, flowToken) {
 
 /**
  * A `block_actions` payload whose first action opens a modal
- * (`open_modal:<kind>`). Returns true if this payload was handled here.
+ * (`open_modal:<kind>` or `open_modal:exam_confirm:<sessionId>`). Returns
+ * true if this payload was handled here.
  */
 async function handleOpenModal(payload) {
   const action = payload?.actions?.[0];
   if (!action || !isOpenModalAction(action.action_id)) return false;
 
   flowRegistry.ensureRegistered();
-  const kind = action.action_id.slice(OPEN_MODAL_PREFIX.length);
+  const { kind, sessionId } = parseOpenModalAction(action.action_id);
   const renderer = flowRegistry.get(kind);
   if (!renderer) {
     logToFile('⚠️ Slack modal: no renderer registered for kind', { kind });
@@ -57,20 +87,79 @@ async function handleOpenModal(payload) {
   }
 
   const slackUserId = payload.user?.id;
-  // registration/settings endpoints key everything off the DB user's UUID
-  // (flow_token = "userId:kind:timestamp", parsed as flow_token.split(':')[0]
-  // by the same convention flow-endpoint.routes.js uses for Meta) — never
-  // the Slack user id itself. Resolves/creates the multi-homed user row the
-  // same way whatsapp-bot.js's ordinary dispatch already does for messages.
-  const user = await getOrCreateUserByChannel('slack', slackUserId);
-  const flowToken = flowRegistry.buildFlowToken(user.id, kind);
-  const ctx = buildCtx(slackUserId, flowToken);
+
+  let ctx;
+  if (sessionId) {
+    // exam_confirm: flowToken IS the exam session's own session.id, unchanged
+    // — never buildFlowToken()'s minted token. userId isn't resolvable from
+    // slackUserId alone for this kind (and buildCtx's flowToken.split(':')[0]
+    // convention doesn't apply to a bare session id either) — the renderer's
+    // endpoint calls key everything off flowToken directly; onFinish looks
+    // the session's own user_id back up. Mirrors
+    // discord-modal-interactions.handler.js's tryHandleStartFlow() exactly.
+    ctx = { userId: null, slackUserId, flowToken: sessionId };
+  } else {
+    // registration/settings/attendance endpoints key everything off the DB
+    // user's UUID (flow_token = "userId:kind:timestamp", parsed as
+    // flow_token.split(':')[0] by the same convention flow-endpoint.routes.js
+    // uses for Meta) — never the Slack user id itself. Resolves/creates the
+    // multi-homed user row the same way whatsapp-bot.js's ordinary dispatch
+    // already does for messages.
+    const user = await getOrCreateUserByChannel('slack', slackUserId);
+    const flowToken = flowRegistry.buildFlowToken(user.id, kind);
+    ctx = buildCtx(slackUserId, flowToken);
+  }
 
   try {
     const view = await renderer.buildInitialView(ctx);
     await slackWebClient.openView(payload.trigger_id, view);
   } catch (error) {
     logToFile('❌ Slack modal: failed to open initial view', { kind, error: error.message, stack: error.stack });
+  }
+  return true;
+}
+
+/**
+ * A `block_actions` payload whose action is attendance's "I'm Done" button
+ * (`attendance_finish`), living inside the ADD_STUDENT modal view rather than
+ * being that modal's native Submit — see slack-views/attendance.view.js's
+ * header comment. {list_id, class_display} are recovered from
+ * private_metadata's `carry` field (see slack-modal-flow.js's encodeMetadata
+ * `carry` param and slack-flow-registry.js's attendance registration, which
+ * supplies `metadataCarry` for exactly this) rather than from state.values —
+ * Slack's block_actions payload for an interaction inside an open modal does
+ * include payload.view.private_metadata (unchanged from what the view was
+ * opened/pushed with), which is what makes this recoverable at all.
+ * Calls attendance-setup-endpoint.js's handleDoneAction directly — bypassing
+ * exchange()'s screenData._action indirection entirely, since there is no
+ * view_submission state to read an _action field from for a plain button
+ * click. Returns true if this payload was handled here.
+ */
+async function handleAttendanceFinish(payload) {
+  const action = payload?.actions?.[0];
+  if (!action || !isAttendanceFinishAction(action.action_id)) return false;
+
+  flowRegistry.ensureRegistered();
+  const { flowToken, carry } = decodeMetadata(payload.view?.private_metadata);
+  const ctx = buildCtx(payload.user?.id, flowToken);
+
+  try {
+    const attendance = require('./attendance-setup-endpoint');
+    const response = await attendance.handleDoneAction(carry?.list_id, carry?.class_display);
+    if (response?.data?.success_message) {
+      await slackWebClient.postMessage(ctx.slackUserId, response.data.success_message);
+    } else if (response?.data?.error && response.screen) {
+      // Still needs at least one student — reopen ADD_STUDENT with the error,
+      // via the SAME screenToView() the ordinary submission path uses (its
+      // {screen, data} input shape is exactly what handleDoneAction's own
+      // error response already provides).
+      const attendanceView = require('./slack-views/attendance.view');
+      const metadata = JSON.stringify({ kind: 'attendance', screen: response.screen, flowToken, carry });
+      const view = attendanceView.screenToView(response.screen, response.data, { ...ctx, metadata });
+      await slackWebClient.updateView(payload.view.id, view);
+    }
+  } catch (error) {
+    logToFile('❌ Slack modal: attendance "I\'m Done" handling failed', { error: error.message, stack: error.stack });
   }
   return true;
 }
@@ -109,7 +198,7 @@ async function handleBackButton(payload) {
  */
 async function handleViewSubmission(payload) {
   flowRegistry.ensureRegistered();
-  const { kind, screen, flowToken } = decodeMetadata(payload.view?.private_metadata);
+  const { kind, screen, flowToken, carry } = decodeMetadata(payload.view?.private_metadata);
   const renderer = flowRegistry.get(kind);
   if (!renderer) {
     logToFile('⚠️ Slack modal: no renderer registered for view_submission kind', { kind });
@@ -120,7 +209,7 @@ async function handleViewSubmission(payload) {
   const stateValues = payload.view?.state?.values || {};
 
   try {
-    return await renderer.handleSubmission(ctx, screen, stateValues);
+    return await renderer.handleSubmission(ctx, screen, stateValues, carry);
   } catch (error) {
     logToFile('❌ Slack modal: view_submission handling failed', { kind, screen, error: error.message, stack: error.stack });
     return { response_action: 'errors', errors: {} };
@@ -130,8 +219,12 @@ async function handleViewSubmission(payload) {
 module.exports = {
   handleOpenModal,
   handleBackButton,
+  handleAttendanceFinish,
   handleViewSubmission,
   isOpenModalAction,
   isBackAction,
+  isAttendanceFinishAction,
+  parseOpenModalAction,
   OPEN_MODAL_PREFIX,
+  ATTENDANCE_FINISH_ACTION,
 };

--- a/bot/shared/routes/slack-modal-interactions.handler.js
+++ b/bot/shared/routes/slack-modal-interactions.handler.js
@@ -1,0 +1,137 @@
+/**
+ * Slack modal interaction handling — the counterpart to
+ * flow-endpoint.routes.js's registration/settings blocks, but for Slack's
+ * Interactivity payload shapes instead of Meta's encrypted Flow envelope.
+ *
+ * Handles the three modal-specific interaction shapes Slack sends, none of
+ * which are ordinary chat button/select clicks (those stay
+ * slack-events.adapter.js's job):
+ *   - block_actions with an `open_modal:<kind>` action_id — opens the FIRST
+ *     modal view for that Flow-equivalent kind.
+ *   - view_submission — the modal's Next/Save/Finish button; advances or
+ *     completes the flow.
+ *   - block_actions with a `<kind>_back` action_id — the modal's own Back
+ *     button (not Slack's native stack pop — see slack-modal-flow.js's file
+ *     header for why registration needs real server-side back navigation).
+ */
+
+const { logToFile } = require('../utils/logger');
+const flowRegistry = require('./slack-flow-registry');
+const slackWebClient = require('./../services/messaging/slack-web-client');
+const { decodeMetadata } = require('../services/messaging/slack-modal-flow');
+const { getOrCreateUserByChannel } = require('../database/bot-helpers');
+
+const OPEN_MODAL_PREFIX = 'open_modal:';
+const BACK_ACTION_SUFFIX = '_back';
+
+function isOpenModalAction(actionId) {
+  return typeof actionId === 'string' && actionId.startsWith(OPEN_MODAL_PREFIX);
+}
+
+function isBackAction(actionId) {
+  return typeof actionId === 'string' && actionId.endsWith(BACK_ACTION_SUFFIX);
+}
+
+function kindFromBackAction(actionId) {
+  return actionId.slice(0, -BACK_ACTION_SUFFIX.length);
+}
+
+function buildCtx(slackUserId, flowToken) {
+  return { userId: flowToken.split(':')[0] || null, slackUserId, flowToken };
+}
+
+/**
+ * A `block_actions` payload whose first action opens a modal
+ * (`open_modal:<kind>`). Returns true if this payload was handled here.
+ */
+async function handleOpenModal(payload) {
+  const action = payload?.actions?.[0];
+  if (!action || !isOpenModalAction(action.action_id)) return false;
+
+  flowRegistry.ensureRegistered();
+  const kind = action.action_id.slice(OPEN_MODAL_PREFIX.length);
+  const renderer = flowRegistry.get(kind);
+  if (!renderer) {
+    logToFile('⚠️ Slack modal: no renderer registered for kind', { kind });
+    return true;
+  }
+
+  const slackUserId = payload.user?.id;
+  // registration/settings endpoints key everything off the DB user's UUID
+  // (flow_token = "userId:kind:timestamp", parsed as flow_token.split(':')[0]
+  // by the same convention flow-endpoint.routes.js uses for Meta) — never
+  // the Slack user id itself. Resolves/creates the multi-homed user row the
+  // same way whatsapp-bot.js's ordinary dispatch already does for messages.
+  const user = await getOrCreateUserByChannel('slack', slackUserId);
+  const flowToken = flowRegistry.buildFlowToken(user.id, kind);
+  const ctx = buildCtx(slackUserId, flowToken);
+
+  try {
+    const view = await renderer.buildInitialView(ctx);
+    await slackWebClient.openView(payload.trigger_id, view);
+  } catch (error) {
+    logToFile('❌ Slack modal: failed to open initial view', { kind, error: error.message, stack: error.stack });
+  }
+  return true;
+}
+
+/**
+ * A `block_actions` payload whose action is a modal's own Back button
+ * (`<kind>_back`). Returns true if this payload was handled here.
+ */
+async function handleBackButton(payload) {
+  const action = payload?.actions?.[0];
+  if (!action || !isBackAction(action.action_id)) return false;
+
+  flowRegistry.ensureRegistered();
+  const kind = kindFromBackAction(action.action_id);
+  const renderer = flowRegistry.get(kind);
+  if (!renderer) return true;
+
+  const { screen, flowToken } = decodeMetadata(payload.view?.private_metadata);
+  const ctx = buildCtx(payload.user?.id, flowToken);
+
+  try {
+    const previousView = await renderer.handleBack(ctx, screen);
+    if (previousView) {
+      await slackWebClient.updateView(payload.view.id, previousView);
+    }
+  } catch (error) {
+    logToFile('❌ Slack modal: BACK handling failed', { kind, screen, error: error.message, stack: error.stack });
+  }
+  return true;
+}
+
+/**
+ * A `view_submission` payload — the modal's Next/Save/Finish button.
+ * Returns the response Slack expects back in the HTTP response body
+ * (a `response_action`), or null if this kind has no registered renderer.
+ */
+async function handleViewSubmission(payload) {
+  flowRegistry.ensureRegistered();
+  const { kind, screen, flowToken } = decodeMetadata(payload.view?.private_metadata);
+  const renderer = flowRegistry.get(kind);
+  if (!renderer) {
+    logToFile('⚠️ Slack modal: no renderer registered for view_submission kind', { kind });
+    return null;
+  }
+
+  const ctx = buildCtx(payload.user?.id, flowToken);
+  const stateValues = payload.view?.state?.values || {};
+
+  try {
+    return await renderer.handleSubmission(ctx, screen, stateValues);
+  } catch (error) {
+    logToFile('❌ Slack modal: view_submission handling failed', { kind, screen, error: error.message, stack: error.stack });
+    return { response_action: 'errors', errors: {} };
+  }
+}
+
+module.exports = {
+  handleOpenModal,
+  handleBackButton,
+  handleViewSubmission,
+  isOpenModalAction,
+  isBackAction,
+  OPEN_MODAL_PREFIX,
+};

--- a/bot/shared/routes/slack-views/attendance.view.js
+++ b/bot/shared/routes/slack-views/attendance.view.js
@@ -1,0 +1,153 @@
+/**
+ * Block Kit screen mapping for the attendance/class-setup Flow-equivalent —
+ * the counterpart to discord-views/attendance.view.js, shaped for Slack's
+ * slack-modal-flow.js screenToView()/viewToScreenData() contract.
+ *
+ * CLASS_INFO: one enum field (attendance_frequency: once/twice — a static
+ * 2-option list, confirmed against docs/flows/attendance-setup-flow.json)
+ * plus two text fields (class_name, section).
+ *
+ * ADD_STUDENT: both fields (first_name, last_name) are free text, zero enum.
+ * The Add/Done duality: the modal's native Submit button stays "Add & Continue"
+ * (an ordinary view_submission, handled by buildEndpointModal's own
+ * handleSubmission -> attendance-setup-endpoint.js's handleAddStudentAction).
+ * A SEPARATE "I'm Done" button lives in this same view as a plain `actions`
+ * block (a block_actions interaction, NOT a modal submission — Slack modals
+ * may contain `actions` blocks alongside `input` blocks; the registration
+ * view's own back_block already proves this coexists fine). That button's
+ * action_id is `attendance_finish` — recognized and handled by
+ * slack-modal-interactions.handler.js, which calls handleDoneAction directly
+ * with screenData._action = 'done', matching what
+ * attendance-setup-endpoint.js's handleSetupDataExchange already expects at
+ * `_action`/`_list_id`/`_class_display` (the same hidden-field round-trip
+ * convention docs/flows/attendance-setup-flow.json:188-190 uses for Meta).
+ *
+ * {list_id, class_display} are never collected from the teacher — they're
+ * threaded through private_metadata's `carry` field (see this file's own
+ * metadataCarry() and slack-modal-flow.js's encodeMetadata `carry` param),
+ * exactly like discord-views/attendance.view.js's mergeScreenData
+ * carriedData param serves the same role for Discord's Redis-backed state.
+ */
+
+function toOption(row) {
+  return { text: { type: 'plain_text', text: String(row.title).slice(0, 75) }, value: String(row.id) };
+}
+
+const FREQUENCY_OPTIONS = [
+  { id: 'once', title: 'Once per day' },
+  { id: 'twice', title: 'Twice (morning & afternoon)' },
+];
+
+function screenToView(screen, data, ctx) {
+  const metadata = ctx.metadata;
+
+  if (screen === 'CLASS_INFO') {
+    return {
+      type: 'modal',
+      callback_id: 'attendance',
+      private_metadata: metadata,
+      title: { type: 'plain_text', text: 'Set up your class' },
+      submit: { type: 'plain_text', text: 'Next: Add Students' },
+      blocks: [
+        {
+          type: 'input', block_id: 'class_name_block',
+          label: { type: 'plain_text', text: 'Class / grade name' },
+          element: { type: 'plain_text_input', action_id: 'class_name' },
+        },
+        {
+          type: 'input', block_id: 'section_block', optional: true,
+          label: { type: 'plain_text', text: 'Section (optional)' },
+          element: { type: 'plain_text_input', action_id: 'section' },
+        },
+        {
+          type: 'input', block_id: 'attendance_frequency_block',
+          label: { type: 'plain_text', text: 'How often do you take attendance?' },
+          element: { type: 'static_select', action_id: 'attendance_frequency', options: FREQUENCY_OPTIONS.map(toOption) },
+        },
+      ],
+    };
+  }
+
+  if (screen === 'ADD_STUDENT') {
+    return {
+      type: 'modal',
+      callback_id: 'attendance',
+      private_metadata: metadata,
+      title: { type: 'plain_text', text: (data?.heading || 'Add a student').slice(0, 24) },
+      submit: { type: 'plain_text', text: 'Add & Continue' },
+      blocks: [
+        ...(data?.class_info ? [{ type: 'section', block_id: 'class_info_block', text: { type: 'plain_text', text: data.class_info } }] : []),
+        ...(data?.students_list ? [{ type: 'section', block_id: 'students_list_block', text: { type: 'plain_text', text: data.students_list } }] : []),
+        {
+          type: 'input', block_id: 'first_name_block',
+          label: { type: 'plain_text', text: 'Student first name' },
+          element: { type: 'plain_text_input', action_id: 'first_name' },
+        },
+        {
+          type: 'input', block_id: 'last_name_block', optional: true,
+          label: { type: 'plain_text', text: 'Student last name (optional)' },
+          element: { type: 'plain_text_input', action_id: 'last_name' },
+        },
+        {
+          type: 'actions', block_id: 'attendance_finish_block',
+          elements: [{ type: 'button', action_id: 'attendance_finish', style: 'primary', text: { type: 'plain_text', text: "I'm Done" } }],
+        },
+      ],
+    };
+  }
+
+  throw new Error(`slack-views/attendance: no view mapping for screen "${screen}"`);
+}
+
+/**
+ * @param {string} screen
+ * @param {object} stateValues
+ * @param {object} [carried] - {list_id, class_display} recovered from
+ *   private_metadata's `carry` field (see slack-modal-flow.js's
+ *   metadataCarry config) — ADD_STUDENT's own screenData needs these under
+ *   `_list_id`/`_class_display` exactly like the Meta Flow's hidden-field
+ *   round-trip (docs/flows/attendance-setup-flow.json:188-190), since
+ *   attendance-setup-endpoint.js's handleSetupDataExchange reads them from
+ *   screenData directly, never from anywhere else.
+ */
+function viewToScreenData(screen, stateValues, carried = {}) {
+  const get = (blockId, actionId) => stateValues?.[blockId]?.[actionId];
+
+  if (screen === 'CLASS_INFO') {
+    return {
+      class_name: get('class_name_block', 'class_name')?.value || '',
+      section: get('section_block', 'section')?.value || '',
+      attendance_frequency: get('attendance_frequency_block', 'attendance_frequency')?.selected_option?.value || '',
+    };
+  }
+  if (screen === 'ADD_STUDENT') {
+    return {
+      first_name: get('first_name_block', 'first_name')?.value || '',
+      last_name: get('last_name_block', 'last_name')?.value || '',
+      _action: 'add',
+      _list_id: carried?.list_id,
+      _class_display: carried?.class_display,
+    };
+  }
+  return {};
+}
+
+/**
+ * Picks {list_id, class_display} out of ADD_STUDENT's response `data` to
+ * round-trip via private_metadata's `carry` field — see
+ * slack-modal-flow.js's buildEndpointModal `metadataCarry` config param and
+ * viewToScreenData's own doc comment above for why this is needed at all
+ * (the `attendance_finish` block_actions button has no view_submission
+ * state.values to read them from).
+ */
+function metadataCarry(screen, data) {
+  if (screen !== 'ADD_STUDENT') return undefined;
+  return { list_id: data?.list_id, class_display: data?.class_display };
+}
+
+const FIRST_INPUT_BLOCK_ID = {
+  CLASS_INFO: 'class_name_block',
+  ADD_STUDENT: 'first_name_block',
+};
+
+module.exports = { screenToView, viewToScreenData, metadataCarry, FIRST_INPUT_BLOCK_ID, toOption, FREQUENCY_OPTIONS };

--- a/bot/shared/routes/slack-views/exam-confirm.view.js
+++ b/bot/shared/routes/slack-views/exam-confirm.view.js
@@ -1,0 +1,80 @@
+/**
+ * Block Kit screen mapping for the exam-checker student-confirmation
+ * Flow-equivalent — the counterpart to discord-views/exam-confirm.view.js,
+ * shaped for Slack's slack-modal-flow.js screenToView()/viewToScreenData()
+ * contract.
+ *
+ * CONFIRM_STUDENTS renders the dynamically-sized roster
+ * (exam-confirm-endpoint.js's `data.students`, an array of {id, title}) as a
+ * single Block Kit `checkboxes` element — the same `data.countries.map(toOption)`
+ * pattern slack-views/registration.view.js's PERSONAL_INFO screen already
+ * uses for a runtime-sized array. Unlike Discord's StringSelectMenu (hard
+ * capped at 25 options, forcing a 2-select chunking scheme on that side),
+ * Slack's Block Kit `checkboxes` element has no documented hard option cap —
+ * so no chunking is needed here. (Slack DOES cap a `static_select`'s options
+ * at 100 and a modal at 100 total blocks, but `checkboxes` is a single block
+ * holding all of its options as one element's `options` array, not one block
+ * per option — so a 40-student roster is one block with 40 option entries,
+ * nowhere near either limit.)
+ *
+ * Every option defaults to checked (matching Meta's CheckboxGroup default —
+ * all pre-selected; the teacher unchecks anyone who isn't a real student),
+ * via Block Kit's `initial_options`.
+ *
+ * No Back button (exam-confirm-endpoint.js's own handleExamConfirmBack just
+ * re-renders this same screen — nothing upstream of it to navigate to), and
+ * no separate Done-style action needed: the modal's native Submit IS the
+ * confirm action, matching how exam-confirm-endpoint.js's own
+ * handleExamConfirmDataExchange doesn't distinguish an intermediate action.
+ */
+
+function toOption(row) {
+  // Block Kit option text is capped at 75 chars; the endpoint's rows are {id, title}.
+  return { text: { type: 'plain_text', text: String(row.title).slice(0, 75) }, value: String(row.id) };
+}
+
+function screenToView(screen, data, ctx) {
+  const metadata = ctx.metadata;
+
+  if (screen === 'CONFIRM_STUDENTS') {
+    const students = data?.students || [];
+    const options = students.map(toOption);
+
+    return {
+      type: 'modal',
+      callback_id: 'exam_confirm',
+      private_metadata: metadata,
+      title: { type: 'plain_text', text: 'Confirm Students' },
+      submit: { type: 'plain_text', text: 'Confirm & Grade' },
+      blocks: [
+        ...(data?.subheading ? [{ type: 'section', block_id: 'subheading_block', text: { type: 'plain_text', text: data.subheading } }] : []),
+        {
+          type: 'input', block_id: 'confirmed_students_block',
+          label: { type: 'plain_text', text: (data?.heading || 'Students').slice(0, 2000) },
+          element: {
+            type: 'checkboxes',
+            action_id: 'confirmed_students',
+            options,
+            initial_options: options,
+          },
+        },
+      ],
+    };
+  }
+
+  throw new Error(`slack-views/exam-confirm: no view mapping for screen "${screen}"`);
+}
+
+function viewToScreenData(screen, stateValues) {
+  const get = (blockId, actionId) => stateValues?.[blockId]?.[actionId];
+
+  if (screen === 'CONFIRM_STUDENTS') {
+    const selected = get('confirmed_students_block', 'confirmed_students')?.selected_options || [];
+    return { confirmed_students: selected.map((o) => o.value) };
+  }
+  return {};
+}
+
+const FIRST_INPUT_BLOCK_ID = { CONFIRM_STUDENTS: 'confirmed_students_block' };
+
+module.exports = { screenToView, viewToScreenData, FIRST_INPUT_BLOCK_ID, toOption };

--- a/bot/shared/routes/slack-views/registration.view.js
+++ b/bot/shared/routes/slack-views/registration.view.js
@@ -9,11 +9,39 @@
  * multi_static_select rather than checkboxes. Lives next to the endpoint it
  * renders, same principle as docs/flows/ keeping sanitized JSON next to the
  * Flow it documents.
+ *
+ * PERSONAL_INFO's `country` field is a REAL, confirmed bug fix, not a
+ * pre-emptive design choice: Slack's static_select caps at 100 options
+ * (confirmed live — Slack's API itself rejects a 164-option static_select
+ * with "no more than 100 items allowed"), so registration on Slack failed
+ * every single time the modal tried to open. Fixed with the same 2-step
+ * region-bucket-then-country picker Discord's registration view already
+ * uses — reusing discord-country-regions.js's buildBuckets() (a pure,
+ * channel-agnostic function over a countries array, despite the file's
+ * name) rather than duplicating the bucket data a second time.
+ *
+ * Unlike Discord's sequential chat-message picker, Slack renders both
+ * selects in ONE modal screen at once (a modal can't sequence steps the way
+ * Discord's ordinary chat messages can), using Slack's standard "dependent
+ * select menus" pattern: picking a region fires a block_actions event
+ * immediately (Slack always sends one for a static_select pick, even inside
+ * an open modal, with no special config needed), which
+ * slack-modal-interactions.handler.js#handleCountryBucketChange answers with
+ * a live views.update — re-rendering this same screenToView() with the
+ * newly-picked bucket, so the country field's options refresh to match.
  */
+
+const { buildBuckets } = require('../../config/discord-country-regions');
+
+const COUNTRY_BUCKET_ACTION_ID = 'country_bucket_select';
 
 function toOption(row) {
   // Block Kit option text is capped at 75 chars; Flow dropdown rows are {id, title}.
   return { text: { type: 'plain_text', text: String(row.title).slice(0, 75) }, value: String(row.id) };
+}
+
+function bucketOption(bucket) {
+  return { text: { type: 'plain_text', text: String(bucket.title).slice(0, 75) }, value: bucket.id };
 }
 
 function backButton() {
@@ -28,6 +56,11 @@ function screenToView(screen, data, ctx) {
   const metadata = ctx.metadata;
 
   if (screen === 'PERSONAL_INFO') {
+    const buckets = buildBuckets(data.countries);
+    const selectedBucketId = ctx.selectedCountryBucket || null;
+    const activeBucket = buckets.find((b) => b.id === selectedBucketId) || buckets[0];
+    const selectedBucketOption = buckets.find((b) => b.id === selectedBucketId);
+
     return {
       type: 'modal',
       callback_id: 'registration',
@@ -38,12 +71,36 @@ function screenToView(screen, data, ctx) {
         {
           type: 'input', block_id: 'full_name_block',
           label: { type: 'plain_text', text: 'Full name' },
-          element: { type: 'plain_text_input', action_id: 'full_name' },
+          element: {
+            type: 'plain_text_input', action_id: 'full_name',
+            ...(ctx.fullNameValue ? { initial_value: ctx.fullNameValue } : {}),
+          },
+        },
+        {
+          // dispatch_action: true is REQUIRED here — confirmed live, not a
+          // guess: without it, an `input` block's element behaves like an
+          // ordinary, inert form field (Slack updates its own displayed
+          // value locally, but never sends the block_actions event this
+          // live-update mechanism depends on). `actions` blocks (like the
+          // Back button below) fire block_actions on interaction by
+          // default; `input` blocks do not, unless told to.
+          type: 'input', block_id: 'country_bucket_block', dispatch_action: true,
+          label: { type: 'plain_text', text: 'Region' },
+          element: {
+            type: 'static_select', action_id: COUNTRY_BUCKET_ACTION_ID,
+            placeholder: { type: 'plain_text', text: 'Pick a region' },
+            options: buckets.map(bucketOption),
+            ...(selectedBucketOption ? { initial_option: bucketOption(selectedBucketOption) } : {}),
+          },
         },
         {
           type: 'input', block_id: 'country_block',
           label: { type: 'plain_text', text: 'Country' },
-          element: { type: 'static_select', action_id: 'country', options: data.countries.map(toOption) },
+          element: {
+            type: 'static_select', action_id: 'country',
+            placeholder: { type: 'plain_text', text: 'Pick a country' },
+            options: activeBucket.countries.map(toOption),
+          },
         },
       ],
     };
@@ -156,4 +213,4 @@ const FIRST_INPUT_BLOCK_ID = {
   ORG_DETAILS: 'organization_other_block',
 };
 
-module.exports = { screenToView, viewToScreenData, FIRST_INPUT_BLOCK_ID, toOption };
+module.exports = { screenToView, viewToScreenData, FIRST_INPUT_BLOCK_ID, toOption, COUNTRY_BUCKET_ACTION_ID };

--- a/bot/shared/routes/slack-views/registration.view.js
+++ b/bot/shared/routes/slack-views/registration.view.js
@@ -1,0 +1,159 @@
+/**
+ * Block Kit screen mapping for the registration Flow — the Slack renderer's
+ * counterpart to registration-endpoint.js's {screen, data} contract.
+ *
+ * One small per-screen mapping file, not a generic field-type inferrer: a
+ * generic mapper can't tell "a form field" from "just narrative text to
+ * show" (SUCCESS's welcome_message/portal_message aren't form fields at
+ * all), and can't guess UX-specific choices like `subjects` needing a
+ * multi_static_select rather than checkboxes. Lives next to the endpoint it
+ * renders, same principle as docs/flows/ keeping sanitized JSON next to the
+ * Flow it documents.
+ */
+
+function toOption(row) {
+  // Block Kit option text is capped at 75 chars; Flow dropdown rows are {id, title}.
+  return { text: { type: 'plain_text', text: String(row.title).slice(0, 75) }, value: String(row.id) };
+}
+
+function backButton() {
+  return {
+    type: 'button',
+    action_id: 'registration_back',
+    text: { type: 'plain_text', text: 'Back' },
+  };
+}
+
+function screenToView(screen, data, ctx) {
+  const metadata = ctx.metadata;
+
+  if (screen === 'PERSONAL_INFO') {
+    return {
+      type: 'modal',
+      callback_id: 'registration',
+      private_metadata: metadata,
+      title: { type: 'plain_text', text: 'Register with Rumi' },
+      submit: { type: 'plain_text', text: 'Next' },
+      blocks: [
+        {
+          type: 'input', block_id: 'full_name_block',
+          label: { type: 'plain_text', text: 'Full name' },
+          element: { type: 'plain_text_input', action_id: 'full_name' },
+        },
+        {
+          type: 'input', block_id: 'country_block',
+          label: { type: 'plain_text', text: 'Country' },
+          element: { type: 'static_select', action_id: 'country', options: data.countries.map(toOption) },
+        },
+      ],
+    };
+  }
+
+  if (screen === 'REGION_INFO') {
+    return {
+      type: 'modal',
+      callback_id: 'registration',
+      private_metadata: metadata,
+      title: { type: 'plain_text', text: 'Register with Rumi' },
+      submit: { type: 'plain_text', text: 'Next' },
+      blocks: [
+        {
+          type: 'input', block_id: 'region_block',
+          label: { type: 'plain_text', text: 'Region' },
+          element: { type: 'static_select', action_id: 'region', options: data.regions.map(toOption) },
+        },
+        { type: 'actions', block_id: 'back_block', elements: [backButton()] },
+      ],
+    };
+  }
+
+  if (screen === 'PROFESSIONAL_INFO') {
+    return {
+      type: 'modal',
+      callback_id: 'registration',
+      private_metadata: metadata,
+      title: { type: 'plain_text', text: 'Register with Rumi' },
+      submit: { type: 'plain_text', text: 'Next' },
+      blocks: [
+        {
+          type: 'input', block_id: 'organization_block',
+          label: { type: 'plain_text', text: 'Organization' },
+          element: { type: 'static_select', action_id: 'organization', options: data.organizations.map(toOption) },
+        },
+        {
+          type: 'input', block_id: 'school_name_block', optional: true,
+          label: { type: 'plain_text', text: 'School name' },
+          element: { type: 'plain_text_input', action_id: 'school_name' },
+        },
+        {
+          type: 'input', block_id: 'grade_block',
+          label: { type: 'plain_text', text: 'Grade' },
+          element: { type: 'static_select', action_id: 'grade', options: data.grades.map(toOption) },
+        },
+        {
+          type: 'input', block_id: 'subjects_block',
+          label: { type: 'plain_text', text: 'Subjects' },
+          element: { type: 'multi_static_select', action_id: 'subjects', options: data.subjects.map(toOption) },
+        },
+        { type: 'actions', block_id: 'back_block', elements: [backButton()] },
+      ],
+    };
+  }
+
+  if (screen === 'ORG_DETAILS') {
+    return {
+      type: 'modal',
+      callback_id: 'registration',
+      private_metadata: metadata,
+      title: { type: 'plain_text', text: 'Register with Rumi' },
+      submit: { type: 'plain_text', text: 'Finish' },
+      blocks: [
+        {
+          type: 'input', block_id: 'organization_other_block',
+          label: { type: 'plain_text', text: 'Organization name' },
+          element: { type: 'plain_text_input', action_id: 'organization_other' },
+        },
+        { type: 'actions', block_id: 'back_block', elements: [backButton()] },
+      ],
+    };
+  }
+
+  throw new Error(`registration.view: no view mapping for screen "${screen}"`);
+}
+
+function viewToScreenData(screen, stateValues) {
+  const get = (blockId, actionId) => stateValues?.[blockId]?.[actionId];
+
+  if (screen === 'PERSONAL_INFO') {
+    return {
+      full_name: get('full_name_block', 'full_name')?.value || '',
+      country: get('country_block', 'country')?.selected_option?.value || '',
+    };
+  }
+  if (screen === 'REGION_INFO') {
+    return { region: get('region_block', 'region')?.selected_option?.value || null };
+  }
+  if (screen === 'PROFESSIONAL_INFO') {
+    return {
+      organization: get('organization_block', 'organization')?.selected_option?.value || '',
+      school_name: get('school_name_block', 'school_name')?.value || '',
+      grade: get('grade_block', 'grade')?.selected_option?.value || '',
+      subjects: (get('subjects_block', 'subjects')?.selected_options || []).map((o) => o.value),
+    };
+  }
+  if (screen === 'ORG_DETAILS') {
+    return { organization_other: get('organization_other_block', 'organization_other')?.value || '' };
+  }
+  return {};
+}
+
+// The block_id carrying the FIRST input on each screen — where a validation
+// error from exchange() surfaces via Slack's response_action: 'errors'.
+const FIRST_INPUT_BLOCK_ID = {
+  PERSONAL_INFO: 'full_name_block',
+  REGION_INFO: 'region_block',
+  PROFESSIONAL_INFO: 'organization_block',
+  ORG_DETAILS: 'organization_other_block',
+};
+
+module.exports = { screenToView, viewToScreenData, FIRST_INPUT_BLOCK_ID, toOption };

--- a/bot/shared/routes/slack-views/settings.view.js
+++ b/bot/shared/routes/slack-views/settings.view.js
@@ -1,0 +1,55 @@
+/**
+ * Block Kit screen mapping for the settings Flow — the Slack renderer's
+ * counterpart to settings-endpoint.js's single-screen {screen, data} contract.
+ */
+
+function toOption(row) {
+  return { text: { type: 'plain_text', text: String(row.title).slice(0, 75) }, value: String(row.id) };
+}
+
+function screenToView(screen, data, ctx) {
+  const metadata = ctx.metadata;
+  const currentLangOpt = data.languages.find((l) => l.id === data.current_language);
+  const currentFwOpt = data.frameworks.find((f) => f.id === data.current_framework);
+
+  return {
+    type: 'modal',
+    callback_id: 'settings',
+    private_metadata: metadata,
+    title: { type: 'plain_text', text: 'Rumi Settings' },
+    submit: { type: 'plain_text', text: 'Save' },
+    blocks: [
+      {
+        type: 'input', block_id: 'language_block',
+        label: { type: 'plain_text', text: 'Reply language' },
+        element: {
+          type: 'static_select', action_id: 'language',
+          options: data.languages.map(toOption),
+          ...(currentLangOpt ? { initial_option: toOption(currentLangOpt) } : {}),
+        },
+      },
+      {
+        type: 'input', block_id: 'framework_block',
+        label: { type: 'plain_text', text: 'Observation framework' },
+        element: {
+          type: 'static_select', action_id: 'observation_framework',
+          options: data.frameworks.map(toOption),
+          ...(currentFwOpt ? { initial_option: toOption(currentFwOpt) } : {}),
+        },
+        ...(data.info_text ? { hint: { type: 'plain_text', text: data.info_text.slice(0, 150) } } : {}),
+      },
+    ],
+  };
+}
+
+function viewToScreenData(screen, stateValues) {
+  const get = (blockId, actionId) => stateValues?.[blockId]?.[actionId];
+  return {
+    language: get('language_block', 'language')?.selected_option?.value || 'en',
+    observation_framework: get('framework_block', 'observation_framework')?.selected_option?.value || 'oecd',
+  };
+}
+
+const FIRST_INPUT_BLOCK_ID = { SETTINGS_MAIN: 'language_block' };
+
+module.exports = { screenToView, viewToScreenData, FIRST_INPUT_BLOCK_ID, toOption };

--- a/bot/shared/services/coaching/coaching-session.service.js
+++ b/bot/shared/services/coaching/coaching-session.service.js
@@ -55,6 +55,14 @@ class CoachingSessionService {
           session_id: sessionId,
           audio_id: audioId,
           audio_duration_seconds: audioDuration,
+          // The exact channel identifier this request came in on (a bare
+          // WhatsApp phone number, or "slack:<id>") — captured now because
+          // it's never re-derivable correctly later: a users.phone_number
+          // join is WhatsApp-only and silently sends this session's later
+          // background notifications to the wrong channel (or nowhere) for
+          // a Slack-originated request. See lesson-plan-extraction.worker.js
+          // and stale-session.worker.js, which read this column back.
+          recipient_identifier: from,
           status: 'initiated',
           conversation_state: {
             current_state: 'AWAITING_CONFIRMATION',

--- a/bot/shared/services/exam-checker/delivery.service.js
+++ b/bot/shared/services/exam-checker/delivery.service.js
@@ -13,7 +13,10 @@ class DeliveryService {
   /**
    * Send grading results to user
    * @param {object} session - Exam session with grading results
-   * @param {string} userId - User ID for looking up phone
+   * @param {string} userId - User ID (for logging only — delivery targets
+   *   session.recipient_identifier, the exact channel this session
+   *   originated on, never a users.phone_number re-derivation, which is
+   *   WhatsApp-only and would misdeliver a Slack-originated session)
    */
   static async sendResults(session, userId) {
     logToFile('📤 Starting result delivery', {
@@ -24,10 +27,9 @@ class DeliveryService {
     const gradingResults = session.grading_results || { successful: [], failed: [], summary: {} };
     const annotatedImages = session.annotated_images || [];
 
-    // Get user's phone number
-    const phoneNumber = await this._getUserPhone(userId);
+    const phoneNumber = session.recipient_identifier;
     if (!phoneNumber) {
-      throw new Error('User phone number not found');
+      throw new Error('Session has no recipient_identifier — cannot deliver results');
     }
 
     // 1. Send summary message
@@ -168,26 +170,6 @@ class DeliveryService {
     await whatsappService.sendMessage(phoneNumber, message, {
       preview_url: true
     });
-  }
-
-  /**
-   * Get user's phone number from database
-   */
-  static async _getUserPhone(userId) {
-    const supabase = require('../../config/supabase');
-
-    const { data, error } = await supabase
-      .from('users')
-      .select('phone_number')
-      .eq('id', userId)
-      .single();
-
-    if (error || !data) {
-      logToFile('⚠️ Failed to get user phone', { userId, error: error?.message });
-      return null;
-    }
-
-    return data.phone_number;
   }
 
   /**

--- a/bot/shared/services/exam-checker/exam-checker.orchestrator.js
+++ b/bot/shared/services/exam-checker/exam-checker.orchestrator.js
@@ -45,15 +45,20 @@ class ExamCheckerOrchestrator {
    * Main entry point - delegates to appropriate handler based on session state
    * @param {object} message - WhatsApp message object
    * @param {string} userId - User UUID
+   * @param {string} [from] - The channel identifier this request came in on (a
+   *   bare WhatsApp phone number, or "slack:<id>") — stored on the session at
+   *   creation so background delivery (grading results, progress updates)
+   *   never has to re-derive it from users.phone_number, which is WhatsApp-only
+   *   and would misdeliver a Slack-originated session's results.
    * @returns {object} Response to send back
    */
-  static async process(message, userId) {
+  static async process(message, userId, from) {
     const correlationId = getCurrentCorrelationId() || `ech-${Date.now()}`;
 
     return runWithCorrelation(correlationId, async () => {
       // Get or create session (delegate to session service)
       const ExamSessionService = require('./exam-session.service');
-      const session = await ExamSessionService.getOrCreate(userId);
+      const session = await ExamSessionService.getOrCreate(userId, from);
 
       logToFile('📝 Processing exam checker message', {
         state: session.status,

--- a/bot/shared/services/exam-checker/exam-session.service.js
+++ b/bot/shared/services/exam-checker/exam-session.service.js
@@ -18,9 +18,13 @@ class ExamSessionService {
   /**
    * Get or create an exam session for a user
    * @param {string} userId - User UUID
+   * @param {string} [from] - The channel identifier this request came in on
+   *   (a bare WhatsApp phone number, or "slack:<id>") — only used if a NEW
+   *   session is created; an existing session already has its own stored
+   *   value from when it was first created.
    * @returns {object} Session object
    */
-  static async getOrCreate(userId) {
+  static async getOrCreate(userId, from) {
     // Check Redis first for active session
     const cachedSession = await this._getFromRedis(userId);
     if (cachedSession) {
@@ -43,7 +47,7 @@ class ExamSessionService {
     }
 
     // Create new session
-    return this._createSession(userId);
+    return this._createSession(userId, from);
   }
 
   /**
@@ -99,15 +103,20 @@ class ExamSessionService {
   /**
    * Create a new exam session
    * @param {string} userId - User UUID
+   * @param {string} [from] - The channel identifier this request came in on
+   *   (a bare WhatsApp phone number, or "slack:<id>") — stored on the row so
+   *   later delivery (grading results, progress updates) never has to
+   *   re-derive it from users.phone_number, which is WhatsApp-only.
    * @returns {object} New session
    */
-  static async _createSession(userId) {
+  static async _createSession(userId, from) {
     const { data, error } = await supabase
       .from('exam_check_sessions')
       .insert({
         user_id: userId,
         status: 'collecting_images',
-        original_images: []
+        original_images: [],
+        recipient_identifier: from || null
       })
       .select()
       .single();

--- a/bot/shared/services/feature-registration.service.js
+++ b/bot/shared/services/feature-registration.service.js
@@ -145,6 +145,46 @@ class FeatureRegistrationService {
    * @param {string} format - 'text' | 'voice'
    */
   static async sendNameQuestion(userId, phoneNumber, language = 'en', format = 'text') {
+    // Slack/Discord have a real Flow-equivalent (a modal-workaround renderer,
+    // opened by button click — see slack-flow-registry.js /
+    // discord-flow-registry.js), not sendFlow()'s Meta/Baileys-shaped
+    // {flowId, flowToken} contract, which is a no-op stub on both. Previously
+    // this branch didn't exist at all, so Slack/Discord users silently fell
+    // through to the plain-text name-capture path below instead of getting
+    // the polished registration form — fixed here for both channels, matching
+    // how /settings already branches on driverForIdentifier() in
+    // text-message.handler.js.
+    const { driverForIdentifier } = require('./messaging/channel-registry');
+    const driverName = driverForIdentifier(phoneNumber);
+
+    if (driverName === 'slack') {
+      try {
+        await WhatsAppService.sendInteractiveButtons(phoneNumber, {
+          body: 'Quick setup — tell us a little about you.',
+          buttons: [{ id: 'open_modal:registration', title: 'Get started' }],
+        });
+        logToFile('Registration modal button sent (Slack)', { userId, phoneNumber });
+        return;
+      } catch (error) {
+        logToFile('Slack registration button send failed; falling back to name question', { userId, error: error.message });
+        // fall through to the conversational path
+      }
+    }
+
+    if (driverName === 'discord') {
+      try {
+        await WhatsAppService.sendInteractiveButtons(phoneNumber, {
+          body: 'Quick setup — tell us a little about you.',
+          buttons: [{ id: 'discord_start_flow:registration', title: 'Get started' }],
+        });
+        logToFile('Registration modal button sent (Discord)', { userId, phoneNumber });
+        return;
+      } catch (error) {
+        logToFile('Discord registration button send failed; falling back to name question', { userId, error: error.message });
+        // fall through to the conversational path
+      }
+    }
+
     // Presence-gated: if a registration Flow is configured, open the polished
     // form instead of the conversational name question. Unset (default) → the
     // conversational path below. The Flow completes via

--- a/bot/shared/services/messaging/baileys-connection.js
+++ b/bot/shared/services/messaging/baileys-connection.js
@@ -360,6 +360,17 @@ async function connect(opts = {}) {
       const { connection, lastDisconnect, qr } = update;
 
       if (qr) {
+        // A shutdown already in progress (close() has set this) must not
+        // render, or act on, a fresh QR — Baileys' own reconnect/QR-refresh
+        // cycle keeps running on the socket close() is trying to tear down
+        // until this event fires, and printing a new QR here is what makes a
+        // deliberate Ctrl+C look like it did nothing.
+        if (shuttingDown) {
+          try { sock.end(new Error('shutting down — ignoring QR')); } catch { /* already closing */ }
+          if (!settled) { settled = true; reject(new Error('Baileys: shutting down')); }
+          return;
+        }
+
         // A QR when we ALREADY had credentials is not a pairing opportunity —
         // the session was invalidated (WhatsApp reports this as
         // "Stream Errored (conflict)", typically because two processes shared one
@@ -461,17 +472,26 @@ function isConnected() {
  * @param {object}  [opts]
  * @param {number}  [opts.flushMs=500] grace period for pending auth-state writes.
  */
-async function close({ flushMs = 500 } = {}) {
+async function close({ flushMs = 500, pendingTimeoutMs = 2000 } = {}) {
   shuttingDown = true;
   const pending = socketPromise;
   socketPromise = null;
 
   if (pending) {
     try {
-      const sock = await pending;
+      // `pending` only settles once the socket reaches 'open' or 'close' —
+      // a socket still waiting on an unscanned QR (never paired) reaches
+      // neither, so awaiting it unconditionally can hang shutdown forever.
+      // The QR-branch's shuttingDown guard above handles the common case
+      // (a QR event arrives and self-terminates), but nothing GUARANTEES
+      // that event fires promptly, so this timeout is the real backstop.
+      const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error('timed out waiting for socket')), pendingTimeoutMs));
+      const sock = await Promise.race([pending, timeout]);
       sock.end(undefined); // undefined = clean close, NOT a logout
     } catch {
-      // Never reached "open" (or already rejected) — nothing to close.
+      // Never reached "open" (or already rejected, or timed out) — nothing
+      // reachable to close cleanly; shuttingDown is already true, so any
+      // late settlement of `pending` is a no-op from here on.
     }
   }
 

--- a/bot/shared/services/messaging/channel-registry.js
+++ b/bot/shared/services/messaging/channel-registry.js
@@ -16,30 +16,33 @@ const DRIVERS = {
   meta: './meta-channel.service',
   baileys: './baileys-channel.service',
   slack: './slack-channel.service',
-  // discord: './discord-channel.service' — added in the Discord phase.
+  discord: './discord-channel.service',
 };
 
 const DEFAULT_DRIVER = 'baileys';
 
 // Drivers that require a formal business registration / app-review process —
 // the thing that actually makes a channel "production-grade" here. Every
-// driver NOT in this list is sandbox-tier by default. Slack has no such
-// process (a Slack app install has no review gate like WhatsApp Business
-// verification), so it is listed here — usable in BOTH sandbox and
-// production, per the original ask, unlike Baileys which stays sandbox-only.
-const PRODUCTION_TIER_DRIVERS = ['meta', 'slack'];
+// driver NOT in this list is sandbox-tier by default. Slack and Discord have
+// no such process (neither has a review gate like WhatsApp Business
+// verification for the permission scopes this bot needs), so both are
+// listed here — usable in BOTH sandbox and production, unlike Baileys which
+// stays sandbox-only. (Discord's MESSAGE_CONTENT privileged intent does need
+// Discord's own Bot Verification once a bot is in 100+ servers — a separate,
+// later operational concern, not a blocker at this deployment's scale.)
+const PRODUCTION_TIER_DRIVERS = ['meta', 'slack', 'discord'];
 
 // Additive-channel drivers (Slack, Discord, ...) are never selected via
 // CHANNEL_DRIVER — they run alongside whichever WhatsApp-family driver
 // (meta|baileys) is active, gated by their own env-var presence (see
 // feature-availability.js#resolveActiveChannels). Each gets a wire prefix so
-// messaging/index.js's router can tell "slack:U0123ABC" apart from a bare
-// WhatsApp phone number without any DB/session lookup. WhatsApp itself is
-// intentionally NOT in this map — a bare phone number has no prefix and
-// falls through to the single resolved CHANNEL_DRIVER, unchanged.
+// messaging/index.js's router can tell "slack:U0123ABC" / "discord:9182..."
+// apart from a bare WhatsApp phone number without any DB/session lookup.
+// WhatsApp itself is intentionally NOT in this map — a bare phone number has
+// no prefix and falls through to the single resolved CHANNEL_DRIVER, unchanged.
 const CHANNEL_PREFIXES = {
   slack: 'slack',
-  // discord: 'discord' — added in the Discord phase.
+  discord: 'discord',
 };
 
 function isKnownDriver(name) {

--- a/bot/shared/services/messaging/channel-registry.js
+++ b/bot/shared/services/messaging/channel-registry.js
@@ -15,15 +15,19 @@
 const DRIVERS = {
   meta: './meta-channel.service',
   baileys: './baileys-channel.service',
-  // slack: './slack-channel.service' — added once the Slack driver ships.
+  slack: './slack-channel.service',
+  // discord: './discord-channel.service' — added in the Discord phase.
 };
 
 const DEFAULT_DRIVER = 'baileys';
 
 // Drivers that require a formal business registration / app-review process —
 // the thing that actually makes a channel "production-grade" here. Every
-// driver NOT in this list is sandbox-tier by default.
-const PRODUCTION_TIER_DRIVERS = ['meta'];
+// driver NOT in this list is sandbox-tier by default. Slack has no such
+// process (a Slack app install has no review gate like WhatsApp Business
+// verification), so it is listed here — usable in BOTH sandbox and
+// production, per the original ask, unlike Baileys which stays sandbox-only.
+const PRODUCTION_TIER_DRIVERS = ['meta', 'slack'];
 
 // Additive-channel drivers (Slack, Discord, ...) are never selected via
 // CHANNEL_DRIVER — they run alongside whichever WhatsApp-family driver
@@ -34,7 +38,8 @@ const PRODUCTION_TIER_DRIVERS = ['meta'];
 // intentionally NOT in this map — a bare phone number has no prefix and
 // falls through to the single resolved CHANNEL_DRIVER, unchanged.
 const CHANNEL_PREFIXES = {
-  // slack: 'slack' — added once the Slack driver ships.
+  slack: 'slack',
+  // discord: 'discord' — added in the Discord phase.
 };
 
 function isKnownDriver(name) {

--- a/bot/shared/services/messaging/channel-registry.js
+++ b/bot/shared/services/messaging/channel-registry.js
@@ -15,6 +15,7 @@
 const DRIVERS = {
   meta: './meta-channel.service',
   baileys: './baileys-channel.service',
+  // slack: './slack-channel.service' — added once the Slack driver ships.
 };
 
 const DEFAULT_DRIVER = 'baileys';
@@ -24,6 +25,18 @@ const DEFAULT_DRIVER = 'baileys';
 // driver NOT in this list is sandbox-tier by default.
 const PRODUCTION_TIER_DRIVERS = ['meta'];
 
+// Additive-channel drivers (Slack, Discord, ...) are never selected via
+// CHANNEL_DRIVER — they run alongside whichever WhatsApp-family driver
+// (meta|baileys) is active, gated by their own env-var presence (see
+// feature-availability.js#resolveActiveChannels). Each gets a wire prefix so
+// messaging/index.js's router can tell "slack:U0123ABC" apart from a bare
+// WhatsApp phone number without any DB/session lookup. WhatsApp itself is
+// intentionally NOT in this map — a bare phone number has no prefix and
+// falls through to the single resolved CHANNEL_DRIVER, unchanged.
+const CHANNEL_PREFIXES = {
+  // slack: 'slack' — added once the Slack driver ships.
+};
+
 function isKnownDriver(name) {
   return Object.prototype.hasOwnProperty.call(DRIVERS, name);
 }
@@ -32,4 +45,30 @@ function isProductionTier(name) {
   return PRODUCTION_TIER_DRIVERS.includes(name);
 }
 
-module.exports = { DRIVERS, DEFAULT_DRIVER, PRODUCTION_TIER_DRIVERS, isKnownDriver, isProductionTier };
+/** The wire prefix an additive-channel driver's identifiers carry (e.g. "slack"), or null for WhatsApp. */
+function prefixFor(driverName) {
+  return CHANNEL_PREFIXES[driverName] || null;
+}
+
+/**
+ * Which additive-channel driver owns this identifier, based on its
+ * "<prefix>:<id>" shape — or null for a bare WhatsApp phone number (no
+ * colon), which the router falls back to the resolved CHANNEL_DRIVER for.
+ */
+function driverForIdentifier(id) {
+  const idx = String(id).indexOf(':');
+  if (idx === -1) return null;
+  const prefix = String(id).slice(0, idx);
+  return Object.keys(CHANNEL_PREFIXES).find((name) => CHANNEL_PREFIXES[name] === prefix) || null;
+}
+
+module.exports = {
+  DRIVERS,
+  DEFAULT_DRIVER,
+  PRODUCTION_TIER_DRIVERS,
+  CHANNEL_PREFIXES,
+  isKnownDriver,
+  isProductionTier,
+  prefixFor,
+  driverForIdentifier,
+};

--- a/bot/shared/services/messaging/discord-channel.service.js
+++ b/bot/shared/services/messaging/discord-channel.service.js
@@ -1,0 +1,684 @@
+/**
+ * Discord channel driver — usable in BOTH sandbox and production, same
+ * reasoning as Slack: a Discord bot has no formal review gate for the
+ * permission scopes this bot needs, so there is no tier split here (see
+ * channel-registry.js's PRODUCTION_TIER_DRIVERS).
+ *
+ * Unlike Baileys, Discord CAN render real interactive components (buttons,
+ * select menus) natively — so sendInteractiveButtons/sendInteractiveMessage
+ * are REAL discord.js component implementations here, not a text degradation.
+ * A button's Discord `customId` carries the exact same `id` Meta's
+ * button_reply would have used, so the inbound adapter
+ * (discord-events.adapter.js) can synthesize the identical internal shape
+ * whatsapp-bot.js already dispatches on, with no numeric-reply resolution
+ * step needed (mirrors Slack's own reasoning, not Baileys').
+ *
+ * Method names/async-ness are parsed statically off meta-channel.service.js's
+ * SOURCE (the same mechanism slack-channel.service.js and
+ * baileys-channel.service.js use) rather than by `require()`-ing that
+ * module — meta-channel.service.js pulls in axios/form-data, neither of
+ * which this driver needs. If meta-channel.service.js ever grows a new
+ * method this file doesn't know about, requiring this file throws
+ * immediately (see the assertion loop at the bottom) rather than silently
+ * shipping a missing/wrong-shaped member.
+ *
+ * Identity: `to` always arrives as the full "discord:<snowflake>" identifier
+ * the messaging router (messaging/index.js) dispatches by — this driver
+ * strips the prefix once, internally, and never receives a bare Discord user
+ * id directly (see channel-registry.js's CHANNEL_PREFIXES).
+ *
+ * Real divergences from Slack's driver, all deliberate:
+ *   - showTypingIndicator/startContinuousTypingIndicator are REAL here
+ *     (Discord has channel.sendTyping()) — Slack has no typing API at all
+ *     and stubs both.
+ *   - getMediaInfo/downloadMedia read from an in-process cache the inbound
+ *     adapter populates at receive time (discord-events.adapter.js caches
+ *     {url, mime_type, file_size} keyed by the same prefixed media id it
+ *     mints), NOT a live API lookup — Discord attachments are
+ *     self-describing at receive time (attachment.url/.contentType/.size),
+ *     unlike Slack's files.info, which needs a real API call because Slack
+ *     file ids are not self-describing on their own. downloadMedia needs NO
+ *     Bearer auth header either — Discord CDN attachment URLs are
+ *     pre-signed/public for their lifetime, unlike Slack's private,
+ *     auth-gated file URLs.
+ *   - sendReaction accepts a literal unicode emoji directly — no
+ *     shortcode-translation table needed (Slack needs EMOJI_TO_SLACK_NAME
+ *     because Slack reaction names are bare shortcodes, not unicode).
+ *   - sendVideo is a REAL, size-gated implementation (not a stub or a
+ *     straight upload) — see its own doc comment.
+ *
+ * Templates/Flow/carousels have no Discord equivalent without the
+ * channel-agnostic template registry from
+ * docs/onboarding/sandbox-production-design.md §1 (not built) — those stay
+ * honest stubs, same contract as Slack's/Baileys' stubs for the same
+ * methods. The real Flow-equivalent (Discord modal-workaround flows for
+ * registration/settings/attendance/exam-confirm) is a separate renderer
+ * layered on top of this driver, not part of it — see discord-modal-flow.js.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { logToFile } = require('../../utils/logger');
+const { downloadFromR2, extractKeyFromUrl } = require('../../storage/r2');
+const { prefixFor } = require('./channel-registry');
+
+const META_SOURCE_PATH = path.join(__dirname, 'meta-channel.service.js');
+const DISCORD_PREFIX = prefixFor('discord'); // 'discord' — kept indirect so a rename to CHANNEL_PREFIXES stays a one-line fix
+
+function parseMembers(src) {
+  const members = [];
+  const methodRe = /^\s*static\s+(async\s+)?(\w+)\s*\(/gm;
+  let m;
+  while ((m = methodRe.exec(src))) members.push({ name: m[2], isAsync: !!m[1] });
+  return members;
+}
+
+const MEMBERS = parseMembers(fs.readFileSync(META_SOURCE_PATH, 'utf-8'));
+
+/** Strips the "discord:" prefix the router hands every method — never received bare. */
+function discordUserId(to) {
+  const raw = String(to);
+  const withPrefix = `${DISCORD_PREFIX}:`;
+  return raw.startsWith(withPrefix) ? raw.slice(withPrefix.length) : raw;
+}
+
+// Media ids carry the same "discord:" prefix as user identities (minted by
+// discord-events.adapter.js#toPrefixedMediaId) so the messaging router can
+// tell a Discord attachment id apart from a WhatsApp media id with no DB
+// lookup. Stripped here, once, before ever touching the media cache.
+const stripDiscordPrefix = discordUserId;
+
+// ── Discord Gateway client (shared, NOT constructed here) ───────────────────
+// Unlike Slack's getClient() (a fresh, stateless WebClient per-process —
+// Slack has no persistent connection to share), this driver must reuse the
+// SINGLE already-connected client discord-connection.js owns. A second
+// `new Client()` for the same bot token would open a second Gateway
+// connection for that token — undefined/broken behaviour, not just
+// wasteful. See discord-connection.js's own header comment.
+async function getClient() {
+  const connection = require('./discord-connection');
+  return connection.getClient();
+}
+
+// ── User resolution (cached) ─────────────────────────────────────────────────
+// Discord.js caches fetched User objects on its own (client.users.cache), so
+// this is a thin convenience wrapper, not a from-scratch cache the way
+// Slack's dmChannelCache is (Slack addresses a person by a resolved DM
+// CHANNEL id, which has no equivalent caching inside @slack/web-api itself).
+async function getDiscordUser(userId) {
+  const client = await getClient();
+  const user = await client.users.fetch(userId);
+  if (!user) throw new Error(`Discord: could not resolve user ${userId}`);
+  return user;
+}
+
+// ── Media sources (mirrors slack-channel.service.js's resolveMediaBuffer) ───
+
+function isAbsoluteHttpUrl(url) {
+  return /^https?:\/\//i.test(String(url || ''));
+}
+
+function isR2Configured() {
+  return Boolean(
+    process.env.R2_ENDPOINT && process.env.R2_ACCESS_KEY_ID && process.env.R2_SECRET_ACCESS_KEY
+  );
+}
+
+/**
+ * Resolves a media reference into a Buffer discord.js's `files` send option
+ * can attach. Identical logic to Slack's resolveMediaBuffer — it has zero
+ * Slack-specific code, so it is copied verbatim here rather than shared
+ * (matches this codebase's existing convention of each driver owning its own
+ * copy of this helper, not importing it cross-driver).
+ */
+async function resolveMediaBuffer(url) {
+  if (typeof url === 'string' && url.startsWith('file://')) {
+    const localPath = url.slice('file://'.length);
+    if (!fs.existsSync(localPath)) {
+      throw new Error(`Cannot send media: local file is gone (${localPath})`);
+    }
+    return fs.readFileSync(localPath);
+  }
+
+  if (isR2Configured()) {
+    try {
+      return await downloadFromR2(extractKeyFromUrl(url));
+    } catch (error) {
+      if (!isAbsoluteHttpUrl(url)) throw error;
+      logToFile('⚠️ Discord: R2 download failed — fetching the URL directly instead', {
+        url, error: error.message,
+      });
+    }
+  }
+
+  if (!isAbsoluteHttpUrl(url)) {
+    throw new Error(
+      `Cannot send media from "${url}": it is not an absolute URL, and R2 is not configured `
+      + '(set R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY to read private objects).'
+    );
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Failed to fetch media URL: HTTP ${response.status}`);
+  return Buffer.from(await response.arrayBuffer());
+}
+
+// ── Real implementations ─────────────────────────────────────────────────────
+
+function removeEmotionTags(text) {
+  return text.replace(/\[[a-zA-Z\s]+\]\s*/g, '').trim();
+}
+
+/** Surfaces discord.js's DiscordAPIError detail so a permission/intent problem is diagnosable from the log line alone. */
+function discordErrorDetail(error) {
+  if (error?.code) return { code: error.code, message: error.message };
+  return { message: error?.message };
+}
+
+async function sendMessage(to, message) {
+  try {
+    const user = await getDiscordUser(discordUserId(to));
+    await user.send({ content: removeEmotionTags(message) });
+    logToFile('✅ Discord message sent', { to });
+    return true;
+  } catch (error) {
+    logToFile('❌ Discord: error sending message', { ...discordErrorDetail(error) });
+    return false;
+  }
+}
+
+async function sendTextReturningId(to, message, opts = {}) {
+  try {
+    const user = await getDiscordUser(discordUserId(to));
+    const payload = { content: removeEmotionTags(message) };
+    // Discord's quote-equivalent is a real message reply, not an
+    // approximated thread the way Slack's thread_ts is.
+    if (opts.contextMessageId) payload.reply = { messageReference: opts.contextMessageId };
+    const sent = await user.send(payload);
+    return sent?.id || null;
+  } catch (error) {
+    logToFile('❌ Discord: error sending message (returning id)', { ...discordErrorDetail(error) });
+    return null;
+  }
+}
+
+async function sendReaction(to, messageId, emoji = '❤️') {
+  try {
+    const user = await getDiscordUser(discordUserId(to));
+    const dmChannel = user.dmChannel || await user.createDM();
+    const message = await dmChannel.messages.fetch(messageId);
+    // Discord accepts a literal unicode emoji directly — no shortcode
+    // translation table needed, unlike Slack's EMOJI_TO_SLACK_NAME.
+    await message.react(emoji);
+    return true;
+  } catch (error) {
+    logToFile('❌ Discord: error sending reaction', { ...discordErrorDetail(error) });
+    return false;
+  }
+}
+
+// Discord DOES have a real typing-indicator API, unlike Slack — these are
+// genuine implementations, not honest no-op stubs.
+async function showTypingIndicator(to) {
+  try {
+    const user = await getDiscordUser(discordUserId(to));
+    const dmChannel = user.dmChannel || await user.createDM();
+    await dmChannel.sendTyping();
+    return true;
+  } catch (error) {
+    logToFile('❌ Discord: error sending typing indicator', { ...discordErrorDetail(error) });
+    return false;
+  }
+}
+
+// Discord's typing indicator auto-expires after ~10s with no explicit "stop
+// typing" call — this repeats just under that window, mirroring Baileys'
+// own continuous-typing timer (Slack has nothing to mirror here at all).
+function startContinuousTypingIndicator(to) {
+  let stopped = false;
+  const tick = () => {
+    if (stopped) return;
+    showTypingIndicator(to).catch(() => {});
+  };
+  tick();
+  const interval = setInterval(tick, 8000);
+  return { stop: () => { stopped = true; clearInterval(interval); } };
+}
+
+// Populated by discord-events.adapter.js at receive time — Discord
+// attachments are self-describing (attachment.url/.contentType/.size) with
+// no separate "files.info"-style lookup call needed or available, unlike
+// Slack. Exported so the inbound adapter can write into it without a
+// require cycle back through this file's own module-load path.
+const mediaCache = new Map(); // "discord:<attachmentId>" -> {url, mime_type, file_size}
+
+function cacheIncomingMedia(prefixedMediaId, info) {
+  mediaCache.set(prefixedMediaId, info);
+}
+
+async function getMediaInfo(mediaId) {
+  const cached = mediaCache.get(String(mediaId));
+  if (!cached) {
+    throw new Error(`Discord: no cached media info for id "${mediaId}" — media must be consumed shortly after it is received (see discord-events.adapter.js)`);
+  }
+  return cached;
+}
+
+async function downloadMedia(mediaId) {
+  const info = await getMediaInfo(mediaId);
+  // No Bearer auth header — Discord CDN attachment URLs are pre-signed/
+  // public for their lifetime, unlike Slack's private, auth-gated URLs.
+  const response = await fetch(info.url);
+  if (!response.ok) throw new Error(`Discord: file download failed, HTTP ${response.status}`);
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function sendFile(to, buffer, filename, caption) {
+  const user = await getDiscordUser(discordUserId(to));
+  await user.send({ content: caption || undefined, files: [{ attachment: buffer, name: filename }] });
+  return true;
+}
+
+async function sendDocument(to, filePath, filename, caption) {
+  try {
+    const buffer = fs.readFileSync(filePath);
+    return await sendFile(to, buffer, filename, caption);
+  } catch (error) {
+    logToFile('❌ Discord: error sending document', { ...discordErrorDetail(error) });
+    return false;
+  }
+}
+
+async function sendAudio(to, audioBuffer) {
+  try {
+    return await sendFile(to, audioBuffer, 'audio.mp3');
+  } catch (error) {
+    logToFile('❌ Discord: error sending audio', { ...discordErrorDetail(error) });
+    return false;
+  }
+}
+
+async function sendDocumentFromUrl(to, documentUrl, filename, caption) {
+  try {
+    const buffer = await resolveMediaBuffer(documentUrl);
+    return await sendFile(to, buffer, filename, caption);
+  } catch (error) {
+    logToFile('❌ Discord: error sending document from URL', { ...discordErrorDetail(error), documentUrl });
+    return false;
+  }
+}
+
+async function sendAudioFromUrl(to, audioUrl) {
+  try {
+    const buffer = await resolveMediaBuffer(audioUrl);
+    return await sendFile(to, buffer, 'audio.mp3');
+  } catch (error) {
+    logToFile('❌ Discord: error sending audio from URL', { ...discordErrorDetail(error), audioUrl });
+    return false;
+  }
+}
+
+async function sendAudioFromUrlReturningId(to, audioUrl) {
+  try {
+    const user = await getDiscordUser(discordUserId(to));
+    const buffer = await resolveMediaBuffer(audioUrl);
+    const sent = await user.send({ files: [{ attachment: buffer, name: 'audio.mp3' }] });
+    return sent?.id || null;
+  } catch (error) {
+    logToFile('❌ Discord: error sending audio from URL (returning id)', { ...discordErrorDetail(error), audioUrl });
+    return null;
+  }
+}
+
+async function sendImageFromUrl(to, imageUrl, caption = '') {
+  try {
+    const buffer = await resolveMediaBuffer(imageUrl);
+    return await sendFile(to, buffer, 'image.png', caption);
+  } catch (error) {
+    logToFile('❌ Discord: error sending image from URL', { ...discordErrorDetail(error), imageUrl });
+    return false;
+  }
+}
+
+// Conservative: Discord DM channels are not guild-boosted, so do not assume
+// a guild's higher boost-tier upload limits apply to a bot's DM uploads.
+const SAFE_UPLOAD_LIMIT_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Size-gated real implementation, NOT a stub and NOT an unconditional
+ * upload. A freshly-generated AI video can plausibly exceed Discord's safe
+ * DM upload ceiling — rather than attempt an upload that will likely fail,
+ * this logs and returns false so callers with a durable URL fall back to
+ * sendVideoFromUrl (the real, primary delivery path — see
+ * video-assembly.service.js's own fix preferring that path whenever a
+ * durable R2 URL is available).
+ */
+async function sendVideo(to, videoBuffer, tempDir, caption = '') {
+  if (videoBuffer.length > SAFE_UPLOAD_LIMIT_BYTES) {
+    logToFile('ℹ️ Discord: video exceeds the safe DM upload size — use sendVideoFromUrl instead', {
+      to, sizeBytes: videoBuffer.length, limitBytes: SAFE_UPLOAD_LIMIT_BYTES,
+    });
+    return false;
+  }
+  try {
+    return await sendFile(to, videoBuffer, 'video.mp4', caption);
+  } catch (error) {
+    logToFile('❌ Discord: error sending video', { ...discordErrorDetail(error) });
+    return false;
+  }
+}
+
+/**
+ * REAL, PRIMARY video-delivery path — never uploads raw bytes, sidestepping
+ * Discord's upload-size ceiling entirely. An embed reads better in Discord's
+ * client than a bare URL; the bare URL is also included in `content` as a
+ * fallback for situations where the embed doesn't unfurl.
+ */
+async function sendVideoFromUrl(to, videoUrl, caption = '') {
+  try {
+    // eslint-disable-next-line global-require -- lazy, matching this file's other lazy discord.js requires
+    const { EmbedBuilder } = require('discord.js');
+    const user = await getDiscordUser(discordUserId(to));
+    const embed = new EmbedBuilder().setTitle('Your video is ready').setURL(videoUrl);
+    if (caption) embed.setDescription(caption);
+    await user.send({ content: videoUrl, embeds: [embed] });
+    return true;
+  } catch (error) {
+    logToFile('❌ Discord: error sending video from URL', { ...discordErrorDetail(error), videoUrl });
+    return false;
+  }
+}
+
+async function sendImage(to, mediaIdOrPath, caption = '') {
+  const isFilePath = mediaIdOrPath.includes('/') || mediaIdOrPath.includes('\\');
+  if (!isFilePath) {
+    logToFile(
+      '❌ Discord: sendImage was given a Meta media ID, not a file path/URL — Discord has no reusable '
+      + 'media-ID upload step, so cached-ID reuse is not supported on this channel',
+      { mediaIdOrPath }
+    );
+    return false;
+  }
+  try {
+    const buffer = fs.readFileSync(mediaIdOrPath);
+    return await sendFile(to, buffer, path.basename(mediaIdOrPath), caption);
+  } catch (error) {
+    logToFile('❌ Discord: error sending image', { ...discordErrorDetail(error) });
+    return false;
+  }
+}
+
+async function sendSticker(to, mediaIdOrPath) {
+  const isFilePath = mediaIdOrPath.includes('/') || mediaIdOrPath.includes('\\');
+  if (!isFilePath) {
+    logToFile('❌ Discord: sendSticker was given a Meta media ID, not a file path — not supported on this channel', { mediaIdOrPath });
+    return false;
+  }
+  if (!fs.existsSync(mediaIdOrPath)) {
+    logToFile('Sticker file not found — skipping sticker send (cosmetic)', { path: mediaIdOrPath });
+    return false;
+  }
+  try {
+    const buffer = fs.readFileSync(mediaIdOrPath);
+    return await sendFile(to, buffer, path.basename(mediaIdOrPath));
+  } catch (error) {
+    logToFile('❌ Discord: error sending sticker', { ...discordErrorDetail(error) });
+    return false;
+  }
+}
+
+// ── Real interactive components ──────────────────────────────────────────────
+// Unlike Baileys, these are genuine native components, not a text
+// degradation — a button's `customId` carries the exact `id` Meta's
+// button_reply would have used, and discord-events.adapter.js reads it
+// straight off the interaction with no menu-bookkeeping needed.
+
+async function sendInteractiveButtons(to, options) {
+  try {
+    // eslint-disable-next-line global-require -- lazy, matching this file's other lazy discord.js requires
+    const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+    const user = await getDiscordUser(discordUserId(to));
+    const { body, buttons } = options;
+
+    const row = new ActionRowBuilder().addComponents(
+      buttons.slice(0, 5).map((btn) => new ButtonBuilder()
+        .setCustomId(btn.id)
+        .setLabel(btn.title.substring(0, 80))
+        .setStyle(ButtonStyle.Primary))
+    );
+    await user.send({ content: body, components: [row] });
+    return true;
+  } catch (error) {
+    logToFile('❌ Discord: error sending interactive buttons', { ...discordErrorDetail(error) });
+    return false;
+  }
+}
+
+async function sendImageWithButtons(to, imageUrl, bodyText, buttons) {
+  try {
+    // eslint-disable-next-line global-require -- lazy, matching this file's other lazy discord.js requires
+    const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+    const user = await getDiscordUser(discordUserId(to));
+    const buffer = await resolveMediaBuffer(imageUrl);
+
+    const row = new ActionRowBuilder().addComponents(
+      buttons.slice(0, 5).map((btn) => new ButtonBuilder()
+        .setCustomId(btn.id)
+        .setLabel(btn.title.substring(0, 80))
+        .setStyle(ButtonStyle.Primary))
+    );
+    // Unlike Slack (files can't carry inline block actions, forcing a
+    // two-message split), Discord CAN attach components to a message that
+    // also has file attachments — a real simplification over Slack's design.
+    await user.send({ content: bodyText, files: [{ attachment: buffer, name: 'image.png' }], components: [row] });
+    return true;
+  } catch (error) {
+    logToFile('❌ Discord: error sending image with buttons', { ...discordErrorDetail(error), imageUrl });
+    return false;
+  }
+}
+
+async function sendInteractiveMessage(to, listData) {
+  try {
+    // eslint-disable-next-line global-require -- lazy, matching this file's other lazy discord.js requires
+    const { ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+    const user = await getDiscordUser(discordUserId(to));
+    const { header, body, footer, action } = listData;
+    const { sections } = action || {};
+    const options = (sections || []).flatMap((s) => s.rows || []);
+
+    if (!options.length) {
+      logToFile('⚠️ Discord: no options provided for interactive list', { listData });
+      return false;
+    }
+
+    const headerText = header?.text || header;
+    const bodyText = body?.text || body;
+    const footerText = footer?.text || footer;
+
+    // Discord's StringSelectMenu caps at 25 options (Slack's static_select
+    // caps at 100) — every existing call site here (feature menu = 5, style
+    // picker = 4, language picker <= 10) already fits under 25 with zero
+    // chunking needed. Larger option sets (the 164-country picker) use the
+    // dedicated 2-step chunked flow in discord-modal-flow.js instead of this
+    // generic method.
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId('list_select')
+      .setPlaceholder((action?.button || 'Choose an option').slice(0, 150))
+      .addOptions(options.slice(0, 25).map((opt) => ({
+        label: String(opt.title).slice(0, 100),
+        value: String(opt.id),
+      })));
+    const row = new ActionRowBuilder().addComponents(menu);
+
+    const content = [headerText, bodyText, footerText].filter(Boolean).join('\n\n')
+      || 'Please choose an option';
+    await user.send({ content, components: [row] });
+    return true;
+  } catch (error) {
+    logToFile('❌ Discord: error sending interactive list', { ...discordErrorDetail(error) });
+    return false;
+  }
+}
+
+async function sendLanguageSelectionList(to, currentLanguage = 'en', region = null) {
+  // eslint-disable-next-line global-require -- lazy, matching slack-channel.service.js's convention
+  const { LANGUAGES, SUPPORTED_LANGUAGES } = require('../../config/supported-languages');
+
+  const DEFAULT_PICKER_CODES = ['en', 'ur', 'pa-PK', 'sd-PK', 'ps-PK', 'bal-PK', 'ta-LK', 'ar', 'es'];
+  let codes = DEFAULT_PICKER_CODES;
+  try {
+    // eslint-disable-next-line global-require -- lazy: avoids a DB-backed service on module load
+    const RegionFeaturesService = require('../region-features.service');
+    const feats = await RegionFeaturesService.getRegionFeatures(region);
+    const fromRegion = Array.isArray(feats.supported_languages)
+      ? feats.supported_languages.filter((c) => SUPPORTED_LANGUAGES.includes(c))
+      : [];
+    if (fromRegion.length > 1) codes = fromRegion;
+  } catch (error) {
+    logToFile('Discord language picker: region lookup failed, using default set', { error: error.message });
+  }
+
+  const rows = [
+    { id: 'lang_auto', title: 'Auto-detect' },
+    ...codes.map((code) => ({ id: `lang_${code}`, title: LANGUAGES[code]?.native || code })),
+  ];
+
+  return sendInteractiveMessage(to, {
+    header: 'Select Language',
+    body: 'Choose your preferred language. I will respond in this language for all conversations.',
+    footer: 'You can change this anytime by typing /language',
+    action: { button: 'Languages', sections: [{ title: 'Available Languages', rows }] },
+  });
+}
+
+const STYLE_OPTIONS = [
+  { id: 'style_photorealistic', title: 'Photorealistic' },
+  { id: 'style_infographic', title: 'Infographic' },
+  { id: 'style_cartoon', title: 'Cartoon' },
+  { id: 'style_sketch', title: 'Sketch' },
+];
+
+async function sendStyleListFallback(to) {
+  return sendInteractiveMessage(to, {
+    header: '🎨 Choose Video Style',
+    action: { button: 'View Styles', sections: [{ title: 'Video Styles', rows: STYLE_OPTIONS }] },
+  });
+}
+
+const FEATURE_MENU_OPTIONS = [
+  { id: 'menu_lesson_plan', title: 'Lesson Plans' },
+  { id: 'menu_coaching', title: 'Classroom Coaching' },
+  { id: 'menu_reading', title: 'Reading Assessment' },
+  { id: 'menu_video', title: 'AI Video Generation' },
+  { id: 'menu_other', title: 'Ask Anything' },
+];
+
+async function sendFeatureMenuListFallback(to) {
+  return sendInteractiveMessage(to, {
+    header: "Here's what I can do!",
+    action: { button: 'View Features', sections: [{ title: 'My Features', rows: FEATURE_MENU_OPTIONS }] },
+  });
+}
+
+function notSupportedMessage(methodName) {
+  return `Discord channel driver: ${methodName}() has no equivalent yet — it needs the channel-agnostic `
+    + 'template registry from docs/onboarding/sandbox-production-design.md §1, which is not built. '
+    + 'The template\'s static wording lives only in Meta\'s registered config, not in this call\'s arguments.';
+}
+
+/**
+ * The Flow-equivalent (modal-workaround flows) lives in discord-modal-flow.js
+ * as a SEPARATE renderer, not inside this driver — matching Slack's own
+ * design decision. sendFlow() itself stays an honest stub here so any caller
+ * still branching on its Meta-shaped return value degrades safely rather
+ * than throwing.
+ */
+async function sendFlow() {
+  logToFile('Discord channel driver: sendFlow() has no direct equivalent — Flow-shaped forms render as a '
+    + 'modal-workaround flow via discord-modal-flow.js, triggered by a button click, not by this call.');
+  return false;
+}
+
+// ── Explicit method table ────────────────────────────────────────────────────
+// Every parsed member (see MEMBERS above) must appear in exactly one of these
+// two tables, checked by the assertion loop below.
+
+const IMPLEMENTATIONS = {
+  _removeEmotionTags: removeEmotionTags,
+  sendMessage,
+  sendReaction,
+  showTypingIndicator,
+  startContinuousTypingIndicator,
+  getMediaInfo,
+  downloadMedia,
+  sendDocument,
+  sendAudio,
+  sendDocumentFromUrl,
+  sendAudioFromUrl,
+  sendTextReturningId,
+  sendAudioFromUrlReturningId,
+  sendImageFromUrl,
+  sendVideo,
+  sendVideoFromUrl,
+  sendImage,
+  sendSticker,
+  sendInteractiveButtons,
+  sendImageWithButtons,
+  sendInteractiveMessage,
+  sendLanguageSelectionList,
+  sendStyleListFallback,
+  sendFeatureMenuListFallback,
+  sendFlow,
+};
+
+// name -> whether the real (Meta) method is async, so the stub shape matches.
+const STUBS = {
+  sendTemplate: true,
+  sendStyleCarousel: true,
+  sendFeatureMenuCarousel: true,
+  buildStyleCarouselPayload: false,
+  buildFeatureMenuCarouselPayload: false,
+};
+
+function asyncFalseStub(methodName) {
+  return async function discordStub(...args) {
+    logToFile(notSupportedMessage(methodName), { methodName, driver: 'discord' });
+    return false;
+  };
+}
+
+function syncNullStub(methodName) {
+  return function discordSyncStub(...args) {
+    logToFile(notSupportedMessage(methodName), { methodName, driver: 'discord' });
+    return null;
+  };
+}
+
+const DiscordChannel = {};
+
+for (const { name, isAsync } of MEMBERS) {
+  if (Object.prototype.hasOwnProperty.call(IMPLEMENTATIONS, name)) {
+    DiscordChannel[name] = IMPLEMENTATIONS[name];
+  } else if (Object.prototype.hasOwnProperty.call(STUBS, name)) {
+    const stubIsAsync = STUBS[name];
+    if (stubIsAsync !== isAsync) {
+      throw new Error(
+        `discord-channel.service.js: "${name}" is registered as ${stubIsAsync ? 'async' : 'sync'} in STUBS but `
+        + `meta-channel.service.js now declares it ${isAsync ? 'async' : 'sync'} — update STUBS to match.`
+      );
+    }
+    DiscordChannel[name] = stubIsAsync ? asyncFalseStub(name) : syncNullStub(name);
+  } else {
+    throw new Error(
+      `discord-channel.service.js: meta-channel.service.js declares "${name}" with no matching entry in `
+      + 'IMPLEMENTATIONS or STUBS. Add one so this driver never silently lacks a method the rest of the bot calls.'
+    );
+  }
+}
+
+DiscordChannel._discordUserId = discordUserId;
+DiscordChannel._getDiscordUser = getDiscordUser;
+DiscordChannel._cacheIncomingMedia = cacheIncomingMedia;
+
+module.exports = DiscordChannel;

--- a/bot/shared/services/messaging/discord-channel.service.js
+++ b/bot/shared/services/messaging/discord-channel.service.js
@@ -203,6 +203,14 @@ async function sendTextReturningId(to, message, opts = {}) {
 }
 
 async function sendReaction(to, messageId, emoji = '❤️') {
+  // Slash-command interactions have no real Discord message to react to —
+  // the inbound adapter mints a synthetic "slash-<timestamp>-<userId>" id
+  // for them (discord-events.adapter.js), which Discord's API rejects with
+  // a "not snowflake" Invalid Form Body error on every single slash command.
+  // Confirmed live, not a guess: harmless (caught, returns false either way)
+  // but a wasted round-trip and a scary-looking error log on every command.
+  if (!/^\d+$/.test(String(messageId))) return false;
+
   try {
     const user = await getDiscordUser(discordUserId(to));
     const dmChannel = user.dmChannel || await user.createDM();

--- a/bot/shared/services/messaging/discord-connection.js
+++ b/bot/shared/services/messaging/discord-connection.js
@@ -1,0 +1,176 @@
+/**
+ * Discord connection manager — the ONE place that owns the persistent
+ * Discord Gateway (WebSocket) connection. Mirrors baileys-connection.js's
+ * role (a single shared connection, exposed via getClient()) but is much
+ * simpler: Discord has no auth-folder/QR/multi-file-session-state concept at
+ * all — it's just "token in, Client out". discord-channel.service.js (the
+ * outbound driver) and discord-events.adapter.js (the inbound listener) both
+ * share this ONE client instance; a second `new Client()` for the same bot
+ * token would open a second Gateway connection, which is undefined/broken
+ * behaviour, not just wasteful (unlike Slack's stateless WebClient, which is
+ * safe to construct fresh per-process since Slack has no persistent
+ * connection to share).
+ *
+ * `discord.js` is loaded LAZILY, inside connect(), matching this repo's
+ * existing lazy-client convention (see baileys-connection.js's own header
+ * comment, and shared/storage/r2.js's lazyClient) — requiring this file
+ * never touches the real `discord.js` package or opens a socket; only
+ * connect()/getClient() do.
+ *
+ * `events` is the one place to observe connection lifecycle, mirroring
+ * baileys-connection.js's own `events` emitter.
+ */
+
+const EventEmitter = require('events');
+const { logToFile } = require('../../utils/logger');
+
+let client = null;
+let clientPromise = null;
+const events = new EventEmitter();
+const connectionState = { connected: false };
+
+// Set by close() so a Gateway close/error firing during intentional shutdown
+// is not mistaken for a real problem worth logging loudly — mirrors
+// baileys-connection.js's own `shuttingDown` flag.
+let shuttingDown = false;
+
+/**
+ * Builds a fresh, not-yet-logged-in Client with the intents this bot needs:
+ * Guilds (required for the client to function at all), GuildMessages (guild
+ * text channels, not used today but harmless/cheap to keep), DirectMessages
+ * (the bot's actual primary surface — teachers DM the bot), and MessageContent
+ * (a PRIVILEGED intent — see the file-level operational note below).
+ *
+ * `partials: [Channel, Message]` is required for DM `messageCreate` events to
+ * fire reliably: a DM channel discord.js hasn't already cached arrives as a
+ * "partial" structure unless these are declared, and Gateway events for
+ * partial structures are silently dropped without them.
+ */
+function buildClient() {
+  // eslint-disable-next-line global-require -- lazy on purpose, see file header
+  const { Client, GatewayIntentBits, Partials } = require('discord.js');
+  return new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.DirectMessages,
+      GatewayIntentBits.MessageContent,
+    ],
+    partials: [Partials.Channel, Partials.Message],
+  });
+}
+
+/**
+ * @returns {Promise<import('discord.js').Client>} resolves once the Gateway
+ *   connection is actually up (the 'clientReady' event — NOT 'ready', which
+ *   discord.js renamed; verified against the installed discord.js@14.27.0).
+ */
+async function connect() {
+  const token = process.env.DISCORD_BOT_TOKEN;
+  if (!token) {
+    throw new Error('Discord connection: DISCORD_BOT_TOKEN is not set');
+  }
+
+  // eslint-disable-next-line global-require -- lazy, see file header
+  const { Events } = require('discord.js');
+
+  const freshClient = buildClient();
+
+  freshClient.on(Events.Error, (error) => {
+    logToFile('⚠️ Discord: client error', { error: error.message });
+  });
+
+  // Discord's analogue of a Baileys "connection closed" — a shard's Gateway
+  // websocket dropped. discord.js's own internal reconnect logic runs for
+  // recoverable closes; this listener is purely observational (mirrors
+  // baileys-connection.js's `events.emit('close', ...)`), not something that
+  // manually re-drives a reconnect the way Baileys' own `connection.update`
+  // handler does — discord.js owns that internally.
+  freshClient.on(Events.ShardDisconnect, (event, shardId) => {
+    connectionState.connected = false;
+    logToFile('⚠️ Discord: shard disconnected', { code: event?.code, shardId, shuttingDown });
+    events.emit('close', { code: event?.code, shuttingDown });
+  });
+
+  freshClient.on(Events.ShardReconnecting, (shardId) => {
+    logToFile('🔄 Discord: shard reconnecting', { shardId });
+  });
+
+  freshClient.on(Events.ShardResume, (shardId) => {
+    connectionState.connected = true;
+    logToFile('✅ Discord: shard resumed', { shardId });
+    events.emit('open');
+  });
+
+  return new Promise((resolve, reject) => {
+    freshClient.once(Events.ClientReady, () => {
+      client = freshClient;
+      connectionState.connected = true;
+      logToFile('✅ Discord: connected', { tag: freshClient.user?.tag });
+      events.emit('open');
+      resolve(freshClient);
+    });
+
+    // A bad/revoked token surfaces HERE, as a login rejection — there is no
+    // Baileys-style mid-session "you have been logged out" event for a bot
+    // token; see this module's close()/PERSISTENT_CONNECTION_DRIVERS notes.
+    freshClient.login(token).catch((error) => {
+      logToFile('❌ Discord: login failed — check DISCORD_BOT_TOKEN', { error: error.message });
+      reject(error);
+    });
+  });
+}
+
+/**
+ * Lazily connects on first call; subsequent calls reuse the same connection.
+ * Resolves once the Gateway is actually ready — mirrors baileys-connection.js's
+ * getSocket() resolution semantics exactly (never resolve before real work
+ * can happen on the returned client).
+ *
+ * @returns {Promise<import('discord.js').Client>}
+ */
+function getClient() {
+  if (!clientPromise) clientPromise = connect();
+  return clientPromise;
+}
+
+function isConnected() {
+  return connectionState.connected;
+}
+
+/**
+ * Closes the Gateway connection cleanly. Unlike Baileys' close() (which
+ * disconnects WITHOUT logging out, preserving the pairing), there is no
+ * "logout" concept for a bot token at all — client.destroy() is simply a
+ * clean disconnect; nothing about it invalidates DISCORD_BOT_TOKEN.
+ */
+async function close() {
+  shuttingDown = true;
+  if (client) {
+    try {
+      await client.destroy();
+    } catch (error) {
+      logToFile('Discord: destroy error (ignored)', { error: error.message });
+    }
+  }
+  client = null;
+  clientPromise = null;
+  connectionState.connected = false;
+}
+
+/** Test-only: forces the next getClient() call to reconnect from scratch. */
+function _resetForTests() {
+  client = null;
+  clientPromise = null;
+  connectionState.connected = false;
+  shuttingDown = false;
+  events.removeAllListeners();
+}
+
+module.exports = {
+  getClient,
+  isConnected,
+  close,
+  events,
+  _resetForTests,
+};

--- a/bot/shared/services/messaging/discord-modal-flow.js
+++ b/bot/shared/services/messaging/discord-modal-flow.js
@@ -309,6 +309,21 @@ function buildEndpointModal(config) {
       let enumAnswers = {};
       let ackInteraction = triggerInteraction;
       if (steps.length) {
+        // collectEnumAnswers below sends a BRAND NEW message and awaits a
+        // component click on that, never touching triggerInteraction again —
+        // left un-acked, it silently fails Discord's ~3s window and the
+        // teacher sees "Rumi didn't respond in time" on every flow start,
+        // even though the flow itself keeps working underneath. Confirmed
+        // live, not a guess: this ack must happen here, immediately.
+        //
+        // Guarded: runScreen() is also reached via _advance() with an
+        // ALREADY-acked interaction (e.g. a just-submitted modal, deferred by
+        // handleModalSubmit before calling _advance) — calling deferUpdate()
+        // again there throws DiscordjsError[InteractionAlreadyReplied].
+        // Also confirmed live, immediately after fixing the bug above.
+        if (!triggerInteraction.replied && !triggerInteraction.deferred) {
+          await triggerInteraction.deferUpdate();
+        }
         const user = await triggerInteraction.client.users.fetch(ctx.discordUserId);
         const collected = await collectEnumAnswers(user, steps);
         if (!collected) return 'timed_out';

--- a/bot/shared/services/messaging/discord-modal-flow.js
+++ b/bot/shared/services/messaging/discord-modal-flow.js
@@ -1,0 +1,434 @@
+/**
+ * Discord modal-workaround renderer — the Flow-equivalent for Discord, but
+ * shaped very differently from slack-modal-flow.js because of one hard
+ * platform constraint: a Discord Modal (an interaction response of type
+ * MODAL) may contain ONLY text inputs — no select menus, no buttons, no
+ * checkboxes, ever. Slack's Block Kit modals can render an entire screen's
+ * fields (selects included) in one shot; Discord cannot.
+ *
+ * The workaround, in two stages per screen:
+ *   1. Enum fields are collected via ORDINARY chat messages carrying real
+ *      select-menu components (Discord DOES support these outside a modal —
+ *      the same "genuine native interactivity, not a text degradation"
+ *      property Slack's Block Kit has). One message per field (or per
+ *      interaction round-trip, for a dependent 2-step field like the
+ *      country/region picker), awaited via awaitMessageComponent.
+ *   2. Once every enum field is answered, a REAL modal opens containing only
+ *      whatever free-text fields remain (if any) — screens with zero
+ *      enum fields (e.g. "add student": first_name/last_name) skip stage 1
+ *      entirely; screens with zero remaining text fields (e.g. Discord's
+ *      settings screen: language + framework, both selects) skip the modal
+ *      entirely and call exchange() directly after stage 1.
+ *
+ * Like Slack, this calls a *-endpoint.js's own {init, exchange, back}
+ * functions directly — the same "the endpoint is the renderer-agnostic
+ * source of truth" insight, just with a two-stage renderer on top instead
+ * of Slack's one-shot view.
+ *
+ * State-carrying — the one piece with no Slack equivalent needed: Slack's
+ * `private_metadata` (up to 3000 chars, round-tripped automatically by
+ * Slack on every view interaction) has no Discord analogue for a modal —
+ * Discord's modal `customId` caps at 100 characters, nowhere near enough for
+ * a JSON blob of {kind, screen, flowToken, collectedEnumAnswers}. So real
+ * state is stored in Redis (via railway-redis.service.js, the same service
+ * already used elsewhere in this codebase) under a short opaque token; the
+ * modal's customId becomes just "<kind>:<token>". A short TTL (5 minutes) is
+ * generous enough to fill a form but short enough that an abandoned flow's
+ * Redis key self-cleans without a background sweep.
+ */
+
+const crypto = require('crypto');
+const { logToFile } = require('../../utils/logger');
+const redisService = require('../cache/railway-redis.service');
+
+const STATE_KEY_PREFIX = 'discord_modal:';
+const STATE_TTL_SECONDS = 300;
+
+// Message ids that currently have an active collectEnumAnswers() collector
+// awaiting a reply. Confirmed against the installed discord.js@14.27.0's own
+// source (node_modules/discord.js/src/structures/InteractionCollector.js:120):
+// Message#awaitMessageComponent's collector subscribes to Events.InteractionCreate
+// on the SAME client discord-connection.js owns — Node's EventEmitter invokes
+// EVERY listener for an event, not just one, so a matching interaction fires
+// BOTH this collector's internal listener AND discord-events.adapter.js's own
+// global interactionCreate listener, with no built-in "claiming" between them.
+// discord-modal-interactions.handler.js#tryHandleCollected consults this set
+// so that global listener can skip an interaction the collector below is
+// already about to read and ack itself. Purely in-process (like
+// discord-events.adapter.js's own dedup map) — a restart simply drops any
+// in-flight collector, matching how a restart already drops Slack's own
+// in-flight modal state (Redis TTL aside).
+const activeCollectorMessageIds = new Set();
+
+/** discord-modal-interactions.handler.js#tryHandleCollected's read of the set above. */
+function isCollectorActiveForMessage(messageId) {
+  return Boolean(messageId && activeCollectorMessageIds.has(messageId));
+}
+
+function isTerminalScreen(screen) {
+  return screen === 'SUCCESS';
+}
+
+function mintToken() {
+  return crypto.randomBytes(8).toString('hex'); // 16 hex chars — well under the 100-char customId cap alongside a "<kind>:" prefix
+}
+
+/** Stores modal state under a fresh short token, returning that token for use in a modal's customId. */
+async function storeModalState(state) {
+  const token = mintToken();
+  await redisService.set(`${STATE_KEY_PREFIX}${token}`, state, STATE_TTL_SECONDS);
+  return token;
+}
+
+/** Recovers the state a storeModalState() call saved. redisService.get already JSON-parses; null if expired/missing. */
+async function loadModalState(token) {
+  return redisService.get(`${STATE_KEY_PREFIX}${token}`);
+}
+
+/** Explicitly clears state once consumed, rather than waiting out the TTL. */
+async function deleteModalState(token) {
+  await redisService.delete(`${STATE_KEY_PREFIX}${token}`);
+}
+
+const LOOP_STATE_KEY_PREFIX = 'discord_modal_loop:';
+
+/**
+ * Stores a loop screen's response {screen, data} keyed by flowToken (not a
+ * fresh token — a later "Add Another"/"I'm Done" BUTTON click needs to look
+ * this up by the flowToken it already carries in its own customId, unlike a
+ * modal submission which decodes its token straight off the customId).
+ * Used by config.onScreenLoop's caller (e.g. discord-flow-registry.js's
+ * attendance registration) to resume runScreen()/exchange() on the next
+ * button click, since nothing else keeps this response alive between the
+ * loop message being sent and the teacher's next action.
+ */
+async function storeLoopScreenData(flowToken, screen, data) {
+  await redisService.set(`${LOOP_STATE_KEY_PREFIX}${flowToken}`, { screen, data }, STATE_TTL_SECONDS);
+}
+
+async function loadLoopScreenData(flowToken) {
+  return redisService.get(`${LOOP_STATE_KEY_PREFIX}${flowToken}`);
+}
+
+async function deleteLoopScreenData(flowToken) {
+  await redisService.delete(`${LOOP_STATE_KEY_PREFIX}${flowToken}`);
+}
+
+/** Builds the "<kind>:<token>" customId a modal/select menu carries, and splits it back apart on submission. */
+function encodeCustomId(kind, token) {
+  return `${kind}:${token}`;
+}
+
+function decodeCustomId(customId) {
+  const idx = String(customId || '').indexOf(':');
+  if (idx === -1) return { kind: null, token: null };
+  return { kind: customId.slice(0, idx), token: customId.slice(idx + 1) };
+}
+
+/**
+ * Sends ONE OR MORE select-menu messages — one per enum field, or one per
+ * interaction round-trip for a dependent multi-step field (e.g. the
+ * country/region picker: pick a region, THEN pick a country within it) —
+ * collecting each answer via awaitMessageComponent before sending the next.
+ *
+ * Every step EXCEPT THE LAST is acked here (deferUpdate()) once its answer
+ * is read, since another select-menu message follows immediately. The LAST
+ * step's interaction is deliberately left UN-acked and returned to the
+ * caller: if a modal follows, interaction.showModal() must be THAT
+ * interaction's own direct acknowledgment (it cannot follow a prior
+ * deferUpdate() on the same interaction) — see openTextFieldsModal's own
+ * doc comment. A caller with no modal to show (an all-enum screen) must ack
+ * it itself (deferUpdate()) before calling exchange().
+ *
+ * @param {import('discord.js').User} user
+ * @param {Array<{
+ *   fieldName: string,
+ *   promptText: string,
+ *   buildMenu: (answersSoFar: object) => import('discord.js').StringSelectMenuBuilder,
+ *   multi?: boolean,
+ * }>} steps - `multi: true` reads ALL selected values (a real multi-select field, e.g. "subjects"); otherwise only the first.
+ * @param {number} [timeoutMs=120000] - how long to wait for each step's reply
+ * @returns {Promise<{answers: object, lastInteraction: import('discord.js').StringSelectMenuInteraction}|null>}
+ *   null if any step timed out
+ */
+async function collectEnumAnswers(user, steps, timeoutMs = 120_000) {
+  // eslint-disable-next-line global-require -- lazy: avoids requiring discord.js at module load
+  const { ActionRowBuilder } = require('discord.js');
+  const answers = {};
+  const dmChannel = user.dmChannel || await user.createDM();
+  let lastInteraction = null;
+
+  for (let i = 0; i < steps.length; i += 1) {
+    const step = steps[i];
+    const menu = step.buildMenu(answers);
+    const row = new ActionRowBuilder().addComponents(menu);
+    // eslint-disable-next-line no-await-in-loop -- each step depends on the previous answer, must be sequential
+    const sent = await dmChannel.send({ content: step.promptText, components: [row] });
+    activeCollectorMessageIds.add(sent.id);
+
+    let interaction;
+    try {
+      // eslint-disable-next-line no-await-in-loop -- see above
+      interaction = await sent.awaitMessageComponent({ time: timeoutMs });
+    } catch (error) {
+      logToFile('ℹ️ Discord modal-flow: enum-collection step timed out', { fieldName: step.fieldName });
+      return null;
+    } finally {
+      activeCollectorMessageIds.delete(sent.id);
+    }
+
+    answers[step.fieldName] = step.multi ? interaction.values : interaction.values?.[0];
+
+    const isLastStep = i === steps.length - 1;
+    if (isLastStep) {
+      lastInteraction = interaction; // left un-acked — see doc comment above
+    } else {
+      // eslint-disable-next-line no-await-in-loop -- see above
+      await interaction.deferUpdate();
+    }
+  }
+
+  return { answers, lastInteraction };
+}
+
+/**
+ * Opens the modal for whatever free-text fields remain, stashing the
+ * already-collected enum answers (plus kind/screen/flowToken) under a
+ * short Redis-backed token carried in the modal's customId.
+ *
+ * MUST be called as the direct, synchronous acknowledgment of the
+ * triggering interaction — interaction.showModal() cannot follow a prior
+ * deferReply()/deferUpdate() on the SAME interaction. Every caller here is
+ * itself the last enum-collection step's interaction, or a plain button
+ * click for a screen with no enum fields at all — never a re-used stale one.
+ *
+ * @param {object} args
+ * @param {import('discord.js').Interaction} args.interaction - must support showModal()
+ * @param {string} args.kind
+ * @param {string} args.screen
+ * @param {string} args.flowToken
+ * @param {object} args.collectedEnumAnswers
+ * @param {object} args.carriedData - this screen's own init()/exchange() response data, round-tripped
+ *   back to mergeScreenData() on submission — carries fields like attendance's
+ *   `_list_id`/`_class_display` that aren't collected from the teacher at all,
+ *   just threaded through from the previous screen's response.
+ * @param {Array<{name: string, label: string, multiline?: boolean, required?: boolean}>} args.textFields
+ * @param {string} args.title
+ */
+async function openTextFieldsModal({ interaction, kind, screen, flowToken, collectedEnumAnswers, carriedData, textFields, title }) {
+  // eslint-disable-next-line global-require -- lazy: avoids requiring discord.js at module load
+  const { ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } = require('discord.js');
+
+  const token = await storeModalState({ kind, screen, flowToken, collectedEnumAnswers, carriedData });
+  const modal = new ModalBuilder().setCustomId(encodeCustomId(kind, token)).setTitle(title.slice(0, 45));
+
+  for (const field of textFields) {
+    const input = new TextInputBuilder()
+      .setCustomId(field.name)
+      .setLabel(field.label.slice(0, 45))
+      .setStyle(field.multiline ? TextInputStyle.Paragraph : TextInputStyle.Short)
+      .setRequired(Boolean(field.required));
+    modal.addComponents(new ActionRowBuilder().addComponents(input));
+  }
+
+  await interaction.showModal(modal);
+}
+
+/**
+ * Reads every TextInputComponent's value off a submitted modal interaction,
+ * keyed by the customId each field was given in openTextFieldsModal.
+ * @param {import('discord.js').ModalSubmitInteraction} interaction
+ * @returns {object}
+ */
+function readModalTextAnswers(interaction) {
+  const answers = {};
+  for (const [customId, component] of interaction.fields.fields) {
+    answers[customId] = component.value;
+  }
+  return answers;
+}
+
+/**
+ * @param {object} config
+ * @param {string} config.kind - registry key, e.g. 'registration'
+ * @param {(ctx: object) => Promise<{screen: string, data: object}>} config.init
+ * @param {(ctx: object, screen: string, screenData: object) => Promise<{screen: string, data: object} | {data: {error: {message: string}}}>} config.exchange
+ * @param {(ctx: object, screen: string) => Promise<{screen: string, data: object}>} [config.back]
+ * @param {(screen: string, data: object) => {steps: Array, textFields: Array, title: string}} config.screenToSteps -
+ *   returns this screen's collectEnumAnswers `steps` (empty array if none) and remaining `textFields` (empty array if none)
+ * @param {(screen: string, enumAnswers: object, modalAnswers: object, carriedData: object) => object} config.mergeScreenData -
+ *   combines the collected enum/text answers into the single screenData object exchange() expects.
+ *   `carriedData` is this screen's own init()/exchange() response `data` — for fields that aren't
+ *   collected from the teacher at all, just threaded through unchanged (e.g. attendance's
+ *   `_list_id`/`_class_display`/`_action`); most views ignore this 4th argument entirely.
+ * @param {(response: {screen: string, data: object}, ctx: object) => Promise<void>} [config.onFinish] - called once, on the terminal screen
+ * @param {Set<string>} [config.loopScreens] - screen names that re-visit themselves in a loop
+ *   (e.g. attendance's ADD_STUDENT, added again each time a student is added) where the DEFAULT
+ *   auto-recursion into runScreen() is WRONG: it would immediately reopen a modal reusing an
+ *   already-acked interaction, which Discord's showModal() forbids (it must be a fresh
+ *   interaction's direct ack, never following a prior deferUpdate()). When exchange() returns a
+ *   screen in this set, config.onScreenLoop is called INSTEAD of recursing.
+ * @param {(response: {screen: string, data: object}, ctx: object) => Promise<void>} [config.onScreenLoop] -
+ *   called for a loopScreens screen instead of auto-recursing — e.g. attendance's Discord view
+ *   sends a fresh "Add Another / I'm Done" button message rather than reopening the modal outright.
+ */
+function buildEndpointModal(config) {
+  const { kind, init, exchange, back, screenToSteps, mergeScreenData, onFinish, loopScreens, onScreenLoop } = config;
+
+  if (!kind || typeof init !== 'function' || typeof exchange !== 'function'
+      || typeof screenToSteps !== 'function' || typeof mergeScreenData !== 'function') {
+    throw new Error('discord-modal-flow: buildEndpointModal needs { kind, init, exchange, screenToSteps, mergeScreenData }');
+  }
+
+  return {
+    kind,
+
+    /**
+     * Runs a screen end-to-end: collects any enum fields via chat messages,
+     * then either opens a modal for the remaining text fields (if any) or —
+     * for an all-enum screen like Discord's settings — acks, calls
+     * exchange(), and recurses into the NEXT screen directly (there is no
+     * other driver advancing a Discord flow screen-to-screen the way Slack's
+     * view_submission naturally does one view at a time).
+     *
+     * The interaction ultimately used to ack (either by showing a modal or
+     * by deferUpdate()+exchange()) is always the LAST one reached: the final
+     * enum step's own interaction if this screen has any enum fields, or the
+     * original trigger interaction if it has none at all (e.g. "add student",
+     * whose fields are pure text).
+     *
+     * @param {object} ctx - {userId, discordUserId, flowToken}
+     * @param {import('discord.js').Interaction} triggerInteraction - the button/select/modal-submit interaction that reached this screen
+     * @param {string} screen
+     * @param {object} data - this screen's init()/exchange() response data
+     * @returns {Promise<'awaiting_modal'|'finished'|'timed_out'>}
+     */
+    async runScreen(ctx, triggerInteraction, screen, data) {
+      const { steps, textFields, title } = screenToSteps(screen, data);
+
+      let enumAnswers = {};
+      let ackInteraction = triggerInteraction;
+      if (steps.length) {
+        const user = await triggerInteraction.client.users.fetch(ctx.discordUserId);
+        const collected = await collectEnumAnswers(user, steps);
+        if (!collected) return 'timed_out';
+        enumAnswers = collected.answers;
+        ackInteraction = collected.lastInteraction; // left un-acked by collectEnumAnswers, ready for either path below
+      }
+
+      if (!textFields.length) {
+        // No free text left on this screen — ack the last interaction
+        // ourselves (no modal to ack it) and go straight to exchange().
+        await ackInteraction.deferUpdate();
+        const screenData = mergeScreenData(screen, enumAnswers, {}, data);
+        return this._advance(ctx, ackInteraction, screen, screenData);
+      }
+
+      await openTextFieldsModal({
+        interaction: ackInteraction, kind, screen, flowToken: ctx.flowToken,
+        collectedEnumAnswers: enumAnswers, carriedData: data, textFields, title,
+      });
+      return 'awaiting_modal';
+    },
+
+    /**
+     * Calls exchange() for a screen whose acknowledgment is already handled
+     * (either an all-enum screen's deferUpdate(), or a submitted modal), and
+     * either finishes the flow or recurses into runScreen() for whatever
+     * screen exchange() returns next.
+     */
+    async _advance(ctx, ackedInteraction, screen, screenData) {
+      const response = await exchange(ctx, screen, screenData);
+
+      if (response?.data?.error) {
+        logToFile('⚠️ Discord modal-flow: exchange() returned a validation error with no modal open to re-show it on', {
+          kind, screen, error: response.data.error.message,
+        });
+        return 'finished';
+      }
+      if (isTerminalScreen(response.screen)) {
+        if (onFinish) await onFinish(response, ctx);
+        return 'finished';
+      }
+      if (loopScreens && loopScreens.has(response.screen) && onScreenLoop) {
+        // Persisted BEFORE calling the hook — resumeLoopScreen() (below) is
+        // how a later "Add Another"/"I'm Done" button click continues this
+        // exact screen with its own fresh interaction, since runScreen()'s
+        // caller here (ackedInteraction, already consumed) can't be reused.
+        await storeLoopScreenData(ctx.flowToken, response.screen, response.data);
+        await onScreenLoop(response, ctx, ackedInteraction);
+        return 'awaiting_choice';
+      }
+      return this.runScreen(ctx, ackedInteraction, response.screen, response.data);
+    },
+
+    /**
+     * Resumes a loopScreens screen from a FRESH interaction (e.g. the "Add
+     * Another" button click) — recovers {screen, data} that _advance()
+     * persisted via storeLoopScreenData() right before calling onScreenLoop(),
+     * since the interaction that reached that screen has already been
+     * consumed and can't directly ack a new modal itself.
+     */
+    async resumeLoopScreen(ctx, triggerInteraction) {
+      const stored = await loadLoopScreenData(ctx.flowToken);
+      if (!stored) return 'expired';
+      await deleteLoopScreenData(ctx.flowToken);
+      return this.runScreen(ctx, triggerInteraction, stored.screen, stored.data);
+    },
+
+    /**
+     * Called from discord-modal-interactions.handler.js#triggerFlow — the
+     * Discord analogue of Slack's handleOpenModal, but there is no
+     * proactive "open a modal into someone's DM" the way Slack's trigger_id
+     * allows: this must be called as the ack of a REAL interaction (a button
+     * click on a "Get started"-style message), never invoked out of the blue.
+     */
+    async startFlow(ctx, triggerInteraction) {
+      const response = await init(ctx);
+      return this.runScreen(ctx, triggerInteraction, response.screen, response.data);
+    },
+
+    /** Called from discord-modal-interactions.handler.js#handleModalSubmit. */
+    async handleModalSubmit(interaction, state) {
+      const modalAnswers = readModalTextAnswers(interaction);
+      const ctx = { userId: state.flowToken.split(':')[0], discordUserId: interaction.user.id, flowToken: state.flowToken };
+      const screenData = mergeScreenData(state.screen, state.collectedEnumAnswers, modalAnswers, state.carriedData);
+      // A modal's own submission is itself the interaction to ack — no prior
+      // deferUpdate() needed (unlike the all-enum path in runScreen), since
+      // the modal was shown as the direct response to the PREVIOUS
+      // interaction, and submitting it is a fresh one of its own.
+      await interaction.deferUpdate();
+      return this._advance(ctx, interaction, state.screen, screenData);
+    },
+
+    /**
+     * Called from a "Back" button click — a real button, not Slack's native
+     * modal-stack pop (Discord has no modal stack at all here; every screen
+     * is its own fresh enum-collector-then-modal sequence). Re-runs the
+     * previous screen from scratch via runScreen(), the same as arriving at
+     * it forward would.
+     */
+    async handleBack(ctx, triggerInteraction, screen) {
+      if (!back) return null;
+      const response = await back(ctx, screen);
+      return this.runScreen(ctx, triggerInteraction, response.screen, response.data);
+    },
+  };
+}
+
+module.exports = {
+  buildEndpointModal,
+  collectEnumAnswers,
+  openTextFieldsModal,
+  readModalTextAnswers,
+  storeModalState,
+  loadModalState,
+  deleteModalState,
+  storeLoopScreenData,
+  loadLoopScreenData,
+  deleteLoopScreenData,
+  encodeCustomId,
+  decodeCustomId,
+  isTerminalScreen,
+  isCollectorActiveForMessage,
+};

--- a/bot/shared/services/messaging/inbound/discord-events.adapter.js
+++ b/bot/shared/services/messaging/inbound/discord-events.adapter.js
@@ -291,7 +291,9 @@ async function attach(dispatch) {
     try {
       if (interaction.isChatInputCommand?.()) {
         if (isDuplicateDelivery(interaction.id)) return;
-        await interaction.deferReply({ ephemeral: true });
+        // eslint-disable-next-line global-require -- lazy: avoids requiring discord.js at module load
+        const { MessageFlags } = require('discord.js');
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         const metaMessage = mapSlashCommandToMetaShape(interaction);
         if (metaMessage) await dispatch(buildSyntheticRequest(metaMessage), buildSyntheticResponse());
         return;

--- a/bot/shared/services/messaging/inbound/discord-events.adapter.js
+++ b/bot/shared/services/messaging/inbound/discord-events.adapter.js
@@ -1,0 +1,342 @@
+/**
+ * Discord inbound adapter — translates Gateway events into the same
+ * Meta-webhook-shaped payload bot/whatsapp-bot.js's handleWebhookPost(req, res)
+ * already parses via shared/utils/validators.js#validateWebhookMessage.
+ * Mirrors baileys-socket.adapter.js's role and shape — a parallel entry path
+ * into the existing ~1000-line dispatch logic, not a rewrite of it.
+ *
+ * Unlike Slack (pure HTTP webhook, so its adapter is a pair of Express route
+ * HANDLERS), Discord uses the Gateway (a persistent WebSocket, like Baileys)
+ * for full message support — this adapter is a long-lived event-emitter
+ * `attach(dispatch)` subscription, structurally like baileys-socket.adapter.js,
+ * not like slack-events.adapter.js's route factories.
+ *
+ * Key simplification, confirmed against discord.js@14.27.0: a bot using the
+ * Gateway (with no separate HTTP "Interactions Endpoint URL" configured in
+ * the Developer Portal) receives EVERYTHING over this one connection — plain
+ * messages via `messageCreate`, and slash commands / button+select clicks /
+ * modal submissions all via `interactionCreate`, discriminated by
+ * interaction.isChatInputCommand()/.isButton()/.isStringSelectMenu()/
+ * .isModalSubmit() type guards. There is no separate signed HTTP route to
+ * build here at all, unlike Slack's HMAC-verified /api/slack/* routes.
+ *
+ * Identity: `from` is always the PREFIXED "discord:<snowflake>" identifier
+ * (see channel-registry.js's CHANNEL_PREFIXES) — minted here, at the one
+ * place Discord identities enter the system, then carried unchanged through
+ * getOrCreateUserByChannel and every downstream send.
+ *
+ * Coverage: plain text messages, image/audio/document attachments (mapped by
+ * content-type sniffing), slash commands, and ordinary chat button/select
+ * clicks map onto Meta's shape and reach the real handlers unchanged. Modal
+ * submissions and the enum-collector's own button/select interactions are
+ * claimed FIRST by discord-modal-interactions.handler.js (a separate concern,
+ * mirroring how Slack's view_submission is handled outside this file too) —
+ * only interactions NOT claimed by that machinery fall through to the
+ * ordinary chat mapping here.
+ */
+
+const { logToFile } = require('../../../utils/logger');
+const { prefixFor } = require('../channel-registry');
+
+const DISCORD_PREFIX = prefixFor('discord');
+// A stable, non-test, non-zero entry id — passes validators.isTestWebhook().
+const SYNTHETIC_ENTRY_ID = 'discord-gateway';
+
+function toPrefixedIdentity(snowflake) {
+  return `${DISCORD_PREFIX}:${snowflake}`;
+}
+
+// Media ids need the same "discord:" prefix as user identities — messaging/index.js's
+// router (channel-registry.js#driverForIdentifier) dispatches getMediaInfo/downloadMedia
+// calls by inspecting the id argument itself for a channel prefix. A bare Discord
+// attachment id (e.g. a snowflake) has no colon, so without this prefix those calls
+// would silently fall through to the WhatsApp-family driver instead of Discord's.
+// discord-channel.service.js strips this same prefix before reading its media cache.
+function toPrefixedMediaId(attachmentId) {
+  return `${DISCORD_PREFIX}:${attachmentId}`;
+}
+
+const AUDIO_MIME_RE = /^audio\//i;
+const IMAGE_MIME_RE = /^image\//i;
+
+/**
+ * Maps a Discord message's first attachment into a Meta-shaped audio/image/
+ * document message — mirrors slack-events.adapter.js's mapFileShareToMetaShape
+ * for the same three types. Only the first attachment is handled (matching
+ * Meta's own one-attachment-per-message model), same as both other adapters.
+ *
+ * Unlike Slack/Baileys, no eager download happens here — Discord attachments
+ * carry a durable, self-describing URL at receive time (attachment.url,
+ * .contentType, .size), so only that metadata is cached (see
+ * discord-channel.service.js#getMediaInfo's own doc comment on why this
+ * differs from Slack's live files.info lookup and Baileys' eager-buffer cache).
+ *
+ * @param {import('discord.js').Message} message
+ * @param {import('discord.js').Attachment} attachment
+ * @returns {object|null} Meta-shaped message, or null to skip
+ */
+function mapAttachmentToMetaShape(message, attachment) {
+  const from = toPrefixedIdentity(message.author.id);
+  const timestamp = Math.floor(message.createdTimestamp / 1000);
+  const id = message.id;
+  const base = { from, id, timestamp };
+
+  const mediaId = toPrefixedMediaId(attachment.id);
+  const mimeType = attachment.contentType || 'application/octet-stream';
+
+  // eslint-disable-next-line global-require -- lazy: avoids a require cycle at module load
+  const discordChannel = require('../discord-channel.service');
+  discordChannel._cacheIncomingMedia(mediaId, {
+    url: attachment.url,
+    mime_type: mimeType,
+    file_size: attachment.size,
+  });
+
+  if (AUDIO_MIME_RE.test(mimeType)) {
+    return { ...base, type: 'audio', audio: { id: mediaId, mime_type: mimeType } };
+  }
+  if (IMAGE_MIME_RE.test(mimeType)) {
+    return { ...base, type: 'image', image: { id: mediaId, mime_type: mimeType, caption: message.content || '' } };
+  }
+  return {
+    ...base, type: 'document',
+    document: { id: mediaId, mime_type: mimeType, filename: attachment.name || 'file' },
+  };
+}
+
+/**
+ * Maps a Discord `messageCreate` event into Meta's message shape.
+ * Only plain user-authored DM messages are dispatchable — bot messages and
+ * non-DM channels are skipped, mirroring both other adapters' scoping to a
+ * 1:1 conversation.
+ *
+ * @param {import('discord.js').Message} message
+ * @returns {object|null} Meta-shaped message, or null to skip
+ */
+function mapMessageToMetaShape(message) {
+  if (!message || message.author?.bot) return null;
+  // Discord's DM channel type is 1 (ChannelType.DM) — scoping to DMs only,
+  // matching Slack/Baileys' own 1:1-conversation-only scope.
+  if (message.channel?.type !== 1) return null;
+
+  const attachment = message.attachments?.first?.();
+  if (attachment) return mapAttachmentToMetaShape(message, attachment);
+
+  if (!message.content) return null;
+
+  const from = toPrefixedIdentity(message.author.id);
+  const timestamp = Math.floor(message.createdTimestamp / 1000);
+
+  return {
+    from,
+    id: message.id,
+    timestamp,
+    type: 'text',
+    text: { body: message.content },
+  };
+}
+
+// Discord occasionally re-emits interaction/message events, and the Gateway
+// itself can redeliver on reconnect — the same redelivery class both other
+// adapters guard against, same fix shape: an in-memory, TTL'd seen-id set
+// checked synchronously before any async work.
+const SEEN_ID_TTL_MS = 5 * 60 * 1000;
+const seenIds = new Map(); // message/interaction id -> firstSeenAt
+
+function isDuplicateDelivery(id) {
+  if (!id) return false;
+  const now = Date.now();
+  for (const [seenId, seenAt] of seenIds) {
+    if (now - seenAt > SEEN_ID_TTL_MS) seenIds.delete(seenId);
+  }
+  if (seenIds.has(id)) return true;
+  seenIds.set(id, now);
+  return false;
+}
+
+/** Test-only: clears the seen-id dedup cache between test runs. */
+function _resetSeenIdsForTests() {
+  seenIds.clear();
+}
+
+function buildSyntheticRequest(metaMessage) {
+  return {
+    body: {
+      entry: [{
+        id: SYNTHETIC_ENTRY_ID,
+        changes: [{
+          value: {
+            messages: [metaMessage],
+            metadata: {}, // no phone_number_id — validators.isOurPhoneNumber() auto-allows when absent
+          },
+        }],
+      }],
+    },
+  };
+}
+
+function buildSyntheticResponse() {
+  return {
+    status(code) {
+      return { send: (body) => logToFile('Discord inbound: synthetic response', { code, body }) };
+    },
+  };
+}
+
+/**
+ * Maps a Discord button/select-menu interaction into Meta's
+ * `interactive.button_reply`/`list_reply` shape — the identical branches
+ * whatsapp-bot.js's `messageType === 'interactive'` dispatch already handles
+ * for Meta/Slack. Discord's button `customId`/selected option `value` already
+ * IS the real Meta-shaped `id` (see discord-channel.service.js's
+ * sendInteractiveButtons/sendInteractiveMessage), so this is a direct field
+ * read, no menu-bookkeeping needed — same reasoning as Slack's adapter.
+ *
+ * @param {import('discord.js').ButtonInteraction|import('discord.js').StringSelectMenuInteraction} interaction
+ * @returns {object|null}
+ */
+function mapInteractionToMetaShape(interaction) {
+  const from = toPrefixedIdentity(interaction.user.id);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const id = interaction.message?.id || String(timestamp);
+
+  if (interaction.isButton?.()) {
+    return {
+      from, id, timestamp, type: 'interactive',
+      interactive: { type: 'button_reply', button_reply: { id: interaction.customId, title: interaction.customId } },
+    };
+  }
+
+  if (interaction.isStringSelectMenu?.()) {
+    const value = interaction.values?.[0];
+    if (!value) return null;
+    return {
+      from, id, timestamp, type: 'interactive',
+      interactive: { type: 'list_reply', list_reply: { id: value, title: value } },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Maps a Discord Slash Command (ChatInputCommandInteraction) into the same
+ * Meta-shaped TEXT message every `/command` in text-message.handler.js
+ * already parses via `trimmedMessage === '/x'` / `.startsWith('/x ')` checks
+ * — no new command vocabulary, this just reconstructs the plain-text form a
+ * WhatsApp/Slack user would have typed, so the existing command waterfall
+ * needs zero changes. Mirrors slack-events.adapter.js#mapSlashCommandToMetaShape
+ * exactly, including the `/readingtest` special-case (trailing text dropped,
+ * since text-message.handler.js matches it via an exact string, not a prefix).
+ *
+ * Discord slash-command trailing text (if the command has a "text" option
+ * registered — most of the 9 commands here take no options) arrives as a
+ * named option, not free text after the command name.
+ *
+ * @param {import('discord.js').ChatInputCommandInteraction} interaction
+ * @returns {object|null} Meta-shaped text message, or null to skip
+ */
+function mapSlashCommandToMetaShape(interaction) {
+  if (!interaction?.commandName || !interaction.user?.id) return null;
+
+  const command = `/${interaction.commandName}`;
+  const trailingText = String(interaction.options?.getString?.('text') || '').trim();
+  const from = toPrefixedIdentity(interaction.user.id);
+  const timestamp = Math.floor(Date.now() / 1000);
+
+  const messageText = command === '/readingtest'
+    ? '/readingtest'
+    : (trailingText ? `${command} ${trailingText}` : command);
+
+  return {
+    from,
+    id: `slash-${timestamp}-${interaction.user.id}`,
+    timestamp,
+    type: 'text',
+    text: { body: messageText },
+  };
+}
+
+/**
+ * Attaches every Gateway listener this bot needs onto the shared client
+ * discord-connection.js owns. Mirrors baileys-socket.adapter.js's attach()
+ * shape: a long-lived subscription, not a per-request handler.
+ *
+ * @param {(req: object, res: object) => Promise<void>} dispatch  handleWebhookPost from whatsapp-bot.js
+ */
+async function attach(dispatch) {
+  const connection = require('../discord-connection');
+  const client = await connection.getClient();
+
+  client.on('messageCreate', async (message) => {
+    try {
+      if (isDuplicateDelivery(message.id)) {
+        logToFile('⚠️ Discord inbound: duplicate message delivery skipped', { messageId: message.id });
+        return;
+      }
+      const metaMessage = mapMessageToMetaShape(message);
+      if (!metaMessage) return;
+
+      await dispatch(buildSyntheticRequest(metaMessage), buildSyntheticResponse());
+    } catch (error) {
+      logToFile('❌ Discord inbound: error processing message', { error: error.message, stack: error.stack });
+    }
+  });
+
+  // interactionCreate fires for slash commands, component clicks (buttons/
+  // selects), AND modal submissions, all over this SAME Gateway connection —
+  // discriminated below by type guard. Every branch acks within Discord's
+  // ~3s window before any slow work, mirroring Slack's own 3s ack constraint.
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (interaction.isChatInputCommand?.()) {
+        if (isDuplicateDelivery(interaction.id)) return;
+        await interaction.deferReply({ ephemeral: true });
+        const metaMessage = mapSlashCommandToMetaShape(interaction);
+        if (metaMessage) await dispatch(buildSyntheticRequest(metaMessage), buildSyntheticResponse());
+        return;
+      }
+
+      if (interaction.isModalSubmit?.()) {
+        // eslint-disable-next-line global-require -- lazy: avoids a require cycle at module load
+        const discordModalInteractions = require('../../../routes/discord-modal-interactions.handler');
+        await discordModalInteractions.handleModalSubmit(interaction);
+        return;
+      }
+
+      if (interaction.isButton?.() || interaction.isStringSelectMenu?.()) {
+        // Pre-modal-collector interactions (registration/settings/attendance/
+        // exam-confirm's enum-picking steps) are claimed FIRST, then a
+        // "Get started"-style flow-launch button, then attendance's own
+        // "Add Another"/"I'm Done" loop buttons — only an interaction none of
+        // those claim falls through to ordinary chat button/select mapping.
+        // eslint-disable-next-line global-require -- lazy: avoids a require cycle at module load
+        const discordModalInteractions = require('../../../routes/discord-modal-interactions.handler');
+        if (discordModalInteractions.tryHandleCollected(interaction)) return;
+        if (await discordModalInteractions.tryHandleStartFlow(interaction)) return;
+        if (await discordModalInteractions.tryHandleAttendanceLoopButton(interaction)) return;
+
+        if (isDuplicateDelivery(interaction.id)) return;
+        await interaction.deferUpdate();
+        const metaMessage = mapInteractionToMetaShape(interaction);
+        if (metaMessage) await dispatch(buildSyntheticRequest(metaMessage), buildSyntheticResponse());
+      }
+    } catch (error) {
+      logToFile('❌ Discord inbound: error processing interaction', { error: error.message, stack: error.stack });
+    }
+  });
+
+  logToFile('✅ Discord inbound listener attached', {});
+}
+
+module.exports = {
+  attach,
+  mapMessageToMetaShape,
+  mapAttachmentToMetaShape,
+  mapInteractionToMetaShape,
+  mapSlashCommandToMetaShape,
+  toPrefixedIdentity,
+  toPrefixedMediaId,
+  isDuplicateDelivery,
+  _resetSeenIdsForTests,
+};

--- a/bot/shared/services/messaging/inbound/slack-events.adapter.js
+++ b/bot/shared/services/messaging/inbound/slack-events.adapter.js
@@ -35,6 +35,55 @@ function toPrefixedIdentity(slackUserId) {
   return `${SLACK_PREFIX}:${slackUserId}`;
 }
 
+// Media ids need the same "slack:" prefix as user identities — messaging/index.js's
+// router (channel-registry.js#driverForIdentifier) dispatches getMediaInfo/downloadMedia
+// calls by inspecting the id argument itself for a channel prefix. A bare Slack file id
+// (e.g. "F0123FILE") has no colon, so without this prefix those calls would silently fall
+// through to the WhatsApp-family driver instead of Slack's. slack-channel.service.js
+// strips this same prefix before calling the real Slack Web API.
+function toPrefixedMediaId(slackFileId) {
+  return `${SLACK_PREFIX}:${slackFileId}`;
+}
+
+// Slack's audio-representable mimetypes — used only to pick "audio" vs "voice" the
+// same way Meta's own message.type does; both map to handleVoiceMessage either way
+// (see whatsapp-bot.js's messageType dispatch), so this only affects downstream framing.
+const AUDIO_MIME_RE = /^audio\//i;
+const IMAGE_MIME_RE = /^image\//i;
+
+/**
+ * Maps a Slack `file_share` message event's first file into a Meta-shaped
+ * audio/image/document message — mirrors baileys-socket.adapter.js's own
+ * mapToMetaShape for the same three types. Only the first file is handled
+ * (matching Meta's own one-attachment-per-message model); a multi-file share
+ * is otherwise ignored beyond that first file, same as Baileys' adapter.
+ *
+ * @param {object} event - Slack's inner `event` object (subtype 'file_share')
+ * @returns {object|null} Meta-shaped message, or null to skip
+ */
+function mapFileShareToMetaShape(event) {
+  if (!event || event.bot_id) return null;
+  const file = event.files?.[0];
+  if (!event.user || !file) return null;
+
+  const from = toPrefixedIdentity(event.user);
+  const timestamp = event.ts ? Math.floor(Number(event.ts)) : Math.floor(Date.now() / 1000);
+  const id = event.ts || String(timestamp);
+  const mediaId = toPrefixedMediaId(file.id);
+  const mimeType = file.mimetype || 'application/octet-stream';
+
+  if (AUDIO_MIME_RE.test(mimeType)) {
+    return { from, id, timestamp, type: 'audio', audio: { id: mediaId, mime_type: mimeType } };
+  }
+  if (IMAGE_MIME_RE.test(mimeType)) {
+    return { from, id, timestamp, type: 'image', image: { id: mediaId, mime_type: mimeType, caption: event.text || '' } };
+  }
+  return {
+    from, id, timestamp, type: 'document',
+    document: { id: mediaId, mime_type: mimeType, filename: file.name || 'file' },
+  };
+}
+
 // Slack occasionally redelivers the identical event (its own documented
 // at-least-once retry behavior, e.g. on a slow ack) — the same redelivery
 // class Baileys' adapter guards against, same fix shape: an in-memory,
@@ -93,7 +142,10 @@ function buildSyntheticResponse() {
  * @returns {object|null} Meta-shaped message, or null to skip
  */
 function mapEventToMetaShape(event) {
-  if (!event || event.bot_id || event.subtype) return null;
+  if (!event || event.bot_id) return null;
+  // file_share carries the file(s), not text — dispatched separately, below.
+  if (event.subtype && event.subtype !== 'file_share') return null;
+  if (event.subtype === 'file_share') return mapFileShareToMetaShape(event);
   if (!event.user || !event.text) return null;
 
   const from = toPrefixedIdentity(event.user);
@@ -235,12 +287,86 @@ function makeInteractionsHandler(dispatch) {
   };
 }
 
+/**
+ * Maps a Slack Slash Command payload into the same Meta-shaped TEXT message
+ * every `/command` in text-message.handler.js already parses via
+ * `trimmedMessage === '/x'` / `.startsWith('/x ')` checks — no new command
+ * vocabulary, this just reconstructs the plain-text form a WhatsApp/Baileys
+ * user would have typed, so the existing ~2000-line waterfall of command
+ * checks needs zero changes.
+ *
+ * Slack's Slash Command request is a DIFFERENT payload shape than
+ * block_actions/view_submission: the command/text/user fields arrive at the
+ * TOP LEVEL of the form-encoded body (no `payload` JSON wrapper), which is
+ * why this is routed separately in slack-interactions.routes.js rather than
+ * through makeInteractionsHandler's `JSON.parse(req.body.payload)` path.
+ *
+ * `/readingtest` is special-cased: text-message.handler.js matches it via an
+ * EXACT string check (`'/reading test'` or `'/readingtest'`, no trailing-arg
+ * parsing, unlike `/quiz`/`/video`), so any trailing free text after the
+ * Slack command is intentionally dropped rather than appended.
+ *
+ * @param {object} body - the parsed top-level Slack Slash Command form body
+ *   (fields: command, text, user_id, ...)
+ * @returns {object|null} Meta-shaped text message, or null to skip
+ */
+function mapSlashCommandToMetaShape(body) {
+  if (!body || !body.command || !body.user_id) return null;
+
+  const command = String(body.command).trim(); // Slack always includes the leading "/"
+  const trailingText = String(body.text || '').trim();
+  const from = toPrefixedIdentity(body.user_id);
+  const timestamp = Math.floor(Date.now() / 1000);
+
+  const messageText = command === '/readingtest'
+    ? '/readingtest'
+    : (trailingText ? `${command} ${trailingText}` : command);
+
+  return {
+    from,
+    id: `slash-${timestamp}-${body.user_id}`,
+    timestamp,
+    type: 'text',
+    text: { body: messageText },
+  };
+}
+
+/**
+ * Express handler for Slack's Slash Command Request URL(s). Slack requires a
+ * response within 3s same as Events API/Interactivity — acks immediately
+ * with an empty 200 (no visible slash-command response bubble; Rumi's real
+ * reply arrives moments later as an ordinary message, same UX as every other
+ * async command reply on this channel).
+ *
+ * @param {(req: object, res: object) => Promise<void>} dispatch
+ */
+function makeSlashCommandHandler(dispatch) {
+  return async function handleSlackSlashCommand(req, res) {
+    res.status(200).send('');
+
+    try {
+      const metaMessage = mapSlashCommandToMetaShape(req.body);
+      if (!metaMessage) return;
+
+      const dispatchReq = buildSyntheticRequest(metaMessage);
+      const dispatchRes = buildSyntheticResponse();
+      await dispatch(dispatchReq, dispatchRes);
+    } catch (error) {
+      logToFile('❌ Slack inbound: error processing slash command', { error: error.message, stack: error.stack });
+    }
+  };
+}
+
 module.exports = {
   makeEventsHandler,
   makeInteractionsHandler,
+  makeSlashCommandHandler,
   mapEventToMetaShape,
+  mapFileShareToMetaShape,
   mapBlockActionToMetaShape,
+  mapSlashCommandToMetaShape,
   toPrefixedIdentity,
+  toPrefixedMediaId,
   isDuplicateDelivery,
   _resetSeenEventsForTests,
 };

--- a/bot/shared/services/messaging/inbound/slack-events.adapter.js
+++ b/bot/shared/services/messaging/inbound/slack-events.adapter.js
@@ -1,0 +1,246 @@
+/**
+ * Slack inbound adapter — translates Slack Events API messages and
+ * Interactivity (block_actions) payloads into the same Meta-webhook-shaped
+ * payload bot/whatsapp-bot.js's handleWebhookPost(req, res) already parses
+ * via shared/utils/validators.js#validateWebhookMessage. Mirrors
+ * baileys-socket.adapter.js's role — a parallel entry path into the existing
+ * ~1000-line dispatch logic, not a rewrite of it.
+ *
+ * Unlike Baileys (a persistent socket, so its adapter subscribes to an
+ * event emitter), Slack is HTTP-webhook-based like Meta — this adapter is a
+ * pair of Express route HANDLERS (handleEvent, handleInteraction), mounted
+ * directly by whatsapp-bot.js, not a long-lived "attach" subscription.
+ *
+ * Identity: `from` is always the PREFIXED "slack:<slack-user-id>" identifier
+ * (see channel-registry.js's CHANNEL_PREFIXES) — minted here, at the one
+ * place Slack identities enter the system, then carried unchanged through
+ * getOrCreateUserByChannel and every downstream send.
+ *
+ * Coverage: plain text messages (Events API `message` events) and button
+ * clicks / select-menu choices (`block_actions` interactivity payloads) map
+ * onto Meta's shape and reach the real handlers unchanged. Slack has no
+ * Flow-submission equivalent here — that is slack-modal-flow.js's
+ * `view_submission` handling, a separate route entirely (see
+ * slack-interactions.routes.js).
+ */
+
+const { logToFile } = require('../../../utils/logger');
+const { prefixFor } = require('../channel-registry');
+
+const SLACK_PREFIX = prefixFor('slack');
+// A stable, non-test, non-zero entry id — passes validators.isTestWebhook().
+const SYNTHETIC_ENTRY_ID = 'slack-events';
+
+function toPrefixedIdentity(slackUserId) {
+  return `${SLACK_PREFIX}:${slackUserId}`;
+}
+
+// Slack occasionally redelivers the identical event (its own documented
+// at-least-once retry behavior, e.g. on a slow ack) — the same redelivery
+// class Baileys' adapter guards against, same fix shape: an in-memory,
+// TTL'd seen-id set checked synchronously before any async work.
+const SEEN_EVENT_TTL_MS = 5 * 60 * 1000;
+const seenEventIds = new Map(); // event_id (or ts fallback) -> firstSeenAt
+
+function isDuplicateDelivery(id) {
+  if (!id) return false;
+  const now = Date.now();
+  for (const [seenId, seenAt] of seenEventIds) {
+    if (now - seenAt > SEEN_EVENT_TTL_MS) seenEventIds.delete(seenId);
+  }
+  if (seenEventIds.has(id)) return true;
+  seenEventIds.set(id, now);
+  return false;
+}
+
+/** Test-only: clears the seen-event dedup cache between test runs. */
+function _resetSeenEventsForTests() {
+  seenEventIds.clear();
+}
+
+function buildSyntheticRequest(metaMessage) {
+  return {
+    body: {
+      entry: [{
+        id: SYNTHETIC_ENTRY_ID,
+        changes: [{
+          value: {
+            messages: [metaMessage],
+            metadata: {}, // no phone_number_id — validators.isOurPhoneNumber() auto-allows when absent
+          },
+        }],
+      }],
+    },
+  };
+}
+
+function buildSyntheticResponse() {
+  return {
+    status(code) {
+      return { send: (body) => logToFile('Slack inbound: synthetic response', { code, body }) };
+    },
+  };
+}
+
+/**
+ * Maps a Slack Events API `message` event into Meta's message shape.
+ * Only plain user-authored text messages are dispatchable — bot messages,
+ * message-changed/deleted subtypes, and thread-broadcast echoes are skipped,
+ * the same category of "not a genuine new inbound" Baileys' adapter filters
+ * via hasDispatchableContent().
+ *
+ * @param {object} event - Slack's inner `event` object from an event_callback payload
+ * @returns {object|null} Meta-shaped message, or null to skip
+ */
+function mapEventToMetaShape(event) {
+  if (!event || event.bot_id || event.subtype) return null;
+  if (!event.user || !event.text) return null;
+
+  const from = toPrefixedIdentity(event.user);
+  const timestamp = event.ts ? Math.floor(Number(event.ts)) : Math.floor(Date.now() / 1000);
+
+  return {
+    from,
+    id: event.ts,
+    timestamp,
+    type: 'text',
+    text: { body: event.text },
+  };
+}
+
+/**
+ * Express handler for Slack's Events API Request URL.
+ *
+ * Handles the one-time `url_verification` handshake (echo `challenge` back,
+ * unsigned — Slack sends this before SLACK_SIGNING_SECRET-based verification
+ * is even meaningful to the requester) and real `event_callback` deliveries,
+ * which ARE signature-verified by the caller before this handler runs (see
+ * slack-interactions.routes.js — signature verification is a route-layer
+ * concern, mirrored from how flow-endpoint.routes.js keeps FlowEncryptionService
+ * out of the endpoint functions themselves).
+ *
+ * @param {(req: object, res: object) => Promise<void>} dispatch - handleWebhookPost from whatsapp-bot.js
+ */
+function makeEventsHandler(dispatch) {
+  return async function handleSlackEvent(req, res) {
+    const payload = req.body || {};
+
+    if (payload.type === 'url_verification') {
+      res.status(200).json({ challenge: payload.challenge });
+      return;
+    }
+
+    // Ack immediately — Slack requires a response within 3s, and expects a
+    // 2xx regardless of whether we act on the event.
+    res.status(200).send('');
+
+    if (payload.type !== 'event_callback') return;
+
+    const event = payload.event;
+    if (isDuplicateDelivery(payload.event_id)) {
+      logToFile('⚠️ Slack inbound: duplicate event delivery skipped', { eventId: payload.event_id });
+      return;
+    }
+
+    try {
+      const metaMessage = mapEventToMetaShape(event);
+      if (!metaMessage) return;
+
+      const dispatchReq = buildSyntheticRequest(metaMessage);
+      const dispatchRes = buildSyntheticResponse();
+      await dispatch(dispatchReq, dispatchRes);
+    } catch (error) {
+      logToFile('❌ Slack inbound: error processing event', { error: error.message, stack: error.stack });
+    }
+  };
+}
+
+/**
+ * Maps a Slack `block_actions` interactivity payload (a button click or
+ * static_select choice) into Meta's `interactive.button_reply`/`list_reply`
+ * shape — the identical branches whatsapp-bot.js's `messageType ===
+ * 'interactive'` dispatch already handles for Meta and (via numeric-reply
+ * resolution) for Baileys. Unlike Baileys, Slack's button `value`/selected
+ * option `value` already IS the real Meta-shaped `id` (see
+ * slack-channel.service.js's sendInteractiveButtons/sendInteractiveMessage),
+ * so this is a direct field read, no pending-menu bookkeeping needed.
+ *
+ * @param {object} payload - the parsed `payload` JSON field from a block_actions interaction
+ * @returns {object|null}
+ */
+function mapBlockActionToMetaShape(payload) {
+  const action = payload?.actions?.[0];
+  if (!action) return null;
+
+  const from = toPrefixedIdentity(payload.user?.id);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const id = payload.container?.message_ts || String(timestamp);
+
+  if (action.type === 'button') {
+    return {
+      from,
+      id,
+      timestamp,
+      type: 'interactive',
+      interactive: { type: 'button_reply', button_reply: { id: action.value, title: action.text?.text || action.value } },
+    };
+  }
+
+  if (action.type === 'static_select') {
+    const selected = action.selected_option;
+    if (!selected) return null;
+    return {
+      from,
+      id,
+      timestamp,
+      type: 'interactive',
+      interactive: { type: 'list_reply', list_reply: { id: selected.value, title: selected.text?.text || selected.value } },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Express handler for Slack's Interactivity Request URL — block_actions only.
+ * `view_submission` (modal form submits) is handled by slack-modal-flow.js's
+ * own dispatch, a separate concern from ordinary chat button/select clicks.
+ *
+ * @param {(req: object, res: object) => Promise<void>} dispatch
+ */
+function makeInteractionsHandler(dispatch) {
+  return async function handleSlackInteraction(req, res) {
+    let payload;
+    try {
+      payload = JSON.parse(req.body.payload);
+    } catch (error) {
+      res.status(400).send('Bad payload');
+      return;
+    }
+
+    res.status(200).send('');
+
+    if (payload.type !== 'block_actions') return; // view_submission etc. handled elsewhere
+
+    try {
+      const metaMessage = mapBlockActionToMetaShape(payload);
+      if (!metaMessage) return;
+
+      const dispatchReq = buildSyntheticRequest(metaMessage);
+      const dispatchRes = buildSyntheticResponse();
+      await dispatch(dispatchReq, dispatchRes);
+    } catch (error) {
+      logToFile('❌ Slack inbound: error processing interaction', { error: error.message, stack: error.stack });
+    }
+  };
+}
+
+module.exports = {
+  makeEventsHandler,
+  makeInteractionsHandler,
+  mapEventToMetaShape,
+  mapBlockActionToMetaShape,
+  toPrefixedIdentity,
+  isDuplicateDelivery,
+  _resetSeenEventsForTests,
+};

--- a/bot/shared/services/messaging/index.js
+++ b/bot/shared/services/messaging/index.js
@@ -1,8 +1,14 @@
 /**
- * messaging/index.js — channel driver selector.
+ * messaging/index.js — channel driver router.
  *
  *   CHANNEL_DRIVER=meta     → Meta WhatsApp Cloud API (needs WHATSAPP_TOKEN + PHONE_NUMBER_ID + ...)
  *   CHANNEL_DRIVER=baileys  → (default) sandbox WhatsApp Web driver, no Meta account needed
+ *
+ * Plus any additive channels (Slack, Discord, ...) whose own env vars are
+ * present (see feature-availability.js#resolveActiveChannels) — these run
+ * CONCURRENTLY alongside the one resolved WhatsApp-family driver, not instead
+ * of it. A deployment with none configured loads exactly one driver, exactly
+ * as before this router existed.
  *
  * Every driver exposes the identical method surface the rest of the bot
  * already depends on (see bot/shared/services/whatsapp.service.js, now a thin
@@ -12,20 +18,72 @@
  * feature-availability.js's resolveChannelDriver so the config file stays the
  * single source of truth for that decision; this file just requires the
  * result and logs when the raw env value didn't name a real driver.
+ *
+ * Dispatch: every exported method takes the same first argument every
+ * existing call site already passes (`to`/`from` — a bare WhatsApp phone
+ * number, or, for an additive channel, a "<prefix>:<id>" identifier minted
+ * once by that channel's inbound adapter — see channel-registry.js). A bare
+ * phone number has no prefix and routes to the resolved WhatsApp driver,
+ * unchanged; ~500 existing call sites need zero changes because of this.
  */
 
-const { DRIVERS, DEFAULT_DRIVER } = require('./channel-registry');
-const { resolveChannelDriver } = require('../../config/feature-availability');
+const { DRIVERS, DEFAULT_DRIVER, driverForIdentifier } = require('./channel-registry');
+const { resolveChannelDriver, resolveActiveChannels } = require('../../config/feature-availability');
 const { logToFile } = require('../../utils/logger');
 
 const rawDriver = (process.env.CHANNEL_DRIVER || '').trim().toLowerCase();
-const driverName = resolveChannelDriver(process.env);
+const whatsappDriverName = resolveChannelDriver(process.env);
 
 if (rawDriver && !Object.prototype.hasOwnProperty.call(DRIVERS, rawDriver)) {
   logToFile(
-    `⚠️  Unknown CHANNEL_DRIVER="${rawDriver}" — falling back to ${driverName}. Valid values: ${Object.keys(DRIVERS).join(' | ')}.`,
+    `⚠️  Unknown CHANNEL_DRIVER="${rawDriver}" — falling back to ${whatsappDriverName}. Valid values: ${Object.keys(DRIVERS).join(' | ')}.`,
     { level: 'warn' }
   );
 }
 
-module.exports = require(DRIVERS[driverName]);
+const activeChannelNames = resolveActiveChannels(process.env);
+const whatsappDriver = require(DRIVERS[whatsappDriverName]);
+
+const additiveDrivers = {};
+for (const name of activeChannelNames) {
+  additiveDrivers[name] = require(DRIVERS[name]);
+}
+
+/**
+ * The export IS the WhatsApp-family driver object itself (via a Proxy), not
+ * a fresh plain object copying its methods over — this matters beyond style:
+ * meta-channel.service.js has ~13 internal cross-method calls
+ * (sendImageFromUrl calling this.sendImage, etc.), and existing tests
+ * jest.spyOn() the facade to intercept exactly those calls
+ * (tests/whatsapp/send-image-from-url.test.js). A copied-methods router
+ * object is a DIFFERENT object than the driver class, so `this` inside the
+ * driver's own methods would still correctly resolve to the driver (runtime
+ * behavior is fine either way), but spying on the copy would no longer
+ * intercept the driver's internal calls (a real regression, verified while
+ * building this). Proxying the driver directly preserves identity for the
+ * common (no additive channel involved) case, so every existing call site,
+ * spy, and `instanceof`-adjacent assumption keeps working unchanged.
+ *
+ * The trap only special-cases actual send methods, and only when `to` (the
+ * proxied call's first argument) carries an additive-channel prefix — every
+ * other property access (extra static properties, non-send methods) falls
+ * straight through to the real WhatsApp driver via Reflect.get, untouched.
+ */
+module.exports = new Proxy(whatsappDriver, {
+  get(target, prop, receiver) {
+    const original = Reflect.get(target, prop, receiver);
+    if (typeof original !== 'function' || Object.keys(additiveDrivers).length === 0) {
+      return original;
+    }
+    return function routed(to, ...args) {
+      const driverName = driverForIdentifier(to);
+      if (!driverName) return original.apply(this === receiver ? target : this, [to, ...args]);
+
+      const driver = additiveDrivers[driverName];
+      if (!driver || typeof driver[prop] !== 'function') {
+        throw new Error(`Channel driver "${driverName}" has no method "${String(prop)}" (identifier: ${to})`);
+      }
+      return driver[prop](to, ...args);
+    };
+  },
+});

--- a/bot/shared/services/messaging/slack-channel.service.js
+++ b/bot/shared/services/messaging/slack-channel.service.js
@@ -153,6 +153,23 @@ function removeEmotionTags(text) {
   return text.replace(/\[[a-zA-Z\s]+\]\s*/g, '').trim();
 }
 
+/**
+ * @slack/web-api's error.message is just "An API error occurred: <code>" —
+ * useless for a missing_scope error, since it never names WHICH scope. The
+ * actual detail lives on error.data (the raw Slack API response body):
+ * `{ error: 'missing_scope', needed: 'chat:write', provided: '...' }`. This
+ * surfaces that detail in every log call below so a scope problem is
+ * diagnosable from the log line alone, not by guessing at api.slack.com/methods.
+ */
+function slackErrorDetail(error) {
+  const data = error?.data;
+  if (data?.error === 'missing_scope') {
+    return { code: data.error, neededScope: data.needed, providedScopes: data.provided };
+  }
+  if (data?.error) return { code: data.error };
+  return { message: error?.message };
+}
+
 async function sendMessage(to, message) {
   try {
     const client = getClient();
@@ -161,7 +178,7 @@ async function sendMessage(to, message) {
     logToFile('✅ Slack message sent', { to });
     return true;
   } catch (error) {
-    logToFile('❌ Slack: error sending message', { error: error.message });
+    logToFile('❌ Slack: error sending message', { ...slackErrorDetail(error) });
     return false;
   }
 }
@@ -176,7 +193,7 @@ async function sendTextReturningId(to, message, opts = {}) {
     const result = await client.chat.postMessage(payload);
     return result?.ts || null;
   } catch (error) {
-    logToFile('❌ Slack: error sending message (returning id)', { error: error.message });
+    logToFile('❌ Slack: error sending message (returning id)', { ...slackErrorDetail(error) });
     return null;
   }
 }
@@ -193,7 +210,7 @@ async function sendReaction(to, messageId, emoji = 'heart') {
     await client.reactions.add({ channel, timestamp: messageId, name });
     return true;
   } catch (error) {
-    logToFile('❌ Slack: error sending reaction', { error: error.message });
+    logToFile('❌ Slack: error sending reaction', { ...slackErrorDetail(error) });
     return false;
   }
 }
@@ -251,7 +268,7 @@ async function sendDocument(to, filePath, filename, caption) {
     const buffer = fs.readFileSync(filePath);
     return await uploadFile(to, buffer, filename, caption);
   } catch (error) {
-    logToFile('❌ Slack: error sending document', { error: error.message });
+    logToFile('❌ Slack: error sending document', { ...slackErrorDetail(error) });
     return false;
   }
 }
@@ -260,7 +277,7 @@ async function sendAudio(to, audioBuffer) {
   try {
     return await uploadFile(to, audioBuffer, 'audio.mp3');
   } catch (error) {
-    logToFile('❌ Slack: error sending audio', { error: error.message });
+    logToFile('❌ Slack: error sending audio', { ...slackErrorDetail(error) });
     return false;
   }
 }
@@ -270,7 +287,7 @@ async function sendDocumentFromUrl(to, documentUrl, filename, caption) {
     const buffer = await resolveMediaBuffer(documentUrl);
     return await uploadFile(to, buffer, filename, caption);
   } catch (error) {
-    logToFile('❌ Slack: error sending document from URL', { error: error.message, documentUrl });
+    logToFile('❌ Slack: error sending document from URL', { ...slackErrorDetail(error), documentUrl });
     return false;
   }
 }
@@ -280,7 +297,7 @@ async function sendAudioFromUrl(to, audioUrl) {
     const buffer = await resolveMediaBuffer(audioUrl);
     return await uploadFile(to, buffer, 'audio.mp3');
   } catch (error) {
-    logToFile('❌ Slack: error sending audio from URL', { error: error.message, audioUrl });
+    logToFile('❌ Slack: error sending audio from URL', { ...slackErrorDetail(error), audioUrl });
     return false;
   }
 }
@@ -295,7 +312,7 @@ async function sendAudioFromUrlReturningId(to, audioUrl) {
     // closest analogue Slack has to "the sent item's id" for a file share.
     return result?.files?.[0]?.id || null;
   } catch (error) {
-    logToFile('❌ Slack: error sending audio from URL (returning id)', { error: error.message, audioUrl });
+    logToFile('❌ Slack: error sending audio from URL (returning id)', { ...slackErrorDetail(error), audioUrl });
     return null;
   }
 }
@@ -305,7 +322,7 @@ async function sendImageFromUrl(to, imageUrl, caption = '') {
     const buffer = await resolveMediaBuffer(imageUrl);
     return await uploadFile(to, buffer, 'image.png', caption);
   } catch (error) {
-    logToFile('❌ Slack: error sending image from URL', { error: error.message, imageUrl });
+    logToFile('❌ Slack: error sending image from URL', { ...slackErrorDetail(error), imageUrl });
     return false;
   }
 }
@@ -314,7 +331,7 @@ async function sendVideo(to, videoBuffer, tempDir, caption = '') {
   try {
     return await uploadFile(to, videoBuffer, 'video.mp4', caption);
   } catch (error) {
-    logToFile('❌ Slack: error sending video', { error: error.message });
+    logToFile('❌ Slack: error sending video', { ...slackErrorDetail(error) });
     return false;
   }
 }
@@ -324,7 +341,7 @@ async function sendVideoFromUrl(to, videoUrl, caption = '') {
     const buffer = await resolveMediaBuffer(videoUrl);
     return await uploadFile(to, buffer, 'video.mp4', caption);
   } catch (error) {
-    logToFile('❌ Slack: error sending video from URL', { error: error.message, videoUrl });
+    logToFile('❌ Slack: error sending video from URL', { ...slackErrorDetail(error), videoUrl });
     return false;
   }
 }
@@ -343,7 +360,7 @@ async function sendImage(to, mediaIdOrPath, caption = '') {
     const buffer = fs.readFileSync(mediaIdOrPath);
     return await uploadFile(to, buffer, path.basename(mediaIdOrPath), caption);
   } catch (error) {
-    logToFile('❌ Slack: error sending image', { error: error.message });
+    logToFile('❌ Slack: error sending image', { ...slackErrorDetail(error) });
     return false;
   }
 }
@@ -362,7 +379,7 @@ async function sendSticker(to, mediaIdOrPath) {
     const buffer = fs.readFileSync(mediaIdOrPath);
     return await uploadFile(to, buffer, path.basename(mediaIdOrPath));
   } catch (error) {
-    logToFile('❌ Slack: error sending sticker', { error: error.message });
+    logToFile('❌ Slack: error sending sticker', { ...slackErrorDetail(error) });
     return false;
   }
 }
@@ -394,7 +411,7 @@ async function sendInteractiveButtons(to, options) {
     await client.chat.postMessage({ channel, text: body, blocks });
     return true;
   } catch (error) {
-    logToFile('❌ Slack: error sending interactive buttons', { error: error.message });
+    logToFile('❌ Slack: error sending interactive buttons', { ...slackErrorDetail(error) });
     return false;
   }
 }
@@ -423,7 +440,7 @@ async function sendImageWithButtons(to, imageUrl, bodyText, buttons) {
     await client.chat.postMessage({ channel, text: bodyText, blocks });
     return true;
   } catch (error) {
-    logToFile('❌ Slack: error sending image with buttons', { error: error.message, imageUrl });
+    logToFile('❌ Slack: error sending image with buttons', { ...slackErrorDetail(error), imageUrl });
     return false;
   }
 }
@@ -465,7 +482,7 @@ async function sendInteractiveMessage(to, listData) {
     await client.chat.postMessage({ channel, text: bodyText || headerText || 'Please choose an option', blocks });
     return true;
   } catch (error) {
-    logToFile('❌ Slack: error sending interactive list', { error: error.message });
+    logToFile('❌ Slack: error sending interactive list', { ...slackErrorDetail(error) });
     return false;
   }
 }

--- a/bot/shared/services/messaging/slack-channel.service.js
+++ b/bot/shared/services/messaging/slack-channel.service.js
@@ -1,0 +1,633 @@
+/**
+ * Slack channel driver — usable in BOTH sandbox and production (unlike
+ * Baileys, which is sandbox-only, and Meta, which is production-only). A
+ * Slack app has no formal business-verification process the way WhatsApp
+ * Business does, so there is no tier split here — see channel-registry.js's
+ * PRODUCTION_TIER_DRIVERS.
+ *
+ * Unlike Baileys, Slack CAN render real interactive components (buttons,
+ * select menus) natively — so sendInteractiveButtons/sendInteractiveMessage
+ * are REAL Block Kit implementations here, not a text degradation. A
+ * button's Slack `value` carries the exact same `id` Meta's button_reply
+ * would have used, so the inbound adapter (slack-events.adapter.js) can
+ * synthesize the identical internal shape whatsapp-bot.js already dispatches
+ * on, with no numeric-reply resolution step needed (that machinery —
+ * pending-options.js — exists only because Baileys' native components are
+ * unreliable and must degrade to numbered text; Slack has no such problem).
+ *
+ * Method names/async-ness are parsed statically off meta-channel.service.js's
+ * SOURCE (same mechanism baileys-channel.service.js and
+ * tests/messaging/channel-driver-parity.test.js use) rather than by
+ * `require()`-ing that module — meta-channel.service.js pulls in axios/
+ * form-data, neither of which this driver needs. If meta-channel.service.js
+ * ever grows a new method this file doesn't know about, requiring this file
+ * throws immediately (see the assertion loop at the bottom) rather than
+ * silently shipping a missing/wrong-shaped member.
+ *
+ * Identity: `to` always arrives as the full "slack:<slack-user-id>"
+ * identifier the messaging router (messaging/index.js) dispatches by — this
+ * driver strips the prefix once, internally, and never receives a bare
+ * Slack user id directly (see channel-registry.js's CHANNEL_PREFIXES).
+ *
+ * Templates/Flow/carousels have no Slack equivalent without the
+ * channel-agnostic template registry from
+ * docs/onboarding/sandbox-production-design.md §1 (not built) — those stay
+ * honest stubs, same contract as Baileys' stubs for the same methods. The
+ * real Flow-equivalent (Slack Block Kit MODALS for registration/settings) is
+ * a separate renderer layered on top of this driver, not part of it — see
+ * slack-modal-flow.js.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { logToFile } = require('../../utils/logger');
+const { downloadFromR2, extractKeyFromUrl } = require('../../storage/r2');
+const { prefixFor } = require('./channel-registry');
+
+const META_SOURCE_PATH = path.join(__dirname, 'meta-channel.service.js');
+const SLACK_PREFIX = prefixFor('slack'); // 'slack' — kept indirect so a rename to CHANNEL_PREFIXES stays a one-line fix
+
+function parseMembers(src) {
+  const members = [];
+  const methodRe = /^\s*static\s+(async\s+)?(\w+)\s*\(/gm;
+  let m;
+  while ((m = methodRe.exec(src))) members.push({ name: m[2], isAsync: !!m[1] });
+  return members;
+}
+
+const MEMBERS = parseMembers(fs.readFileSync(META_SOURCE_PATH, 'utf-8'));
+
+/** Strips the "slack:" prefix the router hands every method — never received bare. */
+function slackUserId(to) {
+  const raw = String(to);
+  const withPrefix = `${SLACK_PREFIX}:`;
+  return raw.startsWith(withPrefix) ? raw.slice(withPrefix.length) : raw;
+}
+
+// ── Slack Web API client (lazy) ──────────────────────────────────────────────
+// Mirrors baileys-connection.js's lazy-require convention: nothing touches
+// @slack/web-api until a send actually happens, and tests can jest.doMock
+// this module cleanly without a real network client ever being constructed.
+let cachedClient = null;
+function getClient() {
+  if (cachedClient) return cachedClient;
+  // eslint-disable-next-line global-require -- lazy on purpose; see file header
+  const { WebClient } = require('@slack/web-api');
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (!token) {
+    throw new Error('Slack channel driver: SLACK_BOT_TOKEN is not set');
+  }
+  cachedClient = new WebClient(token);
+  return cachedClient;
+}
+
+// ── DM channel resolution (cached) ───────────────────────────────────────────
+// Slack addresses a person by a CHANNEL id, not their user id directly — a DM
+// requires opening (or reusing) a conversation first. Cached per-process so
+// repeated sends to the same person don't re-open the DM every time.
+const dmChannelCache = new Map(); // slackUserId -> channelId
+
+async function getDmChannelId(userId) {
+  if (dmChannelCache.has(userId)) return dmChannelCache.get(userId);
+  const client = getClient();
+  const result = await client.conversations.open({ users: userId });
+  const channelId = result?.channel?.id;
+  if (!channelId) throw new Error(`Slack: could not open a DM with user ${userId}`);
+  dmChannelCache.set(userId, channelId);
+  return channelId;
+}
+
+// ── Media sources (mirrors baileys-channel.service.js's resolveMediaSource) ──
+
+function isAbsoluteHttpUrl(url) {
+  return /^https?:\/\//i.test(String(url || ''));
+}
+
+function isR2Configured() {
+  return Boolean(
+    process.env.R2_ENDPOINT && process.env.R2_ACCESS_KEY_ID && process.env.R2_SECRET_ACCESS_KEY
+  );
+}
+
+/**
+ * Resolves a media reference into a Buffer Slack's files.uploadV2 can send.
+ * Slack (unlike WhatsApp) has no "hand me a URL and I'll fetch it" upload
+ * mode for a private bucket, so unlike Baileys' resolveMediaSource this
+ * always returns a Buffer, never `{ url }`.
+ */
+async function resolveMediaBuffer(url) {
+  if (typeof url === 'string' && url.startsWith('file://')) {
+    const localPath = url.slice('file://'.length);
+    if (!fs.existsSync(localPath)) {
+      throw new Error(`Cannot send media: local file is gone (${localPath})`);
+    }
+    return fs.readFileSync(localPath);
+  }
+
+  if (isR2Configured()) {
+    try {
+      return await downloadFromR2(extractKeyFromUrl(url));
+    } catch (error) {
+      if (!isAbsoluteHttpUrl(url)) throw error;
+      logToFile('⚠️ Slack: R2 download failed — fetching the URL directly instead', {
+        url, error: error.message,
+      });
+    }
+  }
+
+  if (!isAbsoluteHttpUrl(url)) {
+    throw new Error(
+      `Cannot send media from "${url}": it is not an absolute URL, and R2 is not configured `
+      + '(set R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY to read private objects).'
+    );
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Failed to fetch media URL: HTTP ${response.status}`);
+  return Buffer.from(await response.arrayBuffer());
+}
+
+// ── Real implementations ─────────────────────────────────────────────────────
+
+function removeEmotionTags(text) {
+  return text.replace(/\[[a-zA-Z\s]+\]\s*/g, '').trim();
+}
+
+async function sendMessage(to, message) {
+  try {
+    const client = getClient();
+    const channel = await getDmChannelId(slackUserId(to));
+    await client.chat.postMessage({ channel, text: removeEmotionTags(message) });
+    logToFile('✅ Slack message sent', { to });
+    return true;
+  } catch (error) {
+    logToFile('❌ Slack: error sending message', { error: error.message });
+    return false;
+  }
+}
+
+async function sendTextReturningId(to, message, opts = {}) {
+  try {
+    const client = getClient();
+    const channel = await getDmChannelId(slackUserId(to));
+    const payload = { channel, text: removeEmotionTags(message) };
+    // Slack's quote-equivalent is a threaded reply, not an inline quote.
+    if (opts.contextMessageId) payload.thread_ts = opts.contextMessageId;
+    const result = await client.chat.postMessage(payload);
+    return result?.ts || null;
+  } catch (error) {
+    logToFile('❌ Slack: error sending message (returning id)', { error: error.message });
+    return null;
+  }
+}
+
+async function sendReaction(to, messageId, emoji = 'heart') {
+  try {
+    const client = getClient();
+    const channel = await getDmChannelId(slackUserId(to));
+    // Slack reaction names are bare emoji shortcodes (no colons); a caller
+    // passing a literal unicode glyph (Meta's convention) is mapped to a
+    // close Slack equivalent for the common cases, falling back to a plain
+    // name if it's already shortcode-shaped.
+    const name = EMOJI_TO_SLACK_NAME[emoji] || String(emoji).replace(/:/g, '');
+    await client.reactions.add({ channel, timestamp: messageId, name });
+    return true;
+  } catch (error) {
+    logToFile('❌ Slack: error sending reaction', { error: error.message });
+    return false;
+  }
+}
+
+const EMOJI_TO_SLACK_NAME = {
+  '❤️': 'heart',
+  '👍': '+1',
+  '👎': '-1',
+  '😊': 'blush',
+};
+
+// Slack has no bot typing-indicator API (unlike WhatsApp's presence update) —
+// honest no-op, logged once per call so it's visible in diagnostics without
+// spamming on every message.
+async function showTypingIndicator() {
+  logToFile('ℹ️ Slack channel driver: no typing-indicator API for bots — no-op');
+  return true;
+}
+
+function startContinuousTypingIndicator() {
+  return { stop: () => {} };
+}
+
+async function getMediaInfo(mediaId) {
+  const client = getClient();
+  const result = await client.files.info({ file: mediaId });
+  const file = result?.file;
+  if (!file) throw new Error(`Slack: no file info for id "${mediaId}"`);
+  return { url: file.url_private, mime_type: file.mimetype, file_size: file.size };
+}
+
+async function downloadMedia(mediaId) {
+  const info = await getMediaInfo(mediaId);
+  const response = await fetch(info.url, {
+    headers: { Authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}` },
+  });
+  if (!response.ok) throw new Error(`Slack: file download failed, HTTP ${response.status}`);
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function uploadFile(to, buffer, filename, caption) {
+  const client = getClient();
+  const channel = await getDmChannelId(slackUserId(to));
+  await client.files.uploadV2({
+    channel_id: channel,
+    file: buffer,
+    filename,
+    initial_comment: caption || undefined,
+  });
+  return true;
+}
+
+async function sendDocument(to, filePath, filename, caption) {
+  try {
+    const buffer = fs.readFileSync(filePath);
+    return await uploadFile(to, buffer, filename, caption);
+  } catch (error) {
+    logToFile('❌ Slack: error sending document', { error: error.message });
+    return false;
+  }
+}
+
+async function sendAudio(to, audioBuffer) {
+  try {
+    return await uploadFile(to, audioBuffer, 'audio.mp3');
+  } catch (error) {
+    logToFile('❌ Slack: error sending audio', { error: error.message });
+    return false;
+  }
+}
+
+async function sendDocumentFromUrl(to, documentUrl, filename, caption) {
+  try {
+    const buffer = await resolveMediaBuffer(documentUrl);
+    return await uploadFile(to, buffer, filename, caption);
+  } catch (error) {
+    logToFile('❌ Slack: error sending document from URL', { error: error.message, documentUrl });
+    return false;
+  }
+}
+
+async function sendAudioFromUrl(to, audioUrl) {
+  try {
+    const buffer = await resolveMediaBuffer(audioUrl);
+    return await uploadFile(to, buffer, 'audio.mp3');
+  } catch (error) {
+    logToFile('❌ Slack: error sending audio from URL', { error: error.message, audioUrl });
+    return false;
+  }
+}
+
+async function sendAudioFromUrlReturningId(to, audioUrl) {
+  try {
+    const client = getClient();
+    const channel = await getDmChannelId(slackUserId(to));
+    const buffer = await resolveMediaBuffer(audioUrl);
+    const result = await client.files.uploadV2({ channel_id: channel, file: buffer, filename: 'audio.mp3' });
+    // files.uploadV2 returns per-file metadata, not a chat message ts — the
+    // closest analogue Slack has to "the sent item's id" for a file share.
+    return result?.files?.[0]?.id || null;
+  } catch (error) {
+    logToFile('❌ Slack: error sending audio from URL (returning id)', { error: error.message, audioUrl });
+    return null;
+  }
+}
+
+async function sendImageFromUrl(to, imageUrl, caption = '') {
+  try {
+    const buffer = await resolveMediaBuffer(imageUrl);
+    return await uploadFile(to, buffer, 'image.png', caption);
+  } catch (error) {
+    logToFile('❌ Slack: error sending image from URL', { error: error.message, imageUrl });
+    return false;
+  }
+}
+
+async function sendVideo(to, videoBuffer, tempDir, caption = '') {
+  try {
+    return await uploadFile(to, videoBuffer, 'video.mp4', caption);
+  } catch (error) {
+    logToFile('❌ Slack: error sending video', { error: error.message });
+    return false;
+  }
+}
+
+async function sendVideoFromUrl(to, videoUrl, caption = '') {
+  try {
+    const buffer = await resolveMediaBuffer(videoUrl);
+    return await uploadFile(to, buffer, 'video.mp4', caption);
+  } catch (error) {
+    logToFile('❌ Slack: error sending video from URL', { error: error.message, videoUrl });
+    return false;
+  }
+}
+
+async function sendImage(to, mediaIdOrPath, caption = '') {
+  const isFilePath = mediaIdOrPath.includes('/') || mediaIdOrPath.includes('\\');
+  if (!isFilePath) {
+    logToFile(
+      '❌ Slack: sendImage was given a Meta media ID, not a file path/URL — Slack has no reusable '
+      + 'media-ID upload step, so cached-ID reuse is not supported on this channel',
+      { mediaIdOrPath }
+    );
+    return false;
+  }
+  try {
+    const buffer = fs.readFileSync(mediaIdOrPath);
+    return await uploadFile(to, buffer, path.basename(mediaIdOrPath), caption);
+  } catch (error) {
+    logToFile('❌ Slack: error sending image', { error: error.message });
+    return false;
+  }
+}
+
+async function sendSticker(to, mediaIdOrPath) {
+  const isFilePath = mediaIdOrPath.includes('/') || mediaIdOrPath.includes('\\');
+  if (!isFilePath) {
+    logToFile('❌ Slack: sendSticker was given a Meta media ID, not a file path — not supported on this channel', { mediaIdOrPath });
+    return false;
+  }
+  if (!fs.existsSync(mediaIdOrPath)) {
+    logToFile('Sticker file not found — skipping sticker send (cosmetic)', { path: mediaIdOrPath });
+    return false;
+  }
+  try {
+    const buffer = fs.readFileSync(mediaIdOrPath);
+    return await uploadFile(to, buffer, path.basename(mediaIdOrPath));
+  } catch (error) {
+    logToFile('❌ Slack: error sending sticker', { error: error.message });
+    return false;
+  }
+}
+
+// ── Real interactive components (Block Kit) ─────────────────────────────────
+// Unlike Baileys, these are genuine native components, not a text
+// degradation — a button's `value` carries the exact `id` Meta's
+// button_reply would have used, and slack-events.adapter.js reads it
+// straight off the block_actions payload with no menu-bookkeeping needed.
+
+async function sendInteractiveButtons(to, options) {
+  try {
+    const client = getClient();
+    const channel = await getDmChannelId(slackUserId(to));
+    const { body, buttons } = options;
+
+    const blocks = [
+      { type: 'section', text: { type: 'mrkdwn', text: body } },
+      {
+        type: 'actions',
+        elements: buttons.map((btn) => ({
+          type: 'button',
+          text: { type: 'plain_text', text: btn.title.substring(0, 75) },
+          value: btn.id,
+          action_id: btn.id,
+        })),
+      },
+    ];
+    await client.chat.postMessage({ channel, text: body, blocks });
+    return true;
+  } catch (error) {
+    logToFile('❌ Slack: error sending interactive buttons', { error: error.message });
+    return false;
+  }
+}
+
+async function sendImageWithButtons(to, imageUrl, bodyText, buttons) {
+  try {
+    const client = getClient();
+    const channel = await getDmChannelId(slackUserId(to));
+    const buffer = await resolveMediaBuffer(imageUrl);
+    // Slack files can't carry inline block actions directly, so the image is
+    // uploaded first and the button prompt follows as its own message — the
+    // closest native equivalent to Meta's single image+buttons bubble.
+    await uploadFile(to, buffer, 'image.png');
+    const blocks = [
+      { type: 'section', text: { type: 'mrkdwn', text: bodyText } },
+      {
+        type: 'actions',
+        elements: buttons.map((btn) => ({
+          type: 'button',
+          text: { type: 'plain_text', text: btn.title.substring(0, 75) },
+          value: btn.id,
+          action_id: btn.id,
+        })),
+      },
+    ];
+    await client.chat.postMessage({ channel, text: bodyText, blocks });
+    return true;
+  } catch (error) {
+    logToFile('❌ Slack: error sending image with buttons', { error: error.message, imageUrl });
+    return false;
+  }
+}
+
+async function sendInteractiveMessage(to, listData) {
+  try {
+    const client = getClient();
+    const channel = await getDmChannelId(slackUserId(to));
+    const { header, body, footer, action } = listData;
+    const { sections } = action || {};
+    const options = (sections || []).flatMap((s) => s.rows || []);
+
+    if (!options.length) {
+      logToFile('⚠️ Slack: no options provided for interactive list', { listData });
+      return false;
+    }
+
+    const headerText = header?.text || header;
+    const bodyText = body?.text || body;
+    const footerText = footer?.text || footer;
+
+    const blocks = [];
+    if (headerText) blocks.push({ type: 'header', text: { type: 'plain_text', text: String(headerText).slice(0, 150) } });
+    if (bodyText) blocks.push({ type: 'section', text: { type: 'mrkdwn', text: bodyText } });
+    blocks.push({
+      type: 'actions',
+      elements: [{
+        type: 'static_select',
+        action_id: 'list_select',
+        placeholder: { type: 'plain_text', text: action?.button || 'Choose an option' },
+        options: options.slice(0, 100).map((opt) => ({
+          text: { type: 'plain_text', text: String(opt.title).slice(0, 75) },
+          value: opt.id,
+        })),
+      }],
+    });
+    if (footerText) blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: footerText }] });
+
+    await client.chat.postMessage({ channel, text: bodyText || headerText || 'Please choose an option', blocks });
+    return true;
+  } catch (error) {
+    logToFile('❌ Slack: error sending interactive list', { error: error.message });
+    return false;
+  }
+}
+
+async function sendLanguageSelectionList(to, currentLanguage = 'en', region = null) {
+  // eslint-disable-next-line global-require -- lazy, matching baileys-channel.service.js's convention
+  const { LANGUAGES, SUPPORTED_LANGUAGES } = require('../../config/supported-languages');
+
+  const DEFAULT_PICKER_CODES = ['en', 'ur', 'pa-PK', 'sd-PK', 'ps-PK', 'bal-PK', 'ta-LK', 'ar', 'es'];
+  let codes = DEFAULT_PICKER_CODES;
+  try {
+    // eslint-disable-next-line global-require -- lazy: avoids a DB-backed service on module load
+    const RegionFeaturesService = require('../region-features.service');
+    const feats = await RegionFeaturesService.getRegionFeatures(region);
+    const fromRegion = Array.isArray(feats.supported_languages)
+      ? feats.supported_languages.filter((c) => SUPPORTED_LANGUAGES.includes(c))
+      : [];
+    if (fromRegion.length > 1) codes = fromRegion;
+  } catch (error) {
+    logToFile('Slack language picker: region lookup failed, using default set', { error: error.message });
+  }
+
+  const rows = [
+    { id: 'lang_auto', title: 'Auto-detect' },
+    ...codes.map((code) => ({ id: `lang_${code}`, title: LANGUAGES[code]?.native || code })),
+  ];
+
+  return sendInteractiveMessage(to, {
+    header: 'Select Language',
+    body: 'Choose your preferred language. I will respond in this language for all conversations.',
+    footer: 'You can change this anytime by typing /language',
+    action: { button: 'Languages', sections: [{ title: 'Available Languages', rows }] },
+  });
+}
+
+const STYLE_OPTIONS = [
+  { id: 'style_photorealistic', title: 'Photorealistic' },
+  { id: 'style_infographic', title: 'Infographic' },
+  { id: 'style_cartoon', title: 'Cartoon' },
+  { id: 'style_sketch', title: 'Sketch' },
+];
+
+async function sendStyleListFallback(to) {
+  return sendInteractiveMessage(to, {
+    header: '🎨 Choose Video Style',
+    action: { button: 'View Styles', sections: [{ title: 'Video Styles', rows: STYLE_OPTIONS }] },
+  });
+}
+
+const FEATURE_MENU_OPTIONS = [
+  { id: 'menu_lesson_plan', title: 'Lesson Plans' },
+  { id: 'menu_coaching', title: 'Classroom Coaching' },
+  { id: 'menu_reading', title: 'Reading Assessment' },
+  { id: 'menu_video', title: 'AI Video Generation' },
+  { id: 'menu_other', title: 'Ask Anything' },
+];
+
+async function sendFeatureMenuListFallback(to) {
+  return sendInteractiveMessage(to, {
+    header: "Here's what I can do!",
+    action: { button: 'View Features', sections: [{ title: 'My Features', rows: FEATURE_MENU_OPTIONS }] },
+  });
+}
+
+function notSupportedMessage(methodName) {
+  return `Slack channel driver: ${methodName}() has no equivalent yet — it needs the channel-agnostic `
+    + 'template registry from docs/onboarding/sandbox-production-design.md §1, which is not built. '
+    + 'The template\'s static wording lives only in Meta\'s registered config, not in this call\'s arguments.';
+}
+
+/**
+ * The Flow-equivalent (Block Kit modals) lives in slack-modal-flow.js as a
+ * SEPARATE renderer, not inside this driver — matching the plan's decision
+ * that a modal round-trips through Slack's Interactivity Request URL, not
+ * through a sendFlow() call. sendFlow() itself stays an honest stub here so
+ * any caller still branching on its Meta-shaped return value degrades
+ * safely rather than throwing.
+ */
+async function sendFlow() {
+  logToFile('Slack channel driver: sendFlow() has no direct equivalent — Flow-shaped forms render as a '
+    + 'Block Kit modal via slack-modal-flow.js, triggered by a button click, not by this call.');
+  return false;
+}
+
+// ── Explicit method table ────────────────────────────────────────────────────
+// Every parsed member (see MEMBERS below) must appear in exactly one of these
+// two tables, checked by the assertion loop below.
+
+const IMPLEMENTATIONS = {
+  _removeEmotionTags: removeEmotionTags,
+  sendMessage,
+  sendReaction,
+  showTypingIndicator,
+  startContinuousTypingIndicator,
+  getMediaInfo,
+  downloadMedia,
+  sendDocument,
+  sendAudio,
+  sendDocumentFromUrl,
+  sendAudioFromUrl,
+  sendTextReturningId,
+  sendAudioFromUrlReturningId,
+  sendImageFromUrl,
+  sendVideo,
+  sendVideoFromUrl,
+  sendImage,
+  sendSticker,
+  sendInteractiveButtons,
+  sendImageWithButtons,
+  sendInteractiveMessage,
+  sendLanguageSelectionList,
+  sendStyleListFallback,
+  sendFeatureMenuListFallback,
+  sendFlow,
+};
+
+// name -> whether the real (Meta) method is async, so the stub shape matches.
+const STUBS = {
+  sendTemplate: true,
+  sendStyleCarousel: true,
+  sendFeatureMenuCarousel: true,
+  buildStyleCarouselPayload: false,
+  buildFeatureMenuCarouselPayload: false,
+};
+
+function asyncFalseStub(methodName) {
+  return async function slackStub(...args) {
+    logToFile(notSupportedMessage(methodName), { methodName, driver: 'slack' });
+    return false;
+  };
+}
+
+function syncNullStub(methodName) {
+  return function slackSyncStub(...args) {
+    logToFile(notSupportedMessage(methodName), { methodName, driver: 'slack' });
+    return null;
+  };
+}
+
+const SlackChannel = {};
+
+for (const { name, isAsync } of MEMBERS) {
+  if (Object.prototype.hasOwnProperty.call(IMPLEMENTATIONS, name)) {
+    SlackChannel[name] = IMPLEMENTATIONS[name];
+  } else if (Object.prototype.hasOwnProperty.call(STUBS, name)) {
+    const stubIsAsync = STUBS[name];
+    if (stubIsAsync !== isAsync) {
+      throw new Error(
+        `slack-channel.service.js: "${name}" is registered as ${stubIsAsync ? 'async' : 'sync'} in STUBS but `
+        + `meta-channel.service.js now declares it ${isAsync ? 'async' : 'sync'} — update STUBS to match.`
+      );
+    }
+    SlackChannel[name] = stubIsAsync ? asyncFalseStub(name) : syncNullStub(name);
+  } else {
+    throw new Error(
+      `slack-channel.service.js: meta-channel.service.js declares "${name}" with no matching entry in `
+      + 'IMPLEMENTATIONS or STUBS. Add one so this driver never silently lacks a method the rest of the bot calls.'
+    );
+  }
+}
+
+SlackChannel._slackUserId = slackUserId;
+SlackChannel._getDmChannelId = getDmChannelId;
+
+module.exports = SlackChannel;

--- a/bot/shared/services/messaging/slack-channel.service.js
+++ b/bot/shared/services/messaging/slack-channel.service.js
@@ -457,13 +457,7 @@ async function sendInteractiveMessage(to, listData) {
     const client = getClient();
     const channel = await getDmChannelId(slackUserId(to));
     const { header, body, footer, action } = listData;
-    const { sections } = action || {};
-    const options = (sections || []).flatMap((s) => s.rows || []);
-
-    if (!options.length) {
-      logToFile('⚠️ Slack: no options provided for interactive list', { listData });
-      return false;
-    }
+    const { sections, buttons } = action || {};
 
     const headerText = header?.text || header;
     const bodyText = body?.text || body;
@@ -472,18 +466,45 @@ async function sendInteractiveMessage(to, listData) {
     const blocks = [];
     if (headerText) blocks.push({ type: 'header', text: { type: 'plain_text', text: String(headerText).slice(0, 150) } });
     if (bodyText) blocks.push({ type: 'section', text: { type: 'mrkdwn', text: bodyText } });
-    blocks.push({
-      type: 'actions',
-      elements: [{
-        type: 'static_select',
-        action_id: 'list_select',
-        placeholder: { type: 'plain_text', text: action?.button || 'Choose an option' },
-        options: options.slice(0, 100).map((opt) => ({
-          text: { type: 'plain_text', text: String(opt.title).slice(0, 75) },
-          value: opt.id,
-        })),
-      }],
-    });
+
+    // Meta's interactive.type: 'button' shape (action.buttons: [{type:'reply', reply:{id,title}}],
+    // e.g. exam-checker.orchestrator.js's "Add more"/"Process now" prompt) needs real Slack buttons,
+    // not a select-menu list — the two shapes are mutually exclusive on Meta and must stay so here,
+    // matching sendInteractiveButtons' own block-building exactly so a click round-trips the same way.
+    if (buttons?.length) {
+      blocks.push({
+        type: 'actions',
+        elements: buttons.map((btn) => {
+          const id = btn.reply?.id ?? btn.id;
+          const title = btn.reply?.title ?? btn.title;
+          return {
+            type: 'button',
+            text: { type: 'plain_text', text: String(title).substring(0, 75) },
+            value: id,
+            action_id: id,
+          };
+        }),
+      });
+    } else {
+      const options = (sections || []).flatMap((s) => s.rows || []);
+      if (!options.length) {
+        logToFile('⚠️ Slack: no options provided for interactive list', { listData });
+        return false;
+      }
+      blocks.push({
+        type: 'actions',
+        elements: [{
+          type: 'static_select',
+          action_id: 'list_select',
+          placeholder: { type: 'plain_text', text: action?.button || 'Choose an option' },
+          options: options.slice(0, 100).map((opt) => ({
+            text: { type: 'plain_text', text: String(opt.title).slice(0, 75) },
+            value: opt.id,
+          })),
+        }],
+      });
+    }
+
     if (footerText) blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: footerText }] });
 
     await client.chat.postMessage({ channel, text: bodyText || headerText || 'Please choose an option', blocks });

--- a/bot/shared/services/messaging/slack-channel.service.js
+++ b/bot/shared/services/messaging/slack-channel.service.js
@@ -64,6 +64,12 @@ function slackUserId(to) {
   return raw.startsWith(withPrefix) ? raw.slice(withPrefix.length) : raw;
 }
 
+// Media ids carry the same "slack:" prefix as user identities (minted by
+// slack-events.adapter.js#toPrefixedMediaId) so the messaging router can tell
+// a Slack file id apart from a WhatsApp media id with no DB lookup. Stripped
+// here, once, before ever touching the real Slack Web API.
+const stripSlackPrefix = slackUserId;
+
 // ── Slack Web API client (lazy) ──────────────────────────────────────────────
 // Mirrors baileys-connection.js's lazy-require convention: nothing touches
 // @slack/web-api until a send actually happens, and tests can jest.doMock
@@ -236,7 +242,8 @@ function startContinuousTypingIndicator() {
 
 async function getMediaInfo(mediaId) {
   const client = getClient();
-  const result = await client.files.info({ file: mediaId });
+  const fileId = stripSlackPrefix(mediaId);
+  const result = await client.files.info({ file: fileId });
   const file = result?.file;
   if (!file) throw new Error(`Slack: no file info for id "${mediaId}"`);
   return { url: file.url_private, mime_type: file.mimetype, file_size: file.size };

--- a/bot/shared/services/messaging/slack-modal-flow.js
+++ b/bot/shared/services/messaging/slack-modal-flow.js
@@ -1,0 +1,117 @@
+/**
+ * Slack Block Kit modal renderer — the Flow-equivalent for Slack, but NOT
+ * built on text-flow.js's one-question-per-message engine. That engine
+ * exists only because Baileys can't render a native multi-field form and
+ * must degrade to asking one field at a time; Slack modals render a whole
+ * screen's fields in ONE shot and submit them all at once via
+ * view_submission, so reusing the step-sequencing machinery here would
+ * degrade a channel that doesn't need degrading.
+ *
+ * Instead, this calls a *-endpoint.js's own {init, exchange, back} functions
+ * directly — the same "the endpoint is the renderer-agnostic source of
+ * truth" insight endpoint-text-flow.js is built on, just with a much
+ * thinner renderer on top, because Slack modals don't need step-flattening.
+ *
+ * State (which kind/screen a view represents, plus the endpoint's own
+ * flowToken) is carried in Slack's own `private_metadata` field — Slack
+ * round-trips this unchanged on every subsequent interaction against a view
+ * or any view pushed from it, so no NEW Redis session is needed here; the
+ * endpoint's own flowToken-keyed Redis state (already channel-scoped, since
+ * a Slack flowToken is minted per-conversation, never shared across
+ * channels) is reused unchanged.
+ */
+
+const { logToFile } = require('../../utils/logger');
+
+function isTerminalScreen(screen) {
+  return screen === 'SUCCESS';
+}
+
+function encodeMetadata(kind, screen, flowToken) {
+  return JSON.stringify({ kind, screen, flowToken });
+}
+
+function decodeMetadata(privateMetadata) {
+  try {
+    return JSON.parse(privateMetadata || '{}');
+  } catch (error) {
+    logToFile('⚠️ slack-modal-flow: failed to decode private_metadata', { error: error.message });
+    return {};
+  }
+}
+
+/**
+ * @param {object} config
+ * @param {string} config.kind - registry key, e.g. 'registration'
+ * @param {(ctx: object) => Promise<{screen: string, data: object}>} config.init
+ * @param {(ctx: object, screen: string, screenData: object) => Promise<{screen: string, data: object} | {data: {error: {message: string}}}>} config.exchange
+ * @param {(ctx: object, screen: string) => Promise<{screen: string, data: object}>} [config.back]
+ * @param {(screen: string, data: object, ctx: object) => object} config.screenToView - builds a Slack `view` object for a screen
+ * @param {(screen: string, stateValues: object) => object} config.viewToScreenData - extracts screenData from a view_submission's state.values
+ * @param {Object<string, string>} config.firstInputBlockId - per-screen block_id to attach a validation error to (screen -> blockId)
+ * @param {(response: {screen: string, data: object}, ctx: object) => Promise<void>} [config.onFinish] - called once, on the terminal screen
+ */
+function buildEndpointModal(config) {
+  const { kind, init, exchange, back, screenToView, viewToScreenData, firstInputBlockId, onFinish } = config;
+
+  if (!kind || typeof init !== 'function' || typeof exchange !== 'function'
+      || typeof screenToView !== 'function' || typeof viewToScreenData !== 'function') {
+    throw new Error('slack-modal-flow: buildEndpointModal needs { kind, init, exchange, screenToView, viewToScreenData }');
+  }
+
+  return {
+    kind,
+
+    /** Called when a shortcut/button opens the FIRST modal. Returns a Slack `views.open` `view` argument. */
+    async buildInitialView(ctx) {
+      const response = await init(ctx);
+      const metadata = encodeMetadata(kind, response.screen, ctx.flowToken);
+      return screenToView(response.screen, response.data, { ...ctx, metadata });
+    },
+
+    /**
+     * Called from a `view_submission` interaction.
+     * @returns one of:
+     *   {response_action: 'push', view} — advance to the next screen
+     *   {response_action: 'clear'}      — the flow finished (terminal screen)
+     *   {response_action: 'errors', errors: {blockId: message}} — validation failure, modal stays open
+     */
+    async handleSubmission(ctx, screen, stateValues) {
+      const screenData = viewToScreenData(screen, stateValues);
+      const response = await exchange(ctx, screen, screenData);
+
+      if (response?.data?.error) {
+        const blockId = (firstInputBlockId || {})[screen];
+        return {
+          response_action: 'errors',
+          errors: { [blockId]: response.data.error.message },
+        };
+      }
+
+      if (isTerminalScreen(response.screen)) {
+        if (onFinish) await onFinish(response, ctx);
+        return { response_action: 'clear' };
+      }
+
+      const metadata = encodeMetadata(kind, response.screen, ctx.flowToken);
+      const nextView = screenToView(response.screen, response.data, { ...ctx, metadata });
+      return { response_action: 'push', view: nextView };
+    },
+
+    /**
+     * Called from a "Back" button click (a block_actions interaction on a
+     * per-screen Back element, NOT Slack's native modal-stack pop — see the
+     * file header on registration's country-dependent branching, which a
+     * client-side pop cannot express).
+     * @returns the previous screen's Slack view, for a `views.update` call.
+     */
+    async handleBack(ctx, screen) {
+      if (!back) return null;
+      const response = await back(ctx, screen);
+      const metadata = encodeMetadata(kind, response.screen, ctx.flowToken);
+      return screenToView(response.screen, response.data, { ...ctx, metadata });
+    },
+  };
+}
+
+module.exports = { buildEndpointModal, encodeMetadata, decodeMetadata, isTerminalScreen };

--- a/bot/shared/services/messaging/slack-modal-flow.js
+++ b/bot/shared/services/messaging/slack-modal-flow.js
@@ -27,8 +27,23 @@ function isTerminalScreen(screen) {
   return screen === 'SUCCESS';
 }
 
-function encodeMetadata(kind, screen, flowToken) {
-  return JSON.stringify({ kind, screen, flowToken });
+/**
+ * @param {string} kind
+ * @param {string} screen
+ * @param {string} flowToken
+ * @param {object} [carry] - optional renderer-chosen subset of the endpoint's
+ *   response `data` to round-trip verbatim to the NEXT interaction against
+ *   this view (or any view pushed/updated from it) — e.g. attendance's
+ *   ADD_STUDENT screen carries {list_id, class_display} here so a
+ *   non-view_submission block_actions click (the "I'm Done" button; see
+ *   slack-views/attendance.view.js) can still recover them, since Slack does
+ *   NOT round-trip a view's rendered `data` on a plain block_actions
+ *   interaction the way it round-trips private_metadata. Every other kind
+ *   omits this — private_metadata stays exactly {kind, screen, flowToken} for
+ *   registration/settings/exam_confirm, unchanged.
+ */
+function encodeMetadata(kind, screen, flowToken, carry) {
+  return JSON.stringify(carry ? { kind, screen, flowToken, carry } : { kind, screen, flowToken });
 }
 
 function decodeMetadata(privateMetadata) {
@@ -47,12 +62,13 @@ function decodeMetadata(privateMetadata) {
  * @param {(ctx: object, screen: string, screenData: object) => Promise<{screen: string, data: object} | {data: {error: {message: string}}}>} config.exchange
  * @param {(ctx: object, screen: string) => Promise<{screen: string, data: object}>} [config.back]
  * @param {(screen: string, data: object, ctx: object) => object} config.screenToView - builds a Slack `view` object for a screen
- * @param {(screen: string, stateValues: object) => object} config.viewToScreenData - extracts screenData from a view_submission's state.values
+ * @param {(screen: string, stateValues: object, carried: object) => object} config.viewToScreenData - extracts screenData from a view_submission's state.values, plus whatever was carried in private_metadata (see metadataCarry below)
  * @param {Object<string, string>} config.firstInputBlockId - per-screen block_id to attach a validation error to (screen -> blockId)
  * @param {(response: {screen: string, data: object}, ctx: object) => Promise<void>} [config.onFinish] - called once, on the terminal screen
+ * @param {(screen: string, data: object) => (object|undefined)} [config.metadataCarry] - optional: pick a subset of a screen's response `data` to round-trip in private_metadata's `carry` field, for kinds whose endpoint needs data back that view_submission's own state.values can't carry (e.g. attendance's ADD_STUDENT needs {list_id, class_display} back on every submission — see slack-views/attendance.view.js)
  */
 function buildEndpointModal(config) {
-  const { kind, init, exchange, back, screenToView, viewToScreenData, firstInputBlockId, onFinish } = config;
+  const { kind, init, exchange, back, screenToView, viewToScreenData, firstInputBlockId, onFinish, metadataCarry } = config;
 
   if (!kind || typeof init !== 'function' || typeof exchange !== 'function'
       || typeof screenToView !== 'function' || typeof viewToScreenData !== 'function') {
@@ -65,7 +81,8 @@ function buildEndpointModal(config) {
     /** Called when a shortcut/button opens the FIRST modal. Returns a Slack `views.open` `view` argument. */
     async buildInitialView(ctx) {
       const response = await init(ctx);
-      const metadata = encodeMetadata(kind, response.screen, ctx.flowToken);
+      const carry = metadataCarry ? metadataCarry(response.screen, response.data) : undefined;
+      const metadata = encodeMetadata(kind, response.screen, ctx.flowToken, carry);
       return screenToView(response.screen, response.data, { ...ctx, metadata });
     },
 
@@ -76,8 +93,8 @@ function buildEndpointModal(config) {
      *   {response_action: 'clear'}      — the flow finished (terminal screen)
      *   {response_action: 'errors', errors: {blockId: message}} — validation failure, modal stays open
      */
-    async handleSubmission(ctx, screen, stateValues) {
-      const screenData = viewToScreenData(screen, stateValues);
+    async handleSubmission(ctx, screen, stateValues, carried) {
+      const screenData = viewToScreenData(screen, stateValues, carried || {});
       const response = await exchange(ctx, screen, screenData);
 
       if (response?.data?.error) {
@@ -93,7 +110,8 @@ function buildEndpointModal(config) {
         return { response_action: 'clear' };
       }
 
-      const metadata = encodeMetadata(kind, response.screen, ctx.flowToken);
+      const carry = metadataCarry ? metadataCarry(response.screen, response.data) : undefined;
+      const metadata = encodeMetadata(kind, response.screen, ctx.flowToken, carry);
       const nextView = screenToView(response.screen, response.data, { ...ctx, metadata });
       return { response_action: 'push', view: nextView };
     },

--- a/bot/shared/services/messaging/slack-web-client.js
+++ b/bot/shared/services/messaging/slack-web-client.js
@@ -1,0 +1,53 @@
+/**
+ * Thin wrapper around @slack/web-api's WebClient for the modal renderer and
+ * anything else that needs to open/push/update a modal or post a plain
+ * message outside the normal send-driver path (slack-channel.service.js
+ * covers ordinary outbound sends; this file exists so slack-modal-flow.js
+ * and slack-flow-registry.js never import @slack/web-api directly — every
+ * test mocks THIS module instead, never the real Slack SDK).
+ *
+ * Lazy client construction mirrors slack-channel.service.js's own
+ * convention — nothing touches @slack/web-api until a call actually happens.
+ */
+
+let cachedClient = null;
+function getClient() {
+  if (cachedClient) return cachedClient;
+  // eslint-disable-next-line global-require -- lazy on purpose; see file header
+  const { WebClient } = require('@slack/web-api');
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (!token) {
+    throw new Error('slack-web-client: SLACK_BOT_TOKEN is not set');
+  }
+  cachedClient = new WebClient(token);
+  return cachedClient;
+}
+
+/** Opens a NEW modal from a trigger_id (must be used within Slack's ~3s window). */
+async function openView(triggerId, view) {
+  const client = getClient();
+  return client.views.open({ trigger_id: triggerId, view });
+}
+
+/** Pushes a new view onto an already-open modal's stack. */
+async function pushView(triggerId, view) {
+  const client = getClient();
+  return client.views.push({ trigger_id: triggerId, view });
+}
+
+/** Replaces the CURRENT view in place (used for BACK navigation). */
+async function updateView(viewId, view) {
+  const client = getClient();
+  return client.views.update({ view_id: viewId, view });
+}
+
+/** Posts a plain message to a Slack user's DM — used by onFinish handlers on a completed flow. */
+async function postMessage(slackUserId, text) {
+  const client = getClient();
+  const opened = await client.conversations.open({ users: slackUserId });
+  const channel = opened?.channel?.id;
+  if (!channel) throw new Error(`slack-web-client: could not open a DM with user ${slackUserId}`);
+  return client.chat.postMessage({ channel, text });
+}
+
+module.exports = { openView, pushView, updateView, postMessage };

--- a/bot/shared/services/openai.service.js
+++ b/bot/shared/services/openai.service.js
@@ -727,7 +727,8 @@ Keep your responses relatively short as they will be sent via WhatsApp messages.
    - OR mention a subject + grade in a way that suggests they want teaching materials
 2. "presentation" - ONLY if they explicitly ask to CREATE, GENERATE, or MAKE a presentation/slides
 3. "video" - if they ask for a video, educational video, or want to watch/see a video on a topic (for any grade or subject)
-4. "general" - for questions, advice, guidance, or any other conversation (including "how to teach X")
+4. "quiz" - if they ask to CREATE, GENERATE, or MAKE a quiz, test, or set of questions, or ask to be quizzed/tested on a topic
+5. "general" - for questions, advice, guidance, or any other conversation (including "how to teach X")
 
 IMPORTANT: Distinguish carefully:
 - "Create a lesson plan about X" → lesson_plan
@@ -739,6 +740,9 @@ IMPORTANT: Distinguish carefully:
 - "Do you have a video on fractions?" → video
 - "I want to watch a video about photosynthesis" → video
 - "Video dikhao on multiplication" → video
+- "Create a quiz on X" → quiz (explicit quiz request always wins, even with a topic/grade)
+- "Quiz on X for grade Y" → quiz
+- "Quiz me on X" → quiz
 - "How do I teach X?" → general (they want advice, not a document)
 - "Help me figure out how to teach X" → general (they want guidance)
 - "What's the best way to teach X?" → general (they want advice)
@@ -757,12 +761,15 @@ Examples:
 - "ویڈیو چاہیے" (need video) → video
 - "Show me a grade 3 maths video" → video
 - "Do you have videos on science?" → video
+- "Create a quiz on operating systems for grade 12" → quiz
+- "quiz banao" (make a quiz) → quiz
+- "کوئز بنائیں" (make a quiz) → quiz
 - "یہ کیسے کام کرتا ہے؟" (how does this work?) → general
 - "How do I teach photosynthesis?" → general
 - "Figure out how to teach X" → general
 - "What's a good way to explain X?" → general
 
-Return ONLY one word: lesson_plan, presentation, video, or general`
+Return ONLY one word: lesson_plan, presentation, video, quiz, or general`
           },
           {
             role: 'user',
@@ -782,6 +789,8 @@ Return ONLY one word: lesson_plan, presentation, video, or general`
         return { type: 'presentation', message };
       } else if (intent === 'video') {
         return { type: 'video', message };
+      } else if (intent === 'quiz') {
+        return { type: 'quiz', message };
       } else {
         return { type: 'general', message };
       }
@@ -815,6 +824,20 @@ Return ONLY one word: lesson_plan, presentation, video, or general`
       'video', 'videos', 'watch', 'ویڈیو', 'ویڈیوز',
       'dikhao', 'dekho', 'دکھاؤ', 'دیکھو'
     ];
+
+    const quizKeywords = [
+      'quiz', 'کوئز'
+    ];
+
+    // Checked before lessonPlanKeywords: "quiz" is a more specific request
+    // than the generic "lesson"/"lesson plan" keywords, and isQuizIntent()
+    // (the real gate in text-message.handler.js) already applies its own
+    // "lesson plan" negative-dominance check before this fallback ever runs.
+    for (const keyword of quizKeywords) {
+      if (lowerMessage.includes(keyword.toLowerCase())) {
+        return { type: 'quiz', message };
+      }
+    }
 
     for (const keyword of lessonPlanKeywords) {
       if (lowerMessage.includes(keyword.toLowerCase())) {

--- a/bot/shared/services/quiz/quiz-intent-router.service.js
+++ b/bot/shared/services/quiz/quiz-intent-router.service.js
@@ -30,6 +30,7 @@ const { logToFile } = require('../../utils/logger');
 const PENDING_INTENT_KEY = (userId) => `quiz_intent_pending:${userId}`;
 const PENDING_RESUME_KEY = (userId) => `pending_quiz_resume:${userId}`;
 const RESUME_TTL_SEC = 30 * 60;
+const PENDING_INTENT_TTL_SEC = 30 * 60;
 
 const COPY = {
   no_class: {
@@ -51,6 +52,14 @@ const COPY = {
   show_in_chat_intro: {
     en: (topic) => `Generating a 5-question preview quiz on "${topic}"…`,
     ur: (topic) => `"${topic}" پر 5 سوالات کا پیش نظری کوئز تیار کر رہی ہوں…`
+  },
+  confirm: {
+    en: (topic) => (topic
+      ? `Want a quiz on "${topic}"? I can send it to your class, or show a preview here in chat.`
+      : 'Want a quiz? I can send it to your class, or show a preview here in chat.'),
+    ur: (topic) => (topic
+      ? `کیا آپ "${topic}" پر کوئز چاہتے ہیں؟ میں اسے آپ کی کلاس کو بھیج سکتی ہوں، یا یہاں چیٹ میں ایک جھلک دکھا سکتی ہوں۔`
+      : 'کیا آپ کوئز چاہتے ہیں؟ میں اسے آپ کی کلاس کو بھیج سکتی ہوں، یا یہاں چیٹ میں ایک جھلک دکھا سکتی ہوں۔')
   }
 };
 
@@ -281,6 +290,76 @@ async function _handleShowInChat(user, from, intent) {
 }
 
 /**
+ * Extracts the quiz topic (if any) from a natural-language message, e.g.
+ * "create a quiz on operating systems for grade 12" -> "operating systems".
+ * Mirrors VideoOrchestrator.extractTopicFromMessage's shape (a small,
+ * cheap LLM call, null on anything that doesn't look like a clear topic) —
+ * this is a courtesy for pre-filling the confirmation copy and the eventual
+ * Quiz Manager Flow, not a gate: a null topic still shows the two buttons.
+ */
+async function extractQuizTopic(message) {
+  try {
+    // eslint-disable-next-line global-require -- lazy, avoids a require cycle with text-message.handler.js
+    const OpenAIService = require('../openai.service');
+    const response = await OpenAIService.createChatCompletion({
+      model: 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'system',
+          content: 'Extract the quiz topic from the user message. Return ONLY the topic, nothing else. '
+            + 'If no clear topic is found, return null. Examples:\n'
+            + '- "create a quiz on operating systems for grade 12" -> "operating systems"\n'
+            + '- "quiz on photosynthesis for grade 5" -> "photosynthesis"\n'
+            + '- "quiz me on fractions" -> "fractions"\n'
+            + '- "کوئز بنائیں اسلامیات پر" -> "اسلامیات"'
+        },
+        { role: 'user', content: message }
+      ],
+      max_tokens: 50,
+      temperature: 0.3
+    });
+    const topic = response.choices[0].message.content.trim();
+    if (!topic || topic.toLowerCase() === 'null') return null;
+    return topic;
+  } catch (error) {
+    logToFile('⚠️ Quiz topic extraction failed — proceeding with no topic', { error: error.message });
+    return null;
+  }
+}
+
+/**
+ * Called from text-message.handler.js when isQuizIntent(messageBody) is true.
+ * Stashes { topic, language } under quiz_intent_pending:<userId> (consumed
+ * by handleConfirmationButton below) and shows the two-button confirmation.
+ *
+ * @param {Object} user - users row (must be present)
+ * @param {string} from - recipient identifier (phone or a channel-prefixed id)
+ * @param {string} messageBody - the raw inbound message
+ * @param {string} language - the user's response language ('en' | 'ur')
+ */
+async function promptQuizConfirmation(user, from, messageBody, language) {
+  if (!user || !user.id) {
+    logToFile('⚠️ quiz intent detected without a resolved user — ignoring', { from });
+    return;
+  }
+
+  const lang = language || 'en';
+  const topic = await extractQuizTopic(messageBody);
+
+  await _redisSet(PENDING_INTENT_KEY(user.id), JSON.stringify({ topic: topic || '', language: lang }), PENDING_INTENT_TTL_SEC);
+
+  await WhatsAppService.sendInteractiveButtons(from, {
+    body: _copy('confirm', lang)(topic),
+    buttons: [
+      { id: 'quiz_send_to_class', title: lang === 'ur' ? 'کلاس کو بھیجیں' : 'Send to class' },
+      { id: 'quiz_show_in_chat', title: lang === 'ur' ? 'چیٹ میں دکھائیں' : 'Show in chat' }
+    ]
+  });
+
+  logToFile('✅ Quiz intent confirmation shown', { userId: user.id, topic, language: lang });
+}
+
+/**
  * Public entry called from whatsapp-bot.js button-reply branch.
  *
  * @param {string} buttonId — 'quiz_send_to_class' | 'quiz_show_in_chat'
@@ -342,11 +421,14 @@ async function tryResumeAfterClassFlow(user, from) {
 }
 
 module.exports = {
+  promptQuizConfirmation,
   handleConfirmationButton,
   tryResumeAfterClassFlow,
   // Exposed for tests
   _PENDING_INTENT_KEY: PENDING_INTENT_KEY,
   _PENDING_RESUME_KEY: PENDING_RESUME_KEY,
   _RESUME_TTL_SEC: RESUME_TTL_SEC,
-  _COPY: COPY
+  _PENDING_INTENT_TTL_SEC: PENDING_INTENT_TTL_SEC,
+  _COPY: COPY,
+  _extractQuizTopic: extractQuizTopic
 };

--- a/bot/shared/services/reading/passage-generation.service.js
+++ b/bot/shared/services/reading/passage-generation.service.js
@@ -471,8 +471,8 @@ class PassageGenerationService {
 1. Show this alphabet grid to the student
 2. Ask the student to read the letters aloud going ${directionText} across each row, starting from row 1 at the top
 3. The numbers with arrows (1→, 2→, etc.) show the reading direction for each row
-4. Record the student reading with WhatsApp voice message
-5. Send the recording back to me
+4. Record the student reading as a voice message
+5. Send the recording back to me, right here in this chat
 6. Use encouraging, supportive tone
 7. Maximum 4-5 sentences
 8. NO markdown, NO meta-commentary`;
@@ -481,8 +481,8 @@ class PassageGenerationService {
         instructionsPrompt = `Generate a brief message in language code "${userLanguage}" instructing the teacher to:
 1. Show this passage to the student
 2. Ask the student to read it aloud
-3. Record the student reading with WhatsApp voice message
-4. Send the recording back to me
+3. Record the student reading as a voice message
+4. Send the recording back to me, right here in this chat
 5. Use encouraging, supportive tone
 6. Maximum 3-4 sentences
 7. NO markdown, NO meta-commentary`;

--- a/bot/shared/services/slack-signature.service.js
+++ b/bot/shared/services/slack-signature.service.js
@@ -1,0 +1,55 @@
+/**
+ * Slack request-signature verification — the Slack analogue of
+ * flow-encryption.service.js's role for Meta Flows, but VERIFYING a request
+ * (Slack signs, never encrypts, its payload body) rather than
+ * encrypting/decrypting one.
+ *
+ * Slack signs every request to your Events API / Interactivity URL with
+ * HMAC-SHA256 over `v0:<timestamp>:<raw body>`, keyed by SLACK_SIGNING_SECRET,
+ * sent as the `X-Slack-Signature` header alongside `X-Slack-Request-Timestamp`
+ * (docs: https://api.slack.com/authentication/verifying-requests-from-slack).
+ *
+ * Verification needs the EXACT raw request bytes Slack signed — not the
+ * body Express's json()/urlencoded() parsers would reconstruct via
+ * JSON.stringify/qs.stringify, which can differ in whitespace/key order from
+ * what was actually sent over the wire. Callers must capture `req.rawBody`
+ * (a Buffer or string) BEFORE any body parser touches the request — see
+ * the raw-body-capturing middleware in whatsapp-bot.js's Slack route mount.
+ */
+
+const crypto = require('crypto');
+
+const SIGNATURE_VERSION = 'v0';
+const MAX_TIMESTAMP_SKEW_SECONDS = 60 * 5; // Slack's own documented replay-protection window
+
+function isConfigured() {
+  return Boolean(process.env.SLACK_SIGNING_SECRET);
+}
+
+/**
+ * @param {import('express').Request} req - must carry req.rawBody (Buffer|string),
+ *   captured before any body-parsing middleware ran.
+ * @returns {boolean}
+ */
+function verify(req) {
+  if (!isConfigured()) return false;
+
+  const timestamp = req.headers['x-slack-request-timestamp'];
+  const signature = req.headers['x-slack-signature'];
+  if (!timestamp || !signature) return false;
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSeconds - Number(timestamp)) > MAX_TIMESTAMP_SKEW_SECONDS) return false;
+
+  const rawBody = req.rawBody != null ? req.rawBody.toString('utf8') : '';
+  const base = `${SIGNATURE_VERSION}:${timestamp}:${rawBody}`;
+  const expected = `${SIGNATURE_VERSION}=`
+    + crypto.createHmac('sha256', process.env.SLACK_SIGNING_SECRET).update(base).digest('hex');
+
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  const signatureBuf = Buffer.from(String(signature), 'utf8');
+  if (expectedBuf.length !== signatureBuf.length) return false; // timingSafeEqual requires equal length
+  return crypto.timingSafeEqual(expectedBuf, signatureBuf);
+}
+
+module.exports = { isConfigured, verify };

--- a/bot/shared/services/video/video-assembly.service.js
+++ b/bot/shared/services/video/video-assembly.service.js
@@ -167,8 +167,18 @@ class VideoAssemblyService {
       const VideoSessionService = require('./video-session.service');
       const messages = VideoSessionService.getProgressMessages(language);
 
-      await WhatsAppService.sendVideo(from, fs.readFileSync(finalVideoPath), tempDir, messages.complete);
-      logToFile('Video sent to user', { videoRequestId, from });
+      // Prefer the durable R2 URL already uploaded above — avoids a wasted
+      // raw-buffer upload whenever it succeeded, and sidesteps every
+      // channel's own per-upload size limits (e.g. Discord's ~8MB safe
+      // ceiling on a bot DM channel). Only fall back to the raw-buffer
+      // sendVideo() when R2 upload failed after all retries (finalVideoUrl
+      // is null in that case).
+      if (finalVideoUrl) {
+        await WhatsAppService.sendVideoFromUrl(from, finalVideoUrl, messages.complete);
+      } else {
+        await WhatsAppService.sendVideo(from, fs.readFileSync(finalVideoPath), tempDir, messages.complete);
+      }
+      logToFile('Video sent to user', { videoRequestId, from, deliveredViaUrl: Boolean(finalVideoUrl) });
 
       // Issue #7: Send portal prompt after video delivery (using user's preferred language)
       const userPreferredLanguage = userId ? await getUserLanguage(userId) : language;

--- a/bot/shared/services/video/video-orchestrator.service.js
+++ b/bot/shared/services/video/video-orchestrator.service.js
@@ -515,7 +515,13 @@ class VideoOrchestrator {
           customization,
           style,  // Issue #35: Store selected style
           status: 'pending',
-          created_at: new Date().toISOString()
+          created_at: new Date().toISOString(),
+          // The exact channel this request came in on (a bare WhatsApp phone
+          // number, or "slack:<id>") — stored so a stale-recovery re-queue
+          // (sqs-worker.js) can restore it even if the re-queued job payload
+          // ever drops `from`, rather than falling back to a
+          // users.phone_number re-derivation that is WhatsApp-only.
+          recipient_identifier: from,
         })
         .select('id')
         .single();

--- a/bot/whatsapp-bot.js
+++ b/bot/whatsapp-bot.js
@@ -29,14 +29,52 @@ const constants = require('./shared/utils/constants');
 const { setUserLanguage, setLanguageLock } = require('./shared/utils/language-cache');
 
 // Import Database helpers
-const { getOrCreateUser, trackChatStart } = require('./shared/database/bot-helpers');
+const { getOrCreateUser, getOrCreateUserByChannel, trackChatStart } = require('./shared/database/bot-helpers');
 const supabase = require('./shared/config/supabase');
 
 // Import Routes (Flow encryption endpoints)
 const flowEndpointRoutes = require('./shared/routes/flow-endpoint.routes');
 
+// The channel-registry map from additive-driver name -> the `channel` value
+// user_channels/getOrCreateUserByChannel expects (registry driver names are
+// per-implementation — meta/baileys both mean 'whatsapp' as an identity
+// family; slack/discord map 1:1). See driverForIdentity() below.
+const { driverForIdentifier } = require('./shared/services/messaging/channel-registry');
+const CHANNEL_FAMILY = { slack: 'slack', discord: 'discord' };
+
+/**
+ * Resolves the (channel, channelUserId) pair for a `from` identifier, or null
+ * for a bare WhatsApp phone number — the one place identity resolution needs
+ * to know about additive channels at all; every other line below already
+ * operates on the resolved `user`/`message`/`messageType`, never re-deriving
+ * identity from `from` itself.
+ */
+function resolveChannelIdentity(from) {
+  const driverName = driverForIdentifier(from);
+  if (!driverName) return null;
+  const prefix = `${driverName}:`; // CHANNEL_PREFIXES value happens to equal the driver name today
+  return { channel: CHANNEL_FAMILY[driverName] || driverName, channelUserId: String(from).slice(prefix.length) };
+}
+
 // Create Express app
 const app = express();
+
+// Slack's request signature is an HMAC over the EXACT raw bytes it sent —
+// must be captured before ANY body parser (including the global
+// express.json() below) reconstructs the body, since a reconstruction can
+// differ in whitespace/key order from the wire bytes. Mounted first, and
+// scoped to the Slack path only so every other route's body-parsing is
+// untouched.
+app.use('/api/slack', express.raw({ type: '*/*' }), (req, res, next) => {
+  req.rawBody = req.body; // a Buffer, from express.raw() above
+  next();
+});
+// handleWebhookPost is a hoisted function declaration defined further down
+// this file — safe to reference here since this code only ever RUNS at
+// require-time, after every top-level declaration has already been hoisted.
+const mountSlackRoutes = require('./shared/routes/slack-interactions.routes');
+app.use('/api/slack', mountSlackRoutes(handleWebhookPost));
+
 app.use(express.json());
 
 // Mount routes (Flow encryption endpoints)
@@ -358,10 +396,15 @@ async function handleWebhookPost(req, res) {
     // Show typing indicator
     await WhatsAppService.showTypingIndicator(from, message.id);
 
-    // Get or create user in database
+    // Get or create user in database — a bare phone number goes through the
+    // untouched legacy path; a prefixed additive-channel identifier
+    // (e.g. "slack:U0123ABC") resolves through the multi-homed path instead.
     let user = null;
     try {
-      user = await getOrCreateUser(from);
+      const channelIdentity = resolveChannelIdentity(from);
+      user = channelIdentity
+        ? await getOrCreateUserByChannel(channelIdentity.channel, channelIdentity.channelUserId)
+        : await getOrCreateUser(from);
       logToFile('User retrieved/created', { userId: user.id, phoneNumber: from });
     } catch (error) {
       logToFile('⚠️ Error with database user operation', { error: error.message });

--- a/bot/whatsapp-bot.js
+++ b/bot/whatsapp-bot.js
@@ -1831,8 +1831,22 @@ const PERSISTENT_CONNECTION_DRIVERS = {
     },
     close: () => require('./shared/services/messaging/baileys-connection').close(),
   },
-  // discord: { isActive, attachInbound, onLogoutExit: null, close } — added
-  // once a Discord Gateway driver ships; nothing above needs to change.
+  discord: {
+    isActive: (env) => require('./shared/config/feature-availability').resolveActiveChannels(env).includes('discord'),
+    attachInbound: async (dispatch) => {
+      const discordEventsAdapter = require('./shared/services/messaging/inbound/discord-events.adapter');
+      await discordEventsAdapter.attach(dispatch);
+    },
+    // Unlike Baileys, there is no mid-session "you have been logged out"
+    // event for a bot token — a revoked/regenerated DISCORD_BOT_TOKEN
+    // surfaces as a LOGIN failure (at connect() time), not a live-session
+    // event, so there is nothing for onLogoutExit to subscribe to here.
+    // The login-failure path is already handled by attachInbound's own
+    // try/catch below (logs and continues — Discord being down must never
+    // take WhatsApp down), so this intentionally stays null.
+    onLogoutExit: null,
+    close: () => require('./shared/services/messaging/discord-connection').close(),
+  },
 };
 
 /**

--- a/bot/whatsapp-bot.js
+++ b/bot/whatsapp-bot.js
@@ -1750,26 +1750,6 @@ Si no solicitaste esto, ignora este mensaje.`
 });
 
 /**
- * If CHANNEL_DRIVER resolves to `baileys`, attaches the Baileys inbound
- * listener (shared/services/messaging/inbound/baileys-socket.adapter.js) so
- * incoming WhatsApp Web messages reach handleWebhookPost the same way a real
- * Meta webhook POST does. No-op for the `meta` channel (Express's own
- * /webhook route already handles that). Failures here are logged, never
- * thrown — a Baileys connection problem must not crash server boot.
- */
-async function wireBaileysInboundIfSelected() {
-  const { resolveChannelDriver } = require('./shared/config/feature-availability');
-  if (resolveChannelDriver(process.env) !== 'baileys') return;
-
-  try {
-    const baileysSocketAdapter = require('./shared/services/messaging/inbound/baileys-socket.adapter');
-    await baileysSocketAdapter.attach(handleWebhookPost);
-  } catch (error) {
-    logToFile('❌ Failed to attach Baileys inbound listener', { error: error.message, stack: error.stack });
-  }
-}
-
-/**
  * Exit code for "the WhatsApp session is gone; a human must re-pair". Chosen as
  * sysexits.h's EX_CONFIG — conventionally "don't just restart me, fix the
  * configuration" — so it reads as deliberate rather than a random crash.
@@ -1777,7 +1757,63 @@ async function wireBaileysInboundIfSelected() {
 const EXIT_CODE_CHANNEL_LOGGED_OUT = 78;
 
 /**
- * Treat a logged-out channel session as a TERMINAL failure.
+ * Registry of drivers that hold a persistent connection (a socket/Gateway,
+ * not an HTTP webhook) and therefore need boot-time wiring + graceful
+ * shutdown — as opposed to Meta/Slack-style drivers, which are plain
+ * request/response and need nothing here beyond mounting their route.
+ *
+ * Today this has exactly one entry (baileys). Adding a second
+ * persistent-connection driver (e.g. a future Discord Gateway driver) is a
+ * new entry here, not a rewrite of wireInboundListeners/exitOnChannelLogout/
+ * registerChannelShutdownHandlers below — each of those now loops this
+ * registry instead of hardcoding a single driver-name check.
+ */
+const PERSISTENT_CONNECTION_DRIVERS = {
+  baileys: {
+    isActive: (env) => require('./shared/config/feature-availability').resolveChannelDriver(env) === 'baileys',
+    attachInbound: async (dispatch) => {
+      const baileysSocketAdapter = require('./shared/services/messaging/inbound/baileys-socket.adapter');
+      await baileysSocketAdapter.attach(dispatch);
+    },
+    onLogoutExit: (exitFn) => {
+      const connection = require('./shared/services/messaging/baileys-connection');
+      connection.events.on('close', ({ loggedOut }) => {
+        if (!loggedOut) return;
+        logToFile('🔒 WhatsApp session is logged out — re-pairing is required, exiting', {
+          remedy: `delete ${connection.authDir()} and run: npm run pair:baileys`,
+          exitCode: EXIT_CODE_CHANNEL_LOGGED_OUT,
+        });
+        exitFn();
+      });
+    },
+    close: () => require('./shared/services/messaging/baileys-connection').close(),
+  },
+  // discord: { isActive, attachInbound, onLogoutExit: null, close } — added
+  // once a Discord Gateway driver ships; nothing above needs to change.
+};
+
+/**
+ * Attaches every active persistent-connection driver's inbound listener
+ * (e.g. shared/services/messaging/inbound/baileys-socket.adapter.js) so
+ * incoming messages reach handleWebhookPost the same way a real Meta webhook
+ * POST does. No-op for any driver not in PERSISTENT_CONNECTION_DRIVERS
+ * (Express's own routes already handle those). Failures here are logged,
+ * never thrown — a connection problem must not crash server boot.
+ */
+async function wireBaileysInboundIfSelected() {
+  for (const driver of Object.values(PERSISTENT_CONNECTION_DRIVERS)) {
+    if (!driver.isActive(process.env)) continue;
+    try {
+      await driver.attachInbound(handleWebhookPost);
+    } catch (error) {
+      logToFile('❌ Failed to attach persistent-connection inbound listener', { error: error.message, stack: error.stack });
+    }
+  }
+}
+
+/**
+ * Treat a logged-out persistent-connection channel session as a TERMINAL
+ * failure, for every active driver that defines onLogoutExit.
  *
  * baileys-connection.js already refuses to auto-reconnect on
  * DisconnectReason.loggedOut (401) — but that only protects the current
@@ -1789,45 +1825,42 @@ const EXIT_CODE_CHANNEL_LOGGED_OUT = 78;
  *
  * So: say plainly what happened and exit with a distinctive code, letting the
  * supervisor's backoff/alerting surface it to a human instead of spinning
- * silently. No-op for `meta`, which holds no local session.
+ * silently. No-op for any driver without a local session concept.
  */
 function exitOnChannelLogout() {
-  const { resolveChannelDriver } = require('./shared/config/feature-availability');
-  if (resolveChannelDriver(process.env) !== 'baileys') return;
-
-  const connection = require('./shared/services/messaging/baileys-connection');
-  connection.events.on('close', ({ loggedOut }) => {
-    if (!loggedOut) return;
-    logToFile('🔒 WhatsApp session is logged out — re-pairing is required, exiting', {
-      remedy: `delete ${connection.authDir()} and run: npm run pair:baileys`,
-      exitCode: EXIT_CODE_CHANNEL_LOGGED_OUT,
-    });
-    process.exit(EXIT_CODE_CHANNEL_LOGGED_OUT);
-  });
+  for (const driver of Object.values(PERSISTENT_CONNECTION_DRIVERS)) {
+    if (!driver.isActive(process.env) || !driver.onLogoutExit) continue;
+    driver.onLogoutExit(() => process.exit(EXIT_CODE_CHANNEL_LOGGED_OUT));
+  }
 }
 
 /**
- * Close the Baileys socket cleanly on SIGTERM/SIGINT before the process dies.
+ * Close every active persistent-connection driver's socket cleanly on
+ * SIGTERM/SIGINT before the process dies.
  *
  * Without this, an abrupt exit loses Baileys' not-yet-flushed Signal session
  * state (see baileys-connection.js's close()). A PaaS redeploy sends SIGTERM on
  * every release, so this runs on the normal deploy path, not just on manual
- * stops. No-op for the `meta` channel, which holds no local session state.
+ * stops. No-op for any driver without local session state to flush.
  */
 function registerChannelShutdownHandlers() {
-  const { resolveChannelDriver } = require('./shared/config/feature-availability');
-  if (resolveChannelDriver(process.env) !== 'baileys') return;
+  const activeDrivers = Object.values(PERSISTENT_CONNECTION_DRIVERS).filter((d) => d.isActive(process.env));
+  if (activeDrivers.length === 0) return;
 
   let shuttingDown = false;
   const shutdown = async (signal) => {
     if (shuttingDown) return; // a second signal must not cut the flush short
     shuttingDown = true;
-    logToFile(`Received ${signal} — closing Baileys connection before exit`, {});
-    try {
-      await require('./shared/services/messaging/baileys-connection').close();
-    } catch (error) {
-      logToFile('❌ Baileys shutdown failed', { error: error.message });
-    }
+    logToFile(`Received ${signal} — closing active channel connections before exit`, {});
+    await Promise.all(
+      activeDrivers.map(async (driver) => {
+        try {
+          await driver.close();
+        } catch (error) {
+          logToFile('❌ Channel shutdown failed', { error: error.message });
+        }
+      })
+    );
     process.exit(0);
   };
 

--- a/bot/workers/exam-grading.worker.js
+++ b/bot/workers/exam-grading.worker.js
@@ -24,7 +24,6 @@ const {
   AnnotationService,
   DeliveryService
 } = require('../shared/services/exam-checker');
-const supabase = require('../shared/config/supabase');
 const { logToFile } = require('../shared/utils/logger');
 const { runWithCorrelation, generateCorrelationId } = require('../shared/utils/structured-logger');
 
@@ -105,12 +104,16 @@ async function process(payload) {
         error_message: error.message
       });
 
-      // Notify user of failure
+      // Notify user of failure. Reads recipient_identifier off the session
+      // row (the exact channel this request originated on — a bare WhatsApp
+      // phone number, or "slack:<id>") rather than users.phone_number, which
+      // is WhatsApp-only and would misdeliver a Slack-originated session's
+      // failure notice.
       try {
-        const user = await getUser(userId);
-        if (user?.phone_number) {
+        const failedSession = await ExamSessionService.getById(sessionId);
+        if (failedSession?.recipient_identifier) {
           await DeliveryService.sendErrorNotification(
-            user.phone_number,
+            failedSession.recipient_identifier,
             sessionId,
             error.message
           );
@@ -179,8 +182,9 @@ async function processGradingPhase(session, sessionId, userId) {
     studentCount: session.confirmed_students.length
   });
 
-  // Get user phone for progress updates
-  const user = await getUser(userId);
+  // recipient_identifier (not users.phone_number) is the channel this
+  // session originated on — see exam-session.service.js#_createSession.
+  const recipientIdentifier = session.recipient_identifier;
 
   // Grade all students
   const gradingResults = await GradingService.gradeBatch(session, {
@@ -189,9 +193,9 @@ async function processGradingPhase(session, sessionId, userId) {
       logToFile('📊 Grading progress', { sessionId, ...progress });
 
       // Send progress update at milestones
-      if (user?.phone_number && [25, 50, 75].includes(progress.percentage)) {
+      if (recipientIdentifier && [25, 50, 75].includes(progress.percentage)) {
         try {
-          await DeliveryService.sendProgressUpdate(user.phone_number, progress);
+          await DeliveryService.sendProgressUpdate(recipientIdentifier, progress);
         } catch (e) {
           // Ignore progress notification failures
         }
@@ -258,24 +262,6 @@ async function processDeliveryPhase(session, sessionId, userId) {
   await ExamSessionService.updateStatus(sessionId, 'delivering_results');
 
   logToFile('✅ Delivery Phase complete', { sessionId });
-}
-
-/**
- * Get user from database
- */
-async function getUser(userId) {
-  const { data, error } = await supabase
-    .from('users')
-    .select('id, phone_number, preferred_language')
-    .eq('id', userId)
-    .single();
-
-  if (error) {
-    logToFile('⚠️ Failed to get user', { userId, error: error.message });
-    return null;
-  }
-
-  return data;
 }
 
 /**

--- a/bot/workers/lesson-plan-extraction.worker.js
+++ b/bot/workers/lesson-plan-extraction.worker.js
@@ -435,11 +435,15 @@ Return JSON with these fields:
     try {
       const { data, error } = await supabase
         .from('coaching_sessions')
-        .select('id, lesson_plan_format, users:users(first_name, phone_number)')
+        // recipient_identifier (not users.phone_number) is the channel this
+        // session actually originated on — a WhatsApp-only join here would
+        // silently misdeliver (or fail to deliver) for a Slack-originated
+        // session. See coaching-session.service.js#initiateSession.
+        .select('id, lesson_plan_format, recipient_identifier, users:users(first_name)')
         .eq('id', coachingSessionId)
         .single();
 
-      if (error || !data?.users?.phone_number) {
+      if (error || !data?.recipient_identifier) {
         logToFile('⚠️ Unable to notify teacher about LP format issue', {
           coachingSessionId,
           error: error?.message
@@ -447,7 +451,7 @@ Return JSON with these fields:
         return;
       }
 
-      const teacherName = (data.users.first_name || 'Teacher').trim();
+      const teacherName = (data.users?.first_name || 'Teacher').trim();
       const message = `⚠️ ${teacherName}, I got your lesson plan but couldn’t read the file. It looks like the document was saved under the wrong format (for example, a Word file renamed as PDF). Please resend it as the original Word/DOCX file, a proper PDF export, or clear page photos so I can include it in your report.`;
 
       if (process.env.OFFLINE_REPLAY === 'true') {
@@ -455,7 +459,7 @@ Return JSON with these fields:
         return;
       }
 
-      await WhatsAppService.sendMessage(data.users.phone_number, message);
+      await WhatsAppService.sendMessage(data.recipient_identifier, message);
       logToFile('📣 Notified teacher about lesson plan format issue', { coachingSessionId });
     } catch (notifyError) {
       logToFile('⚠️ Failed to send LP format notification', {

--- a/bot/workers/quiz-job-handler.js
+++ b/bot/workers/quiz-job-handler.js
@@ -122,26 +122,22 @@ async function handleQuizReport(body) {
     return { skipped: true, reason: 'requeued', ageMs };
   }
 
-  // Resolve teacherPhone before firing the report. Two sources in priority
-  // order: payload.teacherPhone → quiz.teacher_id → users.phone_number.
-  // If both miss, we MUST NOT set quiz_report_sent below — otherwise the
-  // sibling 15-min cascade message (which DOES carry teacherPhone) will hit
-  // the flag and skip with reason='already_fired'.
-  let teacherPhone = payload.teacherPhone;
-  if (!teacherPhone && quiz.teacher_id) {
-    const { data: teacher } = await supabase
-      .from('users')
-      .select('phone_number')
-      .eq('id', quiz.teacher_id)
-      .single();
-    if (teacher && teacher.phone_number) {
-      const raw = String(teacher.phone_number);
-      teacherPhone = raw.startsWith('+') ? raw : `+${raw}`;
-    }
-  }
+  // teacherPhone must come from the job payload — it is the exact channel
+  // identifier (a bare WhatsApp phone number, or "slack:<id>") captured when
+  // the quiz was originally requested (see quiz-delivery.service.js#deliverQuiz),
+  // and it survives every 15-min cascade re-queue unchanged (this function
+  // re-queues the SAME payload object above). A users.phone_number fallback
+  // used to exist here, keyed off quiz.teacher_id — removed deliberately: it
+  // silently guesses a DIFFERENT channel than the one the quiz was requested
+  // on (always WhatsApp, formatted with a "+" prefix that would corrupt a
+  // Slack identifier if it were ever reached), which is exactly the
+  // cross-channel misdelivery this fix exists to prevent. If teacherPhone is
+  // genuinely missing, that is a real bug to surface, not paper over with a
+  // guess at a possibly-wrong channel.
+  const teacherPhone = payload.teacherPhone;
 
   if (!teacherPhone) {
-    logToFile('⚠️ quiz_report: no teacher phone could be resolved — skipping (retry stays alive, idempotency flag NOT set)', { quizId, teacherIdPresent: !!quiz.teacher_id });
+    logToFile('⚠️ quiz_report: no teacherPhone in payload — skipping (retry stays alive, idempotency flag NOT set)', { quizId, teacherIdPresent: !!quiz.teacher_id });
     logEvent('quiz.report.skipped', { quizId, reason: 'no_teacher_phone' });
     return { skipped: true, reason: 'no_teacher_phone' };
   }

--- a/bot/workers/sqs-worker.js
+++ b/bot/workers/sqs-worker.js
@@ -776,7 +776,7 @@ async function recoverStaleVideoRequests() {
 
     const { data: staleRequests, error } = await supabase
       .from('video_requests')
-      .select('id, user_id, topic, language, customization, style, retry_count, session_id')
+      .select('id, user_id, topic, language, customization, style, retry_count, session_id, recipient_identifier')
       .eq('status', 'processing')
       .lt('started_at', staleThreshold);
 
@@ -805,14 +805,12 @@ async function recoverStaleVideoRequests() {
         });
 
         try {
-          // Get user's phone number
-          const { data: user } = await supabase
-            .from('users')
-            .select('phone_number')
-            .eq('id', request.user_id)
-            .single();
-
-          if (user?.phone_number) {
+          // recipient_identifier (not users.phone_number) is the exact
+          // channel this request originated on — a WhatsApp-only join would
+          // misdeliver (or silently drop) this apology for a
+          // Slack-originated request. See video-orchestrator.service.js
+          // #startGeneration, which stores it.
+          if (request.recipient_identifier) {
             const apologyMessages = {
               en: "I'm sorry, there was a problem creating your video about \"" + request.topic + "\". Please try again by sending /video.",
               ur: "معذرت، آپ کی ویڈیو \"" + request.topic + "\" بنانے میں مسئلہ ہوا۔ براہ کرم /video بھیج کر دوبارہ کوشش کریں۔",
@@ -820,7 +818,7 @@ async function recoverStaleVideoRequests() {
               es: "Lo siento, hubo un problema al crear tu video sobre \"" + request.topic + "\". Por favor intenta de nuevo enviando /video."
             };
             await WhatsAppService.sendMessage(
-              user.phone_number,
+              request.recipient_identifier,
               apologyMessages[request.language] || apologyMessages.en
             );
           }
@@ -864,6 +862,12 @@ async function recoverStaleVideoRequests() {
             {
               videoRequestId: request.id,
               userId: request.user_id,
+              // Preserve `from` across the re-queue — video-generation.worker.js
+              // reads it directly off the job data for the happy-path
+              // completion message, and previously this re-queue silently
+              // dropped it, so a video job re-queued after a restart could
+              // never deliver its completion message at all.
+              from: request.recipient_identifier,
               topic: request.topic,
               language: request.language,
               customization: request.customization,
@@ -947,4 +951,4 @@ if (require.main === module) {
 }
 
 // Export for testing
-module.exports = { SQSCoachingWorker, WORKER_ID, startWorker };
+module.exports = { SQSCoachingWorker, WORKER_ID, startWorker, recoverStaleVideoRequests };

--- a/bot/workers/stale-session.worker.js
+++ b/bot/workers/stale-session.worker.js
@@ -74,14 +74,18 @@ async function processStaleCoachingSessions() {
   let autoCompleted = 0;
   let skipped = 0;
 
-  // Query sessions in conducting_conversation status
+  // Query sessions in conducting_conversation status. recipient_identifier
+  // (not users.phone_number) is the channel this session actually
+  // originated on — a WhatsApp-only join would misdeliver (or silently drop)
+  // a reminder for a Slack-originated session. See
+  // coaching-session.service.js#initiateSession, which stores it.
   const { data: staleSessions, error } = await supabase
     .from('coaching_sessions')
     .select(`
       id, user_id, status, conversation_state,
       transcript_text, analysis_data, lesson_plan_text,
-      reminder_sent_at, created_at,
-      users!inner(first_name, phone_number)
+      reminder_sent_at, created_at, recipient_identifier,
+      users!inner(first_name)
     `)
     .eq('status', 'conducting_conversation')
     .order('created_at', { ascending: true });
@@ -286,7 +290,7 @@ async function sendSessionReminder(session) {
     }
 
     // Send interactive message with buttons
-    await WhatsAppService.sendInteractiveButtons(session.users.phone_number, {
+    await WhatsAppService.sendInteractiveButtons(session.recipient_identifier, {
       body: reminderText,
       buttons: [
         { id: `coaching_continue_${session.id}`, title: 'Continue Now' },
@@ -355,7 +359,7 @@ async function autoCompleteSession(session) {
 
     // 2. Queue report generation with partial flag
     await CoachingJobQueueService.queueReport(session.id, {
-      from: session.users.phone_number,
+      from: session.recipient_identifier,
       partial: questionsAnswered < 3,
       autoCompleted: true
     });
@@ -367,7 +371,7 @@ async function autoCompleteSession(session) {
       : `Hi ${session.users.first_name}! Since you didn't continue the reflective conversation, ` +
         `I'm generating your coaching report based on the classroom audio analysis. 📊`;
 
-    await WhatsAppService.sendMessage(session.users.phone_number, notificationText);
+    await WhatsAppService.sendMessage(session.recipient_identifier, notificationText);
 
     logToFile('✅ Auto-complete initiated', {
       sessionId: session.id,
@@ -389,4 +393,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { main };
+module.exports = { main, processStaleCoachingSessions };

--- a/infrastructure/scripts/backfill-user-channels.js
+++ b/infrastructure/scripts/backfill-user-channels.js
@@ -1,0 +1,130 @@
+/**
+ * Backfill script — one row per existing user in `user_channels`.
+ *
+ * Every `users` row created before this migration has a phone_number and no
+ * user_channels row at all. This script gives each one a
+ * {channel: 'whatsapp', channel_user_id: phone_number, is_primary: true} row,
+ * so every existing user is immediately shaped for multi-homing (Slack,
+ * Discord, ...) at zero behavior change — bot-helpers.js's
+ * getOrCreateUserByChannel also lazily backfills any row this script misses
+ * (e.g. a user created between a partial run and a re-run), so this script is
+ * safe to re-run and is not the only place the backfill can happen.
+ *
+ * Uses raw fetch against Supabase's PostgREST endpoint (same convention as
+ * infrastructure/scripts/test-connections.js) rather than
+ * @supabase/supabase-js, which lives only in bot/'s dependencies and does not
+ * reliably resolve from a script invoked at the repo root.
+ *
+ * Usage:
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node infrastructure/scripts/backfill-user-channels.js
+ */
+
+const path = require('path');
+
+try {
+  require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
+} catch (e) {
+  /* .env is optional — real env vars may already be set */
+}
+
+const PAGE_SIZE = 500;
+
+function restHeaders(key, extra = {}) {
+  return {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    'Content-Type': 'application/json',
+    ...extra,
+  };
+}
+
+/** One page of users that have a phone_number but no user_channels row yet. */
+async function fetchUnbackfilledPage(url, key, offset) {
+  // PostgREST left-join-is-null idiom: user_channels is fetched embedded and
+  // filtered to is.null on its id, meaning "no matching child row".
+  const query =
+    'select=id,phone_number,user_channels!left(id)' +
+    '&phone_number=not.is.null' +
+    '&user_channels.id=is.null' +
+    `&limit=${PAGE_SIZE}&offset=${offset}&order=id.asc`;
+
+  const response = await fetch(`${url}/rest/v1/users?${query}`, {
+    headers: restHeaders(key),
+  });
+  if (!response.ok) {
+    throw new Error(`Fetch users page failed: HTTP ${response.status} — ${await response.text()}`);
+  }
+  const rows = await response.json();
+  // The embedded left-join returns user_channels: [] for a genuine "no child"
+  // row (PostgREST quirk with !left + is.null on the child) — filter
+  // defensively in case any row's fetch shape slips through.
+  return rows.filter((r) => !r.user_channels || r.user_channels.length === 0);
+}
+
+async function insertUserChannelsBatch(url, key, rows) {
+  if (rows.length === 0) return;
+  const nowIso = new Date().toISOString();
+  const payload = rows.map((r) => ({
+    user_id: r.id,
+    channel: 'whatsapp',
+    channel_user_id: r.phone_number,
+    is_primary: true,
+    created_at: nowIso,
+    last_message_at: nowIso,
+  }));
+
+  const response = await fetch(`${url}/rest/v1/user_channels`, {
+    method: 'POST',
+    headers: restHeaders(key, {
+      // on_conflict + resolution=ignore-duplicates: safe to re-run — a row
+      // already backfilled (by this script or by getOrCreateUserByChannel's
+      // lazy path) is silently skipped rather than erroring on the UNIQUE
+      // (channel, channel_user_id) constraint.
+      Prefer: 'resolution=ignore-duplicates,return=minimal',
+    }),
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`Insert user_channels batch failed: HTTP ${response.status} — ${await response.text()}`);
+  }
+}
+
+async function run() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('❌ SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required.');
+    process.exit(1);
+  }
+
+  let offset = 0;
+  let totalBackfilled = 0;
+
+  // Re-querying from offset 0 each pass (rather than advancing offset) is
+  // deliberate: once a page is backfilled, those rows drop out of the
+  // "no user_channels row yet" filter, so the next fetch naturally surfaces
+  // the next unbackfilled page at the same offset. This also makes an
+  // interrupted run trivially resumable.
+  for (;;) {
+    const page = await fetchUnbackfilledPage(url, key, 0);
+    if (page.length === 0) break;
+
+    await insertUserChannelsBatch(url, key, page);
+    totalBackfilled += page.length;
+    console.log(`  backfilled ${totalBackfilled} users so far...`);
+
+    if (page.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE; // defensive — not expected to be reached given the above
+  }
+
+  console.log(`✅ Backfill complete — ${totalBackfilled} user_channels row(s) created.`);
+}
+
+if (require.main === module) {
+  run().catch((error) => {
+    console.error('❌ Backfill failed:', error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { run };

--- a/infrastructure/supabase/00_complete-schema.sql
+++ b/infrastructure/supabase/00_complete-schema.sql
@@ -47,7 +47,11 @@ CREATE SEQUENCE IF NOT EXISTS migration_test_id_seq;
 
 CREATE TABLE IF NOT EXISTS users (
     id UUID NOT NULL DEFAULT uuid_generate_v4(),
-    phone_number VARCHAR(20) NOT NULL,
+    -- Nullable: a user who first reaches Rumi on a non-WhatsApp channel (Slack,
+    -- Discord, ...) has no phone number at all. See user_channels below for how
+    -- a person's channel identities are tracked; this column stays the sole
+    -- identity key for WhatsApp-only deployments (unchanged UNIQUE constraint).
+    phone_number VARCHAR(20),
     name VARCHAR(100),
     grades_taught VARCHAR(100),
     registration_completed BOOLEAN DEFAULT false,
@@ -80,6 +84,27 @@ CREATE TABLE IF NOT EXISTS users (
     country VARCHAR(100),
     region VARCHAR(100),
     organization VARCHAR(200),
+    PRIMARY KEY (id)
+);
+
+-- A teacher's channel identities — one row per (channel, WhatsApp phone /
+-- Slack user id / Discord user id) linking back to a single `users` row.
+-- Multi-homed by design: the same person can have a whatsapp row AND a slack
+-- row AND a discord row at once, each independently addressable. Conversation
+-- STATE (sessions, pending menus, in-progress Flow/modal steps) must stay
+-- keyed by (channel, channel_user_id) — never by user_id — so a live
+-- conversation on one channel never bleeds into another (see
+-- messaging/channel-registry.js's driverForIdentifier and bot-helpers.js's
+-- getOrCreateUserByChannel). This table is purely about IDENTITY (who is
+-- this), never about session/state.
+CREATE TABLE IF NOT EXISTS user_channels (
+    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    channel VARCHAR(20) NOT NULL,
+    channel_user_id VARCHAR(255) NOT NULL,
+    is_primary BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    last_message_at TIMESTAMPTZ,
     PRIMARY KEY (id)
 );
 
@@ -1329,6 +1354,11 @@ END $$;
 
 DO $$ BEGIN
     ALTER TABLE users ADD CONSTRAINT users_phone_number_key UNIQUE (phone_number);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE user_channels ADD CONSTRAINT user_channels_channel_channel_user_id_key UNIQUE (channel, channel_user_id);
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 
@@ -3367,6 +3397,8 @@ CREATE INDEX IF NOT EXISTS idx_users_portal_invite_token ON users USING btree (p
 CREATE INDEX IF NOT EXISTS idx_users_portal_login ON users USING btree (phone_number, portal_activated) WHERE (portal_activated = true);
 CREATE INDEX IF NOT EXISTS idx_users_preferred_language ON users USING btree (preferred_language);
 CREATE INDEX IF NOT EXISTS idx_users_registration_completed ON users USING btree (registration_completed_at) WHERE (registration_completed_at IS NOT NULL);
+CREATE INDEX IF NOT EXISTS idx_user_channels_user_id ON user_channels USING btree (user_id);
+CREATE INDEX IF NOT EXISTS idx_user_channels_lookup ON user_channels USING btree (channel, channel_user_id);
 CREATE INDEX IF NOT EXISTS idx_users_registration_state ON users USING btree (registration_state);
 CREATE INDEX IF NOT EXISTS idx_users_school_name_lower ON users USING btree (lower((school_name)::text));
 CREATE INDEX IF NOT EXISTS idx_users_session_id ON users USING btree (session_id);
@@ -3956,6 +3988,14 @@ ALTER TABLE dashboard_users ADD COLUMN IF NOT EXISTS phone_number VARCHAR(20);
 -- profile edit). The broadcast user-fetch SELECTed it and threw on the missing
 -- column. Populated on every inbound by bot-helpers.getOrCreateUser.
 ALTER TABLE users ADD COLUMN IF NOT EXISTS last_message_at TIMESTAMPTZ;
+
+-- users.phone_number: relaxed from NOT NULL so a teacher who first reaches
+-- Rumi on a non-WhatsApp channel (Slack, Discord, ...) can have a users row
+-- with no phone number at all. The UNIQUE constraint is untouched — Postgres
+-- allows multiple NULLs under a unique constraint, so existing WhatsApp-only
+-- deployments (every row already has a phone_number) see no behavior change.
+-- See user_channels above and bot-helpers.getOrCreateUserByChannel.
+ALTER TABLE users ALTER COLUMN phone_number DROP NOT NULL;
 
 -- =============================================================================
 -- Function reconcile (Phase 5) — RPCs the bot invokes via supabase.rpc() that the

--- a/infrastructure/supabase/00_complete-schema.sql
+++ b/infrastructure/supabase/00_complete-schema.sql
@@ -3997,6 +3997,20 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS last_message_at TIMESTAMPTZ;
 -- See user_channels above and bot-helpers.getOrCreateUserByChannel.
 ALTER TABLE users ALTER COLUMN phone_number DROP NOT NULL;
 
+-- recipient_identifier: the exact channel identifier (a bare WhatsApp phone
+-- number, or a "slack:<id>"-prefixed Slack identifier — whatever
+-- messaging/index.js's router dispatches on) that ORIGINATED a background job,
+-- captured once at request-creation time. A background job must always
+-- deliver back to this stored value, never re-derive "who to notify" from a
+-- users.phone_number join — that re-derivation is WhatsApp-only and silently
+-- sends a Slack-originated request's results to the wrong channel (or nowhere,
+-- for a Slack-only teacher with no phone number at all). See bot/workers/
+-- coaching-session.service.js#initiateSession, exam-session.service.js#_createSession,
+-- video-orchestrator.service.js#startGeneration for where each is populated.
+ALTER TABLE coaching_sessions ADD COLUMN IF NOT EXISTS recipient_identifier VARCHAR(255);
+ALTER TABLE exam_check_sessions ADD COLUMN IF NOT EXISTS recipient_identifier VARCHAR(255);
+ALTER TABLE video_requests ADD COLUMN IF NOT EXISTS recipient_identifier VARCHAR(255);
+
 -- =============================================================================
 -- Function reconcile (Phase 5) — RPCs the bot invokes via supabase.rpc() that the
 -- consolidated schema predated. CREATE OR REPLACE keeps it idempotent. (get_column_info

--- a/infrastructure/supabase/00_complete-schema.sql
+++ b/infrastructure/supabase/00_complete-schema.sql
@@ -1289,97 +1289,97 @@ CREATE TABLE IF NOT EXISTS migration_test (
 
 DO $$ BEGIN
     ALTER TABLE ab_test_variants ADD CONSTRAINT ab_test_variants_test_id_variant_name_key UNIQUE (variant_name, test_id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE ab_tests ADD CONSTRAINT ab_tests_test_name_key UNIQUE (test_name);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE dashboard_users ADD CONSTRAINT dashboard_users_email_key UNIQUE (email);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE dashboard_users ADD CONSTRAINT dashboard_users_invite_token_key UNIQUE (invite_token);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE dashboard_users ADD CONSTRAINT dashboard_users_password_reset_token_key UNIQUE (password_reset_token);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE dashboard_users ADD CONSTRAINT dashboard_users_username_key UNIQUE (username);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE invitations ADD CONSTRAINT invitations_token_key UNIQUE (token);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE lcpm_benchmarks ADD CONSTRAINT lcpm_benchmarks_grade_level_language_season_key UNIQUE (grade_level, season, language);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE portal_organizations ADD CONSTRAINT portal_organizations_name_key UNIQUE (name);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE teacher_facts ADD CONSTRAINT teacher_facts_user_id_fact_key UNIQUE (user_id, fact);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE feature_permissions ADD CONSTRAINT unique_role_feature UNIQUE (feature_key, role);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE access_scopes ADD CONSTRAINT unique_user_scope UNIQUE (dashboard_user_id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE user_feature_first_use ADD CONSTRAINT user_feature_first_use_user_id_feature_key UNIQUE (user_id, feature);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE users ADD CONSTRAINT users_phone_number_key UNIQUE (phone_number);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE user_channels ADD CONSTRAINT user_channels_channel_channel_user_id_key UNIQUE (channel, channel_user_id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE users ADD CONSTRAINT users_portal_invite_token_key UNIQUE (portal_invite_token);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE video_tasks ADD CONSTRAINT video_tasks_video_request_id_filename_key UNIQUE (video_request_id, filename);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE wcpm_percentiles ADD CONSTRAINT wcpm_percentiles_grade_level_language_season_percentile_key UNIQUE (season, language, grade_level, percentile);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE website_visits ADD CONSTRAINT website_visits_session_id_key UNIQUE (session_id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 
@@ -1391,441 +1391,441 @@ DO $$ BEGIN
     ALTER TABLE ab_test_events
         ADD CONSTRAINT ab_test_events_test_id_fkey
         FOREIGN KEY (test_id) REFERENCES ab_tests(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE ab_test_events
         ADD CONSTRAINT ab_test_events_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE ab_test_variants
         ADD CONSTRAINT ab_test_variants_test_id_fkey
         FOREIGN KEY (test_id) REFERENCES ab_tests(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE access_scopes
         ADD CONSTRAINT access_scopes_created_by_fkey
         FOREIGN KEY (created_by) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE access_scopes
         ADD CONSTRAINT access_scopes_dashboard_user_id_fkey
         FOREIGN KEY (dashboard_user_id) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE ama_conversations
         ADD CONSTRAINT ama_conversations_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE ama_messages
         ADD CONSTRAINT ama_messages_conversation_id_fkey
         FOREIGN KEY (conversation_id) REFERENCES ama_conversations(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE ama_messages
         ADD CONSTRAINT ama_messages_tracer_user_id_fkey
         FOREIGN KEY (tracer_user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE ama_query_audit
         ADD CONSTRAINT ama_query_audit_message_id_fkey
         FOREIGN KEY (message_id) REFERENCES ama_messages(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE ama_query_audit
         ADD CONSTRAINT ama_query_audit_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE attendance_records
         ADD CONSTRAINT attendance_records_session_id_fkey
         FOREIGN KEY (session_id) REFERENCES attendance_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE attendance_records
         ADD CONSTRAINT attendance_records_student_id_fkey
         FOREIGN KEY (student_id) REFERENCES students(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE attendance_sessions
         ADD CONSTRAINT attendance_sessions_list_id_fkey
         FOREIGN KEY (list_id) REFERENCES student_lists(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE attendance_sessions
         ADD CONSTRAINT attendance_sessions_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE audio_sessions
         ADD CONSTRAINT audio_sessions_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE broadcast_logs
         ADD CONSTRAINT broadcast_logs_admin_user_id_fkey
         FOREIGN KEY (admin_user_id) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE broadcast_messages
         ADD CONSTRAINT broadcast_messages_broadcast_id_fkey
         FOREIGN KEY (broadcast_id) REFERENCES broadcast_logs(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE broadcast_messages
         ADD CONSTRAINT broadcast_messages_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE byof_approval_log
         ADD CONSTRAINT byof_approval_log_performed_by_fkey
         FOREIGN KEY (performed_by) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE byof_approval_log
         ADD CONSTRAINT byof_approval_log_plan_id_fkey
         FOREIGN KEY (plan_id) REFERENCES byof_plans(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE byof_messages
         ADD CONSTRAINT byof_messages_session_id_fkey
         FOREIGN KEY (session_id) REFERENCES byof_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE byof_plans
         ADD CONSTRAINT byof_plans_approved_by_fkey
         FOREIGN KEY (approved_by) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE byof_plans
         ADD CONSTRAINT byof_plans_session_id_fkey
         FOREIGN KEY (session_id) REFERENCES byof_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE byof_sessions
         ADD CONSTRAINT byof_sessions_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE chat_sessions
         ADD CONSTRAINT chat_sessions_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE chat_starts
         ADD CONSTRAINT chat_starts_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE coaching_jobs
         ADD CONSTRAINT coaching_jobs_coaching_session_id_fkey
         FOREIGN KEY (coaching_session_id) REFERENCES coaching_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE coaching_processing_queue
         ADD CONSTRAINT coaching_processing_queue_coaching_session_id_fkey
         FOREIGN KEY (coaching_session_id) REFERENCES coaching_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE coaching_quality_metrics
         ADD CONSTRAINT coaching_quality_metrics_coaching_session_id_fkey
         FOREIGN KEY (coaching_session_id) REFERENCES coaching_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE coaching_sessions
         ADD CONSTRAINT coaching_sessions_session_id_fkey
         FOREIGN KEY (session_id) REFERENCES chat_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE coaching_sessions
         ADD CONSTRAINT coaching_sessions_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE conversations
         ADD CONSTRAINT conversations_session_id_fkey
         FOREIGN KEY (session_id) REFERENCES chat_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE conversations
         ADD CONSTRAINT conversations_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE dashboard_audit_log
         ADD CONSTRAINT dashboard_audit_log_organization_id_fkey
         FOREIGN KEY (organization_id) REFERENCES portal_organizations(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE dashboard_audit_log
         ADD CONSTRAINT dashboard_audit_log_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE dashboard_users
         ADD CONSTRAINT dashboard_users_invited_by_fkey
         FOREIGN KEY (invited_by) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE dashboard_users
         ADD CONSTRAINT dashboard_users_organization_id_fkey
         FOREIGN KEY (organization_id) REFERENCES portal_organizations(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE exam_check_sessions
         ADD CONSTRAINT exam_check_sessions_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE exam_grades
         ADD CONSTRAINT exam_grades_edited_by_fkey
         FOREIGN KEY (edited_by) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE exam_grades
         ADD CONSTRAINT exam_grades_submission_id_fkey
         FOREIGN KEY (submission_id) REFERENCES exam_submissions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE exam_submissions
         ADD CONSTRAINT exam_submissions_session_id_fkey
         FOREIGN KEY (session_id) REFERENCES exam_check_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE exam_submissions
         ADD CONSTRAINT exam_submissions_student_id_fkey
         FOREIGN KEY (student_id) REFERENCES students(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE exam_templates
         ADD CONSTRAINT exam_templates_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE feature_suggestions
         ADD CONSTRAINT feature_suggestions_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE grade_audit_log
         ADD CONSTRAINT grade_audit_log_grade_id_fkey
         FOREIGN KEY (grade_id) REFERENCES exam_grades(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE grade_audit_log
         ADD CONSTRAINT grade_audit_log_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE image_analysis_requests
         ADD CONSTRAINT image_analysis_requests_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE invitations
         ADD CONSTRAINT invitations_created_user_id_fkey
         FOREIGN KEY (created_user_id) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE invitations
         ADD CONSTRAINT invitations_invited_by_fkey
         FOREIGN KEY (invited_by) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE invitations
         ADD CONSTRAINT invitations_revoked_by_fkey
         FOREIGN KEY (revoked_by) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE lesson_plan_requests
         ADD CONSTRAINT lesson_plan_requests_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE lesson_plans
         ADD CONSTRAINT lesson_plans_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE portal_organizations
         ADD CONSTRAINT portal_organizations_created_by_fkey
         FOREIGN KEY (created_by) REFERENCES dashboard_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE reading_assessments
         ADD CONSTRAINT reading_assessments_session_id_fkey
         FOREIGN KEY (session_id) REFERENCES chat_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE reading_assessments
         ADD CONSTRAINT reading_assessments_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE student_lists
         ADD CONSTRAINT student_lists_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE students
         ADD CONSTRAINT students_list_id_fkey
         FOREIGN KEY (list_id) REFERENCES student_lists(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE teacher_facts
         ADD CONSTRAINT teacher_facts_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE teacher_progress
         ADD CONSTRAINT teacher_progress_session_id_fkey
         FOREIGN KEY (session_id) REFERENCES audio_sessions(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE teacher_progress
         ADD CONSTRAINT teacher_progress_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE user_feature_first_use
         ADD CONSTRAINT user_feature_first_use_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE video_requests
         ADD CONSTRAINT video_requests_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 DO $$ BEGIN
     ALTER TABLE video_tasks
         ADD CONSTRAINT video_tasks_video_request_id_fkey
         FOREIGN KEY (video_request_id) REFERENCES video_requests(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 END $$;
 
 

--- a/infrastructure/supabase/01_rls-policies.sql
+++ b/infrastructure/supabase/01_rls-policies.sql
@@ -72,99 +72,161 @@ ALTER TABLE migration_test ENABLE ROW LEVEL SECURITY;
 -- =============================================================================
 
 -- Core User Management
+DROP POLICY IF EXISTS "service_role_users" ON users;
 CREATE POLICY "service_role_users" ON users FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_dashboard_users" ON dashboard_users;
 CREATE POLICY "service_role_dashboard_users" ON dashboard_users FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_portal_orgs" ON portal_organizations;
 CREATE POLICY "service_role_portal_orgs" ON portal_organizations FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_access_scopes" ON access_scopes;
 CREATE POLICY "service_role_access_scopes" ON access_scopes FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_feature_perms" ON feature_permissions;
 CREATE POLICY "service_role_feature_perms" ON feature_permissions FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_invitations" ON invitations;
 CREATE POLICY "service_role_invitations" ON invitations FOR ALL USING (auth.role() = 'service_role');
 
 -- Engagement & Analytics
+DROP POLICY IF EXISTS "service_role_feature_first_use" ON user_feature_first_use;
 CREATE POLICY "service_role_feature_first_use" ON user_feature_first_use FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_chat_sessions" ON chat_sessions;
 CREATE POLICY "service_role_chat_sessions" ON chat_sessions FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_conversations" ON conversations;
 CREATE POLICY "service_role_conversations" ON conversations FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_chat_starts" ON chat_starts;
 CREATE POLICY "service_role_chat_starts" ON chat_starts FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_cta_clicks" ON cta_clicks;
 CREATE POLICY "service_role_cta_clicks" ON cta_clicks FOR ALL USING (auth.role() = 'service_role');
 
 -- Coaching
+DROP POLICY IF EXISTS "service_role_coaching_sessions" ON coaching_sessions;
 CREATE POLICY "service_role_coaching_sessions" ON coaching_sessions FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_coaching_jobs" ON coaching_jobs;
 CREATE POLICY "service_role_coaching_jobs" ON coaching_jobs FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_coaching_queue" ON coaching_processing_queue;
 CREATE POLICY "service_role_coaching_queue" ON coaching_processing_queue FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_coaching_metrics" ON coaching_quality_metrics;
 CREATE POLICY "service_role_coaching_metrics" ON coaching_quality_metrics FOR ALL USING (auth.role() = 'service_role');
 
 -- Legacy Audio & Teacher
+DROP POLICY IF EXISTS "service_role_audio_sessions" ON audio_sessions;
 CREATE POLICY "service_role_audio_sessions" ON audio_sessions FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_teacher_progress" ON teacher_progress;
 CREATE POLICY "service_role_teacher_progress" ON teacher_progress FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_teacher_facts" ON teacher_facts;
 CREATE POLICY "service_role_teacher_facts" ON teacher_facts FOR ALL USING (auth.role() = 'service_role');
 
 -- Lesson Plans
+DROP POLICY IF EXISTS "service_role_lesson_plans" ON lesson_plans;
 CREATE POLICY "service_role_lesson_plans" ON lesson_plans FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_lesson_plan_requests" ON lesson_plan_requests;
 CREATE POLICY "service_role_lesson_plan_requests" ON lesson_plan_requests FOR ALL USING (auth.role() = 'service_role');
 
 -- Reading Assessment
+DROP POLICY IF EXISTS "service_role_reading_assessments" ON reading_assessments;
 CREATE POLICY "service_role_reading_assessments" ON reading_assessments FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_lcpm_benchmarks" ON lcpm_benchmarks;
 CREATE POLICY "service_role_lcpm_benchmarks" ON lcpm_benchmarks FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_wcpm_percentiles" ON wcpm_percentiles;
 CREATE POLICY "service_role_wcpm_percentiles" ON wcpm_percentiles FOR ALL USING (auth.role() = 'service_role');
 
 -- Attendance
+DROP POLICY IF EXISTS "service_role_student_lists" ON student_lists;
 CREATE POLICY "service_role_student_lists" ON student_lists FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_students" ON students;
 CREATE POLICY "service_role_students" ON students FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_student_videos" ON student_videos;
 CREATE POLICY "service_role_student_videos" ON student_videos FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_attendance_sessions" ON attendance_sessions;
 CREATE POLICY "service_role_attendance_sessions" ON attendance_sessions FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_attendance_records" ON attendance_records;
 CREATE POLICY "service_role_attendance_records" ON attendance_records FOR ALL USING (auth.role() = 'service_role');
 
 -- Exam Checker
+DROP POLICY IF EXISTS "service_role_exam_sessions" ON exam_check_sessions;
 CREATE POLICY "service_role_exam_sessions" ON exam_check_sessions FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_exam_templates" ON exam_templates;
 CREATE POLICY "service_role_exam_templates" ON exam_templates FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_exam_submissions" ON exam_submissions;
 CREATE POLICY "service_role_exam_submissions" ON exam_submissions FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_exam_grades" ON exam_grades;
 CREATE POLICY "service_role_exam_grades" ON exam_grades FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_grade_audit_log" ON grade_audit_log;
 CREATE POLICY "service_role_grade_audit_log" ON grade_audit_log FOR ALL USING (auth.role() = 'service_role');
 
 -- Image Analysis
+DROP POLICY IF EXISTS "service_role_image_analysis" ON image_analysis_requests;
 CREATE POLICY "service_role_image_analysis" ON image_analysis_requests FOR ALL USING (auth.role() = 'service_role');
 
 -- Video
+DROP POLICY IF EXISTS "service_role_video_requests" ON video_requests;
 CREATE POLICY "service_role_video_requests" ON video_requests FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_video_tasks" ON video_tasks;
 CREATE POLICY "service_role_video_tasks" ON video_tasks FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_videos" ON videos;
 CREATE POLICY "service_role_videos" ON videos FOR ALL USING (auth.role() = 'service_role');
 
 -- A/B Testing
+DROP POLICY IF EXISTS "service_role_ab_tests" ON ab_tests;
 CREATE POLICY "service_role_ab_tests" ON ab_tests FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_ab_test_variants" ON ab_test_variants;
 CREATE POLICY "service_role_ab_test_variants" ON ab_test_variants FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_ab_test_events" ON ab_test_events;
 CREATE POLICY "service_role_ab_test_events" ON ab_test_events FOR ALL USING (auth.role() = 'service_role');
 
 -- AMA
+DROP POLICY IF EXISTS "service_role_ama_conversations" ON ama_conversations;
 CREATE POLICY "service_role_ama_conversations" ON ama_conversations FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_ama_messages" ON ama_messages;
 CREATE POLICY "service_role_ama_messages" ON ama_messages FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_ama_query_audit" ON ama_query_audit;
 CREATE POLICY "service_role_ama_query_audit" ON ama_query_audit FOR ALL USING (auth.role() = 'service_role');
 
 -- BYOF
+DROP POLICY IF EXISTS "service_role_byof_sessions" ON byof_sessions;
 CREATE POLICY "service_role_byof_sessions" ON byof_sessions FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_byof_messages" ON byof_messages;
 CREATE POLICY "service_role_byof_messages" ON byof_messages FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_byof_plans" ON byof_plans;
 CREATE POLICY "service_role_byof_plans" ON byof_plans FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_byof_approval_log" ON byof_approval_log;
 CREATE POLICY "service_role_byof_approval_log" ON byof_approval_log FOR ALL USING (auth.role() = 'service_role');
 
 -- Broadcast
+DROP POLICY IF EXISTS "service_role_broadcast_logs" ON broadcast_logs;
 CREATE POLICY "service_role_broadcast_logs" ON broadcast_logs FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_broadcast_messages" ON broadcast_messages;
 CREATE POLICY "service_role_broadcast_messages" ON broadcast_messages FOR ALL USING (auth.role() = 'service_role');
 
 -- QA
+DROP POLICY IF EXISTS "service_role_qa_test_runs" ON qa_test_runs;
 CREATE POLICY "service_role_qa_test_runs" ON qa_test_runs FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_qa_analyst_proposals" ON qa_analyst_proposals;
 CREATE POLICY "service_role_qa_analyst_proposals" ON qa_analyst_proposals FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_qa_bug_patterns" ON qa_bug_patterns;
 CREATE POLICY "service_role_qa_bug_patterns" ON qa_bug_patterns FOR ALL USING (auth.role() = 'service_role');
 
 -- Misc / System
+DROP POLICY IF EXISTS "service_role_dashboard_audit" ON dashboard_audit_log;
 CREATE POLICY "service_role_dashboard_audit" ON dashboard_audit_log FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_feature_suggestions" ON feature_suggestions;
 CREATE POLICY "service_role_feature_suggestions" ON feature_suggestions FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_api_usage_log" ON api_usage_log;
 CREATE POLICY "service_role_api_usage_log" ON api_usage_log FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_failed_operations" ON failed_operations;
 CREATE POLICY "service_role_failed_operations" ON failed_operations FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_release_notes" ON release_notes;
 CREATE POLICY "service_role_release_notes" ON release_notes FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_schema_versions" ON schema_versions;
 CREATE POLICY "service_role_schema_versions" ON schema_versions FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_website_visits" ON website_visits;
 CREATE POLICY "service_role_website_visits" ON website_visits FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_migration_test" ON migration_test;
 CREATE POLICY "service_role_migration_test" ON migration_test FOR ALL USING (auth.role() = 'service_role');
 
 -- Video quizzes
 ALTER TABLE quiz_share_codes ENABLE ROW LEVEL SECURITY;
 ALTER TABLE video_quiz_deliveries ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "service_role_quiz_share_codes" ON quiz_share_codes;
 CREATE POLICY "service_role_quiz_share_codes" ON quiz_share_codes FOR ALL USING (auth.role() = 'service_role');
+DROP POLICY IF EXISTS "service_role_video_quiz_deliveries" ON video_quiz_deliveries;
 CREATE POLICY "service_role_video_quiz_deliveries" ON video_quiz_deliveries FOR ALL USING (auth.role() = 'service_role');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "discord.js": "^14.27.0",
         "express": "^5.2.1",
         "ioredis": "^5.9.2",
         "openai": "^6.16.0"
@@ -521,6 +522,136 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.3.tgz",
+      "integrity": "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.50",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "^6.27.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
@@ -896,6 +1027,39 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1020,7 +1184,6 @@
       "version": "25.0.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1032,6 +1195,15 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -1049,6 +1221,16 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -1723,6 +1905,42 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/discord-api-types": {
+      "version": "0.38.53",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.53.tgz",
+      "integrity": "sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.27.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
+      "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.5",
+        "discord-api-types": "^0.38.49",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "^6.27.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1960,6 +2178,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3217,6 +3441,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -3229,6 +3459,12 @@
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3238,6 +3474,12 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.1.tgz",
+      "integrity": "sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==",
+      "license": "MIT"
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -4285,6 +4527,18 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4322,11 +4576,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -4455,6 +4717,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "validate:env": "node bot/scripts/validate-env.js",
     "validate:connections": "node infrastructure/scripts/test-connections.js",
     "bootstrap:db": "node infrastructure/scripts/bootstrap-db.js",
+    "backfill:user-channels": "node infrastructure/scripts/backfill-user-channels.js",
     "doctor": "node bot/scripts/setup/doctor.js",
     "setup:flows": "node bot/scripts/setup/run-full-setup.js",
     "setup:interactive": "node bot/scripts/setup/interactive-setup.js",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "backfill:user-channels": "node infrastructure/scripts/backfill-user-channels.js",
     "doctor": "node bot/scripts/setup/doctor.js",
     "setup:flows": "node bot/scripts/setup/run-full-setup.js",
+    "discord:register-commands": "node bot/scripts/setup/discord-register-commands.js",
     "setup:interactive": "node bot/scripts/setup/interactive-setup.js",
     "pair:baileys": "node bot/scripts/setup/baileys-pair.js",
     "graduate": "node bot/scripts/setup/graduate.js",
@@ -53,6 +54,7 @@
     "jest-environment-node": "^29.7.0"
   },
   "dependencies": {
+    "discord.js": "^14.27.0",
     "express": "^5.2.1",
     "ioredis": "^5.9.2",
     "openai": "^6.16.0"

--- a/tests/__mocks__/supabase-js.js
+++ b/tests/__mocks__/supabase-js.js
@@ -1,0 +1,22 @@
+/**
+ * Lightweight stub for @supabase/supabase-js — the root test suite runs
+ * before bot/node_modules installs, so source that requires it can't
+ * resolve it. Same pattern as the axios/form-data/aws-sdk/pino/canvas stubs.
+ *
+ * Unlike those, this one is a safety net rather than the primary defense:
+ * config/supabase.js is a high-traffic, deliberately narrow file, and most
+ * suites already mock it directly (`jest.mock('.../config/supabase', ...)`)
+ * to control query behavior. This stub only matters when config/supabase.js
+ * itself is left unmocked and genuinely executes — without this mapping,
+ * that only broke intermittently depending on which other test files shared
+ * a Jest worker process and in what order, since per-file jest.mock() of
+ * config/supabase does not reliably shadow this require in every ordering.
+ */
+function chainableStub() {
+  const thrower = () => { throw new Error('supabase-js stub: not available in the root test suite — mock config/supabase.js in this test'); };
+  return new Proxy({}, { get: () => thrower });
+}
+
+module.exports = {
+  createClient: () => chainableStub(),
+};

--- a/tests/coaching/coaching-session-recipient-identifier.test.js
+++ b/tests/coaching/coaching-session-recipient-identifier.test.js
@@ -1,0 +1,67 @@
+/**
+ * CoachingSessionService.initiateSession — must store the exact channel
+ * identifier the request originated on (recipient_identifier), so later
+ * background delivery (LP-extraction notices, stale-session reminders,
+ * report generation) never has to re-derive "who to notify" from
+ * users.phone_number, which is WhatsApp-only and would misdeliver a
+ * Slack-originated session's results.
+ */
+
+function makeSupabase({ user, insertedRowCapture }) {
+  return {
+    from(table) {
+      if (table === 'users') {
+        return {
+          select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: user, error: user ? null : { message: 'not found' } }) }) }),
+        };
+      }
+      if (table === 'coaching_sessions') {
+        return {
+          insert: (row) => {
+            insertedRowCapture.row = row;
+            return {
+              select: () => ({
+                single: () => Promise.resolve({ data: { id: 'session-1', ...row }, error: null }),
+              }),
+            };
+          },
+        };
+      }
+      throw new Error(`Unexpected table in test: ${table}`);
+    },
+  };
+}
+
+function load({ user = { name: 'Ayesha', first_name: 'Ayesha', last_name: 'Khan' } } = {}) {
+  jest.resetModules();
+  const insertedRowCapture = {};
+  const supabase = makeSupabase({ user, insertedRowCapture });
+
+  jest.doMock('../../bot/shared/config/supabase', () => supabase);
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/services/whatsapp.service', () => ({
+    sendInteractiveButtons: jest.fn().mockResolvedValue(true),
+  }));
+  jest.doMock('../../bot/shared/config/coaching-messages', () => ({
+    getCoachingMessage: jest.fn(() => 'message'),
+  }));
+
+  const CoachingSessionService = require('../../bot/shared/services/coaching/coaching-session.service');
+  return { CoachingSessionService, insertedRowCapture };
+}
+
+afterEach(() => jest.resetModules());
+
+describe('CoachingSessionService.initiateSession — recipient_identifier', () => {
+  it('stores the bare WhatsApp phone number as recipient_identifier', async () => {
+    const { CoachingSessionService, insertedRowCapture } = load();
+    await CoachingSessionService.initiateSession('user-1', 'session-1', 'audio-1', '923001234567', 120);
+    expect(insertedRowCapture.row.recipient_identifier).toBe('923001234567');
+  });
+
+  it('stores a Slack-prefixed identifier verbatim, unmodified — no WhatsApp-specific formatting applied', async () => {
+    const { CoachingSessionService, insertedRowCapture } = load();
+    await CoachingSessionService.initiateSession('user-1', 'session-1', 'audio-1', 'slack:U0123ABC', 120);
+    expect(insertedRowCapture.row.recipient_identifier).toBe('slack:U0123ABC');
+  });
+});

--- a/tests/coaching/stale-session-worker-recipient-identifier.test.js
+++ b/tests/coaching/stale-session-worker-recipient-identifier.test.js
@@ -59,9 +59,23 @@ function load({ staleSessions = [] } = {}) {
   return { worker, whatsapp, coachingJobQueue };
 }
 
-afterEach(() => jest.resetModules());
-
 const now = Date.parse('2026-08-14T12:00:00Z');
+
+// The worker computes idle time from the REAL clock (Date.now(), called live
+// at run time) — the test data below is built relative to the fixed `now`
+// above, so without actually freezing time, every session's "idle for N
+// hours" drifts further from what the test intends with each day that
+// passes. Real bug this fixes: the first test assumed a session idle for 3
+// hours (past the 2h reminder threshold, but under the 12h auto-complete
+// one) — once enough real days had passed, that same session looked idle
+// for 24+ hours to the worker's real Date.now(), crossing the auto-complete
+// threshold instead, and the worker took a different action than the test
+// expected.
+beforeEach(() => jest.useFakeTimers({ now, doNotFake: ['nextTick', 'setImmediate'] }));
+afterEach(() => {
+  jest.useRealTimers();
+  jest.resetModules();
+});
 
 describe('stale-session.worker — recipient_identifier delivery', () => {
   it('sends the reminder to session.recipient_identifier (Slack) instead of a re-derived phone number', async () => {

--- a/tests/coaching/stale-session-worker-recipient-identifier.test.js
+++ b/tests/coaching/stale-session-worker-recipient-identifier.test.js
@@ -1,0 +1,113 @@
+/**
+ * stale-session.worker.js — coaching reminders and auto-complete
+ * notifications must deliver to session.recipient_identifier, never a
+ * users.phone_number join (which is WhatsApp-only and would misdeliver a
+ * Slack-originated session's reminder).
+ */
+
+function makeSupabase({ staleSessions }) {
+  // A generic, thenable query builder. Every chain method returns the same
+  // builder so any call order works; the builder is also a real thenable
+  // (via .then()) so `await builder` resolves without a trailing .single()/
+  // .limit() call — needed because the MAIN "find stale sessions" query
+  // (.select().eq().order()) has no terminal call at all, while
+  // checkUserActivity's three "is the user busy elsewhere" probes chain
+  // further (.limit().single()) and want "nothing found" so the user is
+  // treated as idle and the reminder/auto-complete path is reached.
+  function builder(resolveValue) {
+    const b = {
+      select: () => b,
+      eq: () => b,
+      order: () => b,
+      in: () => b,
+      limit: () => b,
+      single: () => Promise.resolve(resolveValue.single ?? { data: null, error: { message: 'no rows' } }),
+      update: () => ({ eq: () => Promise.resolve({ data: null, error: null }) }),
+      then: (resolve) => resolve(resolveValue.list ?? { data: [], error: null }),
+    };
+    return b;
+  }
+
+  return {
+    from(table) {
+      if (table === 'coaching_sessions') {
+        // Shared by both the main list query (resolves via .then, no
+        // .single()) and checkUserActivity's "another active coaching
+        // session?" probe (resolves via .single(), "not found").
+        return builder({ list: { data: staleSessions, error: null } });
+      }
+      // conversations / reading_assessments — checkUserActivity's other two
+      // probes; "not found" keeps the user idle.
+      return builder({});
+    },
+  };
+}
+
+function load({ staleSessions = [] } = {}) {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/config/supabase', () => makeSupabase({ staleSessions }));
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  const whatsapp = {
+    sendInteractiveButtons: jest.fn().mockResolvedValue(true),
+    sendMessage: jest.fn().mockResolvedValue(true),
+  };
+  jest.doMock('../../bot/shared/services/whatsapp.service', () => whatsapp);
+  const coachingJobQueue = { queueReport: jest.fn().mockResolvedValue(undefined) };
+  jest.doMock('../../bot/shared/services/coaching/coaching-job-queue.service', () => coachingJobQueue);
+
+  const worker = require('../../bot/workers/stale-session.worker');
+  return { worker, whatsapp, coachingJobQueue };
+}
+
+afterEach(() => jest.resetModules());
+
+const now = Date.parse('2026-08-14T12:00:00Z');
+
+describe('stale-session.worker — recipient_identifier delivery', () => {
+  it('sends the reminder to session.recipient_identifier (Slack) instead of a re-derived phone number', async () => {
+    const session = {
+      id: 'session-1',
+      user_id: 'user-1',
+      status: 'conducting_conversation',
+      recipient_identifier: 'slack:U0123ABC',
+      conversation_state: {
+        last_interaction: new Date(now - 3 * 60 * 60 * 1000).toISOString(), // 3h idle -> past the 2h reminder threshold
+        questions_answered: 1,
+      },
+      created_at: new Date(now - 3 * 60 * 60 * 1000).toISOString(),
+      users: { first_name: 'Ayesha' },
+    };
+    const { worker, whatsapp } = load({ staleSessions: [session] });
+
+    await worker.processStaleCoachingSessions();
+
+    expect(whatsapp.sendInteractiveButtons).toHaveBeenCalledWith(
+      'slack:U0123ABC',
+      expect.objectContaining({ body: expect.any(String) })
+    );
+  });
+
+  it('auto-completes and queues the report notification to session.recipient_identifier past the 12h threshold', async () => {
+    const session = {
+      id: 'session-2',
+      user_id: 'user-2',
+      status: 'conducting_conversation',
+      recipient_identifier: 'slack:U0999XYZ',
+      conversation_state: {
+        last_interaction: new Date(now - 13 * 60 * 60 * 1000).toISOString(), // 13h idle -> past auto-complete
+        questions_answered: 2,
+      },
+      created_at: new Date(now - 13 * 60 * 60 * 1000).toISOString(),
+      users: { first_name: 'Bilal' },
+    };
+    const { worker, whatsapp, coachingJobQueue } = load({ staleSessions: [session] });
+
+    await worker.processStaleCoachingSessions();
+
+    expect(coachingJobQueue.queueReport).toHaveBeenCalledWith(
+      'session-2',
+      expect.objectContaining({ from: 'slack:U0999XYZ' })
+    );
+    expect(whatsapp.sendMessage).toHaveBeenCalledWith('slack:U0999XYZ', expect.any(String));
+  });
+});

--- a/tests/config/discord-country-regions.test.js
+++ b/tests/config/discord-country-regions.test.js
@@ -1,0 +1,56 @@
+const { COUNTRIES_DROPDOWN } = require('../../bot/shared/config/registration-data');
+const { buildBuckets, COUNTRY_REGION_BUCKETS } = require('../../bot/shared/config/discord-country-regions');
+
+describe('discord-country-regions', () => {
+  it('every bucket stays at or under Discord\'s 25-option StringSelectMenu cap', () => {
+    const buckets = buildBuckets(COUNTRIES_DROPDOWN);
+    for (const bucket of buckets) {
+      expect(bucket.countries.length).toBeLessThanOrEqual(25);
+    }
+  });
+
+  it('covers every country in COUNTRIES_DROPDOWN exactly once, with none dropped or duplicated', () => {
+    const buckets = buildBuckets(COUNTRIES_DROPDOWN);
+    const seen = new Map();
+    for (const bucket of buckets) {
+      for (const country of bucket.countries) {
+        expect(seen.has(country.id)).toBe(false); // no duplicates across buckets
+        seen.set(country.id, bucket.id);
+      }
+    }
+    expect(seen.size).toBe(COUNTRIES_DROPDOWN.length);
+    for (const country of COUNTRIES_DROPDOWN) {
+      expect(seen.has(country.id)).toBe(true); // nothing silently dropped
+    }
+  });
+
+  it('preserves each country\'s live title/id from COUNTRIES_DROPDOWN rather than a second hardcoded copy', () => {
+    const buckets = buildBuckets(COUNTRIES_DROPDOWN);
+    const pakistanBucket = buckets.find((b) => b.countries.some((c) => c.id === 'PK'));
+    const pakistan = pakistanBucket.countries.find((c) => c.id === 'PK');
+    expect(pakistan).toEqual({ id: 'PK', title: 'Pakistan' });
+  });
+
+  it('falls back to a catch-all "Other" bucket for any country not yet hand-bucketed, instead of silently dropping it', () => {
+    const extendedDropdown = [...COUNTRIES_DROPDOWN, { id: 'ZZ', title: 'Fictionland' }];
+    const buckets = buildBuckets(extendedDropdown);
+    const other = buckets.find((b) => b.id === 'other');
+    expect(other).toBeTruthy();
+    expect(other.countries).toEqual([{ id: 'ZZ', title: 'Fictionland' }]);
+  });
+
+  it('does not add an "Other" bucket when every country is already covered', () => {
+    const buckets = buildBuckets(COUNTRIES_DROPDOWN);
+    expect(buckets.find((b) => b.id === 'other')).toBeUndefined();
+  });
+
+  it('every hand-maintained bucket has a stable id and title', () => {
+    for (const bucket of COUNTRY_REGION_BUCKETS) {
+      expect(typeof bucket.id).toBe('string');
+      expect(bucket.id.length).toBeGreaterThan(0);
+      expect(typeof bucket.title).toBe('string');
+      expect(Array.isArray(bucket.countryCodes)).toBe(true);
+      expect(bucket.countryCodes.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/database/get-or-create-user-by-channel.test.js
+++ b/tests/database/get-or-create-user-by-channel.test.js
@@ -1,0 +1,177 @@
+/**
+ * getOrCreateUserByChannel / getSendTargetsForUser — the multi-homed identity
+ * layer added alongside the concurrent-channel messaging architecture.
+ *
+ * Contract under test:
+ *   - channel === 'whatsapp' delegates to the untouched getOrCreateUser(),
+ *     then lazily backfills a user_channels row for it.
+ *   - A known (channel, channel_user_id) pair resolves the linked user and
+ *     stamps user_channels.last_message_at.
+ *   - An unknown (channel, channel_user_id) pair creates a NEW users row
+ *     (no phone_number) plus its first user_channels row, is_primary=true.
+ *   - getSendTargetsForUser returns every channel identity linked to a user,
+ *     for async fan-out — not a single assumed phone_number.
+ */
+
+// Mutable state the mock factory reads (must be `mock`-prefixed for jest).
+const mockState = {
+  existingWhatsappUser: null,
+  existingChannelLink: null, // { user_id }
+  usersById: {},
+  calls: { userInserts: [], channelInserts: [], channelUpdates: [] },
+};
+
+jest.mock('../../bot/shared/config/supabase', () => {
+  function usersTable() {
+    const api = {
+      select() { return api; },
+      eq(_col, val) { api._eqVal = val; return api; },
+      single() {
+        if (api._mode === 'insert') {
+          const row = api._lastInsert;
+          api._mode = null;
+          const created = { id: 'new-user-uuid', ...row };
+          mockState.usersById[created.id] = created;
+          return Promise.resolve({ data: created, error: null });
+        }
+        // Lookup by id (getOrCreateUserByChannel's post-link-resolution fetch)
+        if (mockState.usersById[api._eqVal]) {
+          return Promise.resolve({ data: mockState.usersById[api._eqVal], error: null });
+        }
+        return mockState.existingWhatsappUser
+          ? Promise.resolve({ data: mockState.existingWhatsappUser, error: null })
+          : Promise.resolve({ data: null, error: { code: 'PGRST116' } });
+      },
+      insert(row) {
+        api._mode = 'insert';
+        api._lastInsert = row;
+        mockState.calls.userInserts.push(row);
+        return api;
+      },
+      update(row) {
+        return { eq: () => Promise.resolve({ data: null, error: null }) };
+      },
+    };
+    return api;
+  }
+
+  function userChannelsTable() {
+    const api = {
+      select(cols) { api._selectCols = cols; return api; },
+      eq() { return api; },
+      single() {
+        if (api._mode === 'insert') {
+          api._mode = null;
+          return Promise.resolve({ data: null, error: null });
+        }
+        if (api._selectCols === 'user_id') {
+          return Promise.resolve({ data: mockState.existingChannelLink, error: null });
+        }
+        // ensureUserChannelRow's "does a row already exist" probe (select('id'))
+        return Promise.resolve({ data: mockState.existingChannelLink ? { id: 'link-1' } : null, error: null });
+      },
+      insert(row) {
+        api._mode = 'insert';
+        mockState.calls.channelInserts.push(row);
+        return api;
+      },
+      update(row) {
+        mockState.calls.channelUpdates.push(row);
+        return { eq: () => ({ eq: () => Promise.resolve({ data: null, error: null }) }) };
+      },
+    };
+    return api;
+  }
+
+  return {
+    from(table) {
+      if (table === 'users') return usersTable();
+      if (table === 'user_channels') return userChannelsTable();
+      throw new Error(`Unexpected table in test mock: ${table}`);
+    },
+  };
+});
+
+const {
+  getOrCreateUser,
+  getOrCreateUserByChannel,
+  getSendTargetsForUser,
+} = require('../../bot/shared/database/bot-helpers');
+
+describe('getOrCreateUserByChannel', () => {
+  beforeEach(() => {
+    mockState.existingWhatsappUser = null;
+    mockState.existingChannelLink = null;
+    mockState.usersById = {};
+    mockState.calls = { userInserts: [], channelInserts: [], channelUpdates: [] };
+  });
+
+  it("channel === 'whatsapp' delegates to getOrCreateUser and backfills a user_channels row", async () => {
+    mockState.existingWhatsappUser = { id: 'u-wa', phone_number: '923001234567' };
+
+    const user = await getOrCreateUserByChannel('whatsapp', '923001234567');
+
+    expect(user.id).toBe('u-wa');
+    const backfillRow = mockState.calls.channelInserts.find((r) => r.channel === 'whatsapp');
+    expect(backfillRow).toBeDefined();
+    expect(backfillRow.channel_user_id).toBe('923001234567');
+    expect(backfillRow.is_primary).toBe(true);
+  });
+
+  it('resolves an existing non-WhatsApp channel link to its linked user, without creating a new one', async () => {
+    mockState.existingChannelLink = { user_id: 'u-existing' };
+    mockState.usersById['u-existing'] = { id: 'u-existing', phone_number: null };
+
+    const user = await getOrCreateUserByChannel('slack', 'U0123ABC');
+
+    expect(user.id).toBe('u-existing');
+    expect(mockState.calls.userInserts).toHaveLength(0);
+    // Stamps last_message_at on the existing link rather than inserting a new one.
+    expect(mockState.calls.channelUpdates.length).toBeGreaterThan(0);
+  });
+
+  it('creates a brand-new user (no phone_number) plus its first user_channels row for an unknown Slack identity', async () => {
+    mockState.existingChannelLink = null;
+
+    const user = await getOrCreateUserByChannel('slack', 'U9999NEW');
+
+    expect(user.id).toBe('new-user-uuid');
+    expect(user.phone_number).toBeUndefined(); // never set for a non-WhatsApp-only identity
+    const insertedUserRow = mockState.calls.userInserts[0];
+    expect(insertedUserRow.phone_number).toBeUndefined();
+
+    const insertedLink = mockState.calls.channelInserts.find((r) => r.channel === 'slack');
+    expect(insertedLink).toBeDefined();
+    expect(insertedLink.channel_user_id).toBe('U9999NEW');
+    expect(insertedLink.user_id).toBe('new-user-uuid');
+    expect(insertedLink.is_primary).toBe(true);
+  });
+});
+
+describe('getSendTargetsForUser', () => {
+  it('returns every channel identity row for the given user id', async () => {
+    const supabase = require('../../bot/shared/config/supabase');
+    const rows = [
+      { channel: 'whatsapp', channel_user_id: '923001234567' },
+      { channel: 'slack', channel_user_id: 'U0123ABC' },
+    ];
+    jest.spyOn(supabase, 'from').mockReturnValueOnce({
+      select: () => ({ eq: () => Promise.resolve({ data: rows, error: null }) }),
+    });
+
+    const targets = await getSendTargetsForUser('u-multi');
+
+    expect(targets).toEqual(rows);
+  });
+
+  it('returns an empty array (not a throw) on a query error', async () => {
+    const supabase = require('../../bot/shared/config/supabase');
+    jest.spyOn(supabase, 'from').mockReturnValueOnce({
+      select: () => ({ eq: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }),
+    });
+
+    const targets = await getSendTargetsForUser('u-error');
+
+    expect(targets).toEqual([]);
+  });
+});

--- a/tests/database/get-or-create-user-by-channel.test.js
+++ b/tests/database/get-or-create-user-by-channel.test.js
@@ -98,6 +98,10 @@ const {
   getSendTargetsForUser,
 } = require('../../bot/shared/database/bot-helpers');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('getOrCreateUserByChannel', () => {
   beforeEach(() => {
     mockState.existingWhatsappUser = null;

--- a/tests/database/get-or-create-user-last-message.test.js
+++ b/tests/database/get-or-create-user-last-message.test.js
@@ -11,38 +11,47 @@
 // Mutable state the mock factory reads (must be `mock`-prefixed for jest).
 const mockState = { existingUser: null, calls: { updates: [], inserts: [] } };
 
-jest.mock('../../bot/shared/config/supabase', () => {
-  const api = {
-    from() { return api; },
-    select() { return api; },
-    eq() { return api; },
-    single() {
-      if (api._mode === 'insert') {
-        const row = api._lastInsert;
-        api._mode = null;
-        return Promise.resolve({ data: { id: 'new-uuid', ...row }, error: null });
-      }
-      return mockState.existingUser
-        ? Promise.resolve({ data: mockState.existingUser, error: null })
-        : Promise.resolve({ data: null, error: { code: 'PGRST116' } });
-    },
-    insert(row) { api._mode = 'insert'; api._lastInsert = row; mockState.calls.inserts.push(row); return api; },
-    update(row) {
-      mockState.calls.updates.push(row);
-      return { eq: () => Promise.resolve({ data: null, error: null }) };
-    },
-  };
-  return api;
+// jest.resetModules() + jest.doMock() fresh in beforeEach (rather than a
+// single top-level jest.mock() the whole file shares) — this repo's other
+// suites already lean on this pattern, and a hoisted, file-load-time-only
+// mock has shown real, CI-reproducible unreliability when many suites share
+// a Jest worker (confirmed live: this exact file crashed on the real
+// config/supabase.js + @supabase/supabase-js in CI, not locally).
+let getOrCreateUser;
+
+beforeEach(() => {
+  jest.resetModules();
+  mockState.existingUser = null;
+  mockState.calls = { updates: [], inserts: [] };
+
+  jest.doMock('../../bot/shared/config/supabase', () => {
+    const api = {
+      from() { return api; },
+      select() { return api; },
+      eq() { return api; },
+      single() {
+        if (api._mode === 'insert') {
+          const row = api._lastInsert;
+          api._mode = null;
+          return Promise.resolve({ data: { id: 'new-uuid', ...row }, error: null });
+        }
+        return mockState.existingUser
+          ? Promise.resolve({ data: mockState.existingUser, error: null })
+          : Promise.resolve({ data: null, error: { code: 'PGRST116' } });
+      },
+      insert(row) { api._mode = 'insert'; api._lastInsert = row; mockState.calls.inserts.push(row); return api; },
+      update(row) {
+        mockState.calls.updates.push(row);
+        return { eq: () => Promise.resolve({ data: null, error: null }) };
+      },
+    };
+    return api;
+  }, { virtual: true });
+
+  ({ getOrCreateUser } = require('../../bot/shared/database/bot-helpers'));
 });
 
-const { getOrCreateUser } = require('../../bot/shared/database/bot-helpers');
-
 describe('getOrCreateUser — last_message_at stamping (bd-1877)', () => {
-  beforeEach(() => {
-    mockState.existingUser = null;
-    mockState.calls = { updates: [], inserts: [] };
-  });
-
   it('UPDATEs last_message_at for a returning user', async () => {
     mockState.existingUser = { id: 'u1', phone_number: '92300', registration_completed: true };
 

--- a/tests/exam-checker/delivery-service-recipient-identifier.test.js
+++ b/tests/exam-checker/delivery-service-recipient-identifier.test.js
@@ -1,0 +1,65 @@
+/**
+ * DeliveryService.sendResults — must deliver to session.recipient_identifier,
+ * never re-derive a destination from users.phone_number (the removed
+ * _getUserPhone helper). A Slack-originated exam session must have its
+ * grading results delivered back to that exact Slack identifier.
+ */
+
+function load() {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  const whatsapp = {
+    sendMessage: jest.fn().mockResolvedValue(true),
+    sendImage: jest.fn().mockResolvedValue(true),
+  };
+  jest.doMock('../../bot/shared/services/whatsapp.service', () => whatsapp);
+  jest.doMock('../../bot/shared/config/branding', () => ({ portalUrl: () => null }), { virtual: true });
+
+  const DeliveryService = require('../../bot/shared/services/exam-checker/delivery.service');
+  return { DeliveryService, whatsapp };
+}
+
+afterEach(() => jest.resetModules());
+
+describe('DeliveryService.sendResults — recipient_identifier', () => {
+  it('delivers the summary message to session.recipient_identifier when it is a Slack identifier', async () => {
+    const { DeliveryService, whatsapp } = load();
+    const session = {
+      id: 'exam-1',
+      recipient_identifier: 'slack:U0123ABC',
+      grading_results: { successful: [], failed: [], summary: {} },
+      annotated_images: [],
+    };
+
+    await DeliveryService.sendResults(session, 'user-1');
+
+    expect(whatsapp.sendMessage).toHaveBeenCalledWith('slack:U0123ABC', expect.stringContaining('Exam Grading Complete'));
+  });
+
+  it('delivers to a bare WhatsApp phone number unchanged', async () => {
+    const { DeliveryService, whatsapp } = load();
+    const session = {
+      id: 'exam-1',
+      recipient_identifier: '923001234567',
+      grading_results: { successful: [], failed: [], summary: {} },
+      annotated_images: [],
+    };
+
+    await DeliveryService.sendResults(session, 'user-1');
+
+    expect(whatsapp.sendMessage).toHaveBeenCalledWith('923001234567', expect.any(String));
+  });
+
+  it('throws (does not silently fall back to a users.phone_number lookup) when recipient_identifier is missing', async () => {
+    const { DeliveryService, whatsapp } = load();
+    const session = { id: 'exam-1', recipient_identifier: null, grading_results: {}, annotated_images: [] };
+
+    await expect(DeliveryService.sendResults(session, 'user-1')).rejects.toThrow(/recipient_identifier/);
+    expect(whatsapp.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('no longer exposes _getUserPhone — the re-derivation point has been removed entirely, not just bypassed', () => {
+    const { DeliveryService } = load();
+    expect(DeliveryService._getUserPhone).toBeUndefined();
+  });
+});

--- a/tests/exam-checker/exam-grading-worker-recipient-identifier.test.js
+++ b/tests/exam-checker/exam-grading-worker-recipient-identifier.test.js
@@ -1,0 +1,116 @@
+/**
+ * exam-grading.worker.js — progress updates and error notifications must
+ * deliver to session.recipient_identifier, never re-derive a destination
+ * from users.phone_number (the removed getUser() helper).
+ */
+
+function load({ session, gradeBatchImpl } = {}) {
+  jest.resetModules();
+
+  const ExamSessionService = {
+    getById: jest.fn().mockResolvedValue(session),
+    updateStatus: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
+  };
+  const DeliveryService = {
+    sendErrorNotification: jest.fn().mockResolvedValue(true),
+    sendProgressUpdate: jest.fn().mockResolvedValue(true),
+    sendResults: jest.fn().mockResolvedValue(true),
+  };
+  const GradingService = {
+    gradeBatch: jest.fn(gradeBatchImpl || (async () => ({
+      successful: [], failed: [], summary: { averagePercentage: 0 },
+    }))),
+  };
+  const OCRService = { extractBatch: jest.fn().mockResolvedValue({ provider: 'mistral', averageConfidence: 0.9 }) };
+  const QuestionDetectorService = { analyze: jest.fn().mockResolvedValue({ students: [], questions: [] }) };
+  const AnnotationService = { annotateAll: jest.fn().mockResolvedValue([]) };
+
+  jest.doMock('../../bot/shared/services/exam-checker', () => ({
+    ExamCheckerOrchestrator: {},
+    ExamSessionService,
+    OCRService,
+    QuestionDetectorService,
+    GradingService,
+    AnnotationService,
+    DeliveryService,
+  }), { virtual: true });
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/utils/structured-logger', () => ({
+    runWithCorrelation: (id, fn) => fn(),
+    generateCorrelationId: () => 'corr-1',
+  }));
+
+  const worker = require('../../bot/workers/exam-grading.worker');
+  return { worker, ExamSessionService, DeliveryService, GradingService };
+}
+
+afterEach(() => jest.resetModules());
+
+describe('exam-grading.worker — recipient_identifier delivery', () => {
+  it('sends grading-progress updates to session.recipient_identifier, not a users.phone_number lookup', async () => {
+    const session = {
+      id: 'exam-1',
+      status: 'grading',
+      user_id: 'user-1',
+      recipient_identifier: 'slack:U0123ABC',
+      confirmed_students: ['s1'],
+      original_images: [],
+    };
+    const { worker, DeliveryService, GradingService } = load({
+      session,
+      gradeBatchImpl: async (sess, { onProgress }) => {
+        await onProgress({ completed: 1, total: 4, percentage: 25 });
+        return { successful: [], failed: [], summary: { averagePercentage: 0 } };
+      },
+    });
+
+    await worker.process({ sessionId: 'exam-1', userId: 'user-1', phase: 'grading' });
+
+    expect(GradingService.gradeBatch).toHaveBeenCalled();
+    expect(DeliveryService.sendProgressUpdate).toHaveBeenCalledWith('slack:U0123ABC', expect.objectContaining({ percentage: 25 }));
+  });
+
+  it('delivers grading results via session.recipient_identifier through DeliveryService.sendResults', async () => {
+    const session = {
+      id: 'exam-1',
+      status: 'grading',
+      user_id: 'user-1',
+      recipient_identifier: 'slack:U0123ABC',
+      confirmed_students: ['s1'],
+      original_images: [],
+    };
+    const { worker, DeliveryService } = load({ session });
+
+    await worker.process({ sessionId: 'exam-1', userId: 'user-1', phase: 'grading' });
+
+    expect(DeliveryService.sendResults).toHaveBeenCalledWith(
+      expect.objectContaining({ recipient_identifier: 'slack:U0123ABC' }),
+      'user-1'
+    );
+  });
+
+  it('sends an error notification to session.recipient_identifier when the job throws, not a re-derived phone number', async () => {
+    const session = { id: 'exam-1', status: 'grading', user_id: 'user-1', recipient_identifier: 'slack:U0123ABC', confirmed_students: ['s1'] };
+    const { worker, DeliveryService } = load({
+      session,
+      gradeBatchImpl: async () => { throw new Error('grading exploded'); },
+    });
+
+    await expect(worker.process({ sessionId: 'exam-1', userId: 'user-1', phase: 'grading' })).rejects.toThrow('grading exploded');
+
+    expect(DeliveryService.sendErrorNotification).toHaveBeenCalledWith('slack:U0123ABC', 'exam-1', 'grading exploded');
+  });
+
+  it('does not notify at all when the session has no recipient_identifier (never guesses a channel)', async () => {
+    const session = { id: 'exam-1', status: 'grading', user_id: 'user-1', recipient_identifier: null, confirmed_students: ['s1'] };
+    const { worker, DeliveryService } = load({
+      session,
+      gradeBatchImpl: async () => { throw new Error('boom'); },
+    });
+
+    await expect(worker.process({ sessionId: 'exam-1', userId: 'user-1', phase: 'grading' })).rejects.toThrow('boom');
+
+    expect(DeliveryService.sendErrorNotification).not.toHaveBeenCalled();
+  });
+});

--- a/tests/exam-checker/exam-session-recipient-identifier.test.js
+++ b/tests/exam-checker/exam-session-recipient-identifier.test.js
@@ -1,0 +1,79 @@
+/**
+ * ExamSessionService — must thread the originating channel identifier
+ * through session creation, and getOrCreate must only use it on the
+ * CREATE path (an existing session already has its own stored value from
+ * whenever it was first created — a later request's `from` must never
+ * silently overwrite it).
+ */
+
+function makeSupabase({ existingSession, insertedRowCapture }) {
+  return {
+    from(table) {
+      if (table !== 'exam_check_sessions') throw new Error(`Unexpected table: ${table}`);
+      return {
+        select: () => ({
+          eq: () => ({
+            not: () => ({
+              order: () => ({
+                limit: () => ({
+                  single: () => Promise.resolve(
+                    existingSession
+                      ? { data: existingSession, error: null }
+                      : { data: null, error: { message: 'no rows' } }
+                  ),
+                }),
+              }),
+            }),
+          }),
+        }),
+        insert: (row) => {
+          insertedRowCapture.row = row;
+          return { select: () => ({ single: () => Promise.resolve({ data: { id: 'exam-session-1', ...row }, error: null }) }) };
+        },
+      };
+    },
+  };
+}
+
+function load({ existingSession = null } = {}) {
+  jest.resetModules();
+  const insertedRowCapture = {};
+  jest.doMock('../../bot/shared/config/supabase', () => makeSupabase({ existingSession, insertedRowCapture }));
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/services/cache/railway-redis.service', () => ({
+    get: jest.fn().mockResolvedValue(null),
+    setex: jest.fn().mockResolvedValue('OK'),
+  }));
+
+  const ExamSessionService = require('../../bot/shared/services/exam-checker/exam-session.service');
+  return { ExamSessionService, insertedRowCapture };
+}
+
+afterEach(() => jest.resetModules());
+
+describe('ExamSessionService.getOrCreate / _createSession — recipient_identifier', () => {
+  it('stores the WhatsApp phone number on a brand-new session', async () => {
+    const { ExamSessionService, insertedRowCapture } = load();
+    await ExamSessionService.getOrCreate('user-1', '923001234567');
+    expect(insertedRowCapture.row.recipient_identifier).toBe('923001234567');
+  });
+
+  it('stores a Slack-prefixed identifier verbatim on a brand-new session', async () => {
+    const { ExamSessionService, insertedRowCapture } = load();
+    await ExamSessionService.getOrCreate('user-1', 'slack:U0123ABC');
+    expect(insertedRowCapture.row.recipient_identifier).toBe('slack:U0123ABC');
+  });
+
+  it('does NOT touch recipient_identifier when an active session already exists — its original value is preserved', async () => {
+    const existingSession = { id: 'existing-1', user_id: 'user-1', status: 'collecting_images', recipient_identifier: 'slack:U0123ABC' };
+    const { ExamSessionService, insertedRowCapture } = load({ existingSession });
+
+    // A second message arrives on a DIFFERENT channel mid-session (e.g. the
+    // teacher also has a WhatsApp number) — getOrCreate must return the
+    // EXISTING session unchanged, never overwrite its stored channel.
+    const session = await ExamSessionService.getOrCreate('user-1', '923001234567');
+
+    expect(session.recipient_identifier).toBe('slack:U0123ABC');
+    expect(insertedRowCapture.row).toBeUndefined(); // no insert happened at all
+  });
+});

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -23,6 +23,7 @@ module.exports = {
     '^axios$': '<rootDir>/tests/__mocks__/axios.js',
     '^form-data$': '<rootDir>/tests/__mocks__/form-data.js',
     // bot-only optional/native packages — use lightweight mocks for OSS test suite
+    '^@supabase/supabase-js$': '<rootDir>/tests/__mocks__/supabase-js.js',
     '^@aws-sdk/client-s3$': '<rootDir>/tests/__mocks__/aws-sdk-client-s3.js',
     '^@aws-sdk/s3-request-presigner$': '<rootDir>/tests/__mocks__/aws-sdk-s3-request-presigner.js',
     '^pino$': '<rootDir>/tests/__mocks__/pino.js',

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   moduleNameMapper: {
     '^openai$': '<rootDir>/node_modules/openai',
     '^ioredis$': '<rootDir>/node_modules/ioredis',
+    '^discord\\.js$': '<rootDir>/node_modules/discord.js',
     // axios + form-data live in bot/node_modules (not root), and the root test
     // job runs before bot deps install — so source that requires them can't
     // resolve. Map to lightweight stubs (same pattern as pino/canvas above) so

--- a/tests/messaging/baileys-connection.test.js
+++ b/tests/messaging/baileys-connection.test.js
@@ -524,6 +524,50 @@ describe('baileys-connection', () => {
     await expect(conn.close({ flushMs: 0 })).resolves.toBeUndefined();
   });
 
+  it('close() does not hang forever on a socket stuck pre-open/pre-close (unpaired, waiting on an unscanned QR)', async () => {
+    // Real-world bug this fixes: Ctrl+C while Baileys is showing a QR that was
+    // never scanned. getSocket()'s promise only settles on 'open' or 'close' —
+    // neither ever fires for a socket just sitting on an unscanned QR, so
+    // close()'s old unconditional `await pending` hung forever, and the
+    // process never called process.exit().
+    jest.resetModules();
+    const { sockEventHandlers } = mockBaileysPackage();
+    const conn = require('../../bot/shared/services/messaging/baileys-connection');
+
+    const socketPromise = conn.getSocket();
+    await waitForHandler(sockEventHandlers);
+    sockEventHandlers['connection.update']({ qr: 'QR-NEVER-SCANNED' });
+    // Neither 'open' nor 'close' ever fires — this promise stays pending forever.
+    socketPromise.catch(() => {}); // avoid an unhandled-rejection warning once shuttingDown rejects it below
+
+    await expect(conn.close({ flushMs: 0, pendingTimeoutMs: 20 })).resolves.toBeUndefined();
+  });
+
+  it('close() sets shuttingDown so a QR event that fires DURING shutdown is ignored — not rendered, not treated as a new pairing opportunity', async () => {
+    // Real-world bug this fixes: after Ctrl+C, Baileys' own retry/refresh cycle
+    // on the still-alive (unpaired) socket kept firing new 'qr' events, and the
+    // QR branch had no shuttingDown check at all — so a fresh QR code printed
+    // to the terminal well after the user asked the process to exit.
+    jest.resetModules();
+    const { sockEventHandlers } = mockBaileysPackage();
+    const qrTerminal = require('qrcode-terminal');
+    const conn = require('../../bot/shared/services/messaging/baileys-connection');
+
+    const socketPromise = conn.getSocket();
+    await waitForHandler(sockEventHandlers);
+    socketPromise.catch(() => {});
+
+    const closing = conn.close({ flushMs: 0, pendingTimeoutMs: 20 });
+
+    // A QR fires AFTER close() has set shuttingDown = true, but before the
+    // pendingTimeoutMs backstop elapses — simulates Baileys' own QR-refresh
+    // cycle racing with shutdown.
+    sockEventHandlers['connection.update']({ qr: 'QR-DURING-SHUTDOWN' });
+
+    await closing;
+    expect(qrTerminal.generate).not.toHaveBeenCalled();
+  });
+
   it('does NOT reconnect on a logout close (statusCode === 401), and rejects this attempt cleanly', async () => {
     jest.resetModules();
     const { sockEventHandlers, makeWASocket } = mockBaileysPackage();

--- a/tests/messaging/channel-driver-index.test.js
+++ b/tests/messaging/channel-driver-index.test.js
@@ -5,6 +5,18 @@
  * back to Baileys; with no CHANNEL_DRIVER set at all, ANY Meta var already
  * present infers `meta` (backward compat for pre-existing deployments).
  * Mirrors tests/queue/queue-driver-index.test.js.
+ *
+ * messaging/index.js now exports a Proxy WRAPPING the resolved WhatsApp
+ * driver (not the driver object itself) — see index.js's own doc comment for
+ * why (preserving jest.spyOn-ability on internal this.x() cross-method
+ * calls once an additive channel like Slack can also be active). With no
+ * additive channel configured (the case every one of these tests exercises),
+ * the Proxy is fully transparent: every method call and property read
+ * forwards straight through to the real driver, so behavior is identical —
+ * strict `===` against the raw driver module is no longer true (a Proxy is
+ * never `===` its target), so these assertions check behavioral equivalence
+ * instead: the resolved driver's own identifying method returns what only
+ * that driver could return.
  */
 
 function mockCommon() {
@@ -22,13 +34,24 @@ afterEach(() => {
   META_VARS.forEach((k) => delete process.env[k]);
 });
 
+// meta-channel.service.js exports a class (typeof 'function'); baileys-
+// channel.service.js exports a plain object (typeof 'object'). A Proxy
+// preserves the target's typeof, so this cheaply tells the two apart without
+// relying on strict `===` against the wrapped module (see file header).
+function expectResolvesToMeta(idx) {
+  expect(typeof idx).toBe('function');
+}
+function expectResolvesToBaileys(idx) {
+  expect(typeof idx).toBe('object');
+}
+
 describe('messaging channel driver selector', () => {
   it('defaults to the Baileys singleton when CHANNEL_DRIVER is unset and no Meta vars are present', () => {
     jest.resetModules();
     mockCommon();
     const idx = require('../../bot/shared/services/messaging');
-    const baileys = require('../../bot/shared/services/messaging/baileys-channel.service');
-    expect(idx).toBe(baileys);
+    expectResolvesToBaileys(idx);
+    expect(typeof idx.sendMessage).toBe('function');
   });
 
   it('returns the Meta singleton when CHANNEL_DRIVER=meta', () => {
@@ -36,8 +59,8 @@ describe('messaging channel driver selector', () => {
     mockCommon();
     process.env.CHANNEL_DRIVER = 'meta';
     const idx = require('../../bot/shared/services/messaging');
-    const meta = require('../../bot/shared/services/messaging/meta-channel.service');
-    expect(idx).toBe(meta);
+    expectResolvesToMeta(idx);
+    expect(typeof idx.sendMessage).toBe('function');
   });
 
   it('returns the Baileys singleton when CHANNEL_DRIVER=baileys explicitly', () => {
@@ -45,8 +68,7 @@ describe('messaging channel driver selector', () => {
     mockCommon();
     process.env.CHANNEL_DRIVER = 'baileys';
     const idx = require('../../bot/shared/services/messaging');
-    const baileys = require('../../bot/shared/services/messaging/baileys-channel.service');
-    expect(idx).toBe(baileys);
+    expectResolvesToBaileys(idx);
   });
 
   it('falls back to Baileys for an unknown CHANNEL_DRIVER value', () => {
@@ -54,8 +76,7 @@ describe('messaging channel driver selector', () => {
     mockCommon();
     process.env.CHANNEL_DRIVER = 'telegram';
     const idx = require('../../bot/shared/services/messaging');
-    const baileys = require('../../bot/shared/services/messaging/baileys-channel.service');
-    expect(idx).toBe(baileys);
+    expectResolvesToBaileys(idx);
   });
 
   it('with no CHANNEL_DRIVER set, infers Meta when a Meta var is already present (backward compat)', () => {
@@ -63,8 +84,7 @@ describe('messaging channel driver selector', () => {
     mockCommon();
     process.env.WHATSAPP_TOKEN = 'real-looking-token';
     const idx = require('../../bot/shared/services/messaging');
-    const meta = require('../../bot/shared/services/messaging/meta-channel.service');
-    expect(idx).toBe(meta);
+    expectResolvesToMeta(idx);
   });
 
   it('the WhatsAppService facade resolves to the same driver as messaging/index.js', () => {
@@ -72,7 +92,28 @@ describe('messaging channel driver selector', () => {
     mockCommon();
     process.env.CHANNEL_DRIVER = 'baileys';
     const facade = require('../../bot/shared/services/whatsapp.service');
+    const idx = require('../../bot/shared/services/messaging');
+    // Both requires resolve through Node's module cache to the SAME Proxy
+    // instance (whatsapp.service.js is a one-line `module.exports =
+    // require('./messaging')` facade) — this identity DOES still hold, since
+    // both call sites get back the one Proxy messaging/index.js constructed.
+    expect(facade).toBe(idx);
+    expectResolvesToBaileys(facade);
+  });
+
+  it('with no additive channel configured, the Proxy forwards every call to the real driver unchanged', async () => {
+    jest.resetModules();
+    mockCommon();
+    process.env.CHANNEL_DRIVER = 'baileys';
+    const idx = require('../../bot/shared/services/messaging');
     const baileys = require('../../bot/shared/services/messaging/baileys-channel.service');
-    expect(facade).toBe(baileys);
+    // Spying on the raw driver module must still be observable through the
+    // Proxy — this is the property the Proxy-based design exists to
+    // preserve (see tests/whatsapp/send-image-from-url.test.js for the real
+    // regression this guards against).
+    const spy = jest.spyOn(baileys, 'sendReaction').mockResolvedValue('spied');
+    await expect(idx.sendReaction('923001234567', 'msg-1')).resolves.toBe('spied');
+    expect(spy).toHaveBeenCalledWith('923001234567', 'msg-1');
+    spy.mockRestore();
   });
 });

--- a/tests/messaging/channel-driver-parity.test.js
+++ b/tests/messaging/channel-driver-parity.test.js
@@ -8,8 +8,15 @@
  *
  * Method names are parsed independently off meta-channel.service.js's source
  * (same regex the guard test uses), NOT via introspection — so this test
- * doesn't just tautologically confirm baileys-channel.service.js's own
- * derivation mechanism works; it's a second, independent check.
+ * doesn't just tautologically confirm each driver's own derivation mechanism
+ * works; it's a second, independent check.
+ *
+ * The driver LIST itself comes from channel-registry.js's DRIVERS map, not a
+ * literal object — so a third/fourth driver (Slack, Discord, ...) is picked
+ * up here automatically the day it's added to the registry, with no changes
+ * to this file beyond registering that driver's own mock deps in
+ * EXTRA_MOCKS_BY_DRIVER below (mirroring how baileys-connection is mocked
+ * for baileys today).
  *
  * This file only checks EXISTENCE + the still-stubbed methods' behavior.
  * Behavior of the REAL (connection-backed) methods is covered by
@@ -20,7 +27,18 @@
 const fs = require('fs');
 const path = require('path');
 
-const META_SERVICE = path.resolve(__dirname, '../../bot/shared/services/messaging/meta-channel.service.js');
+const MESSAGING_DIR = path.resolve(__dirname, '../../bot/shared/services/messaging');
+const META_SERVICE = path.join(MESSAGING_DIR, 'meta-channel.service.js');
+const { DRIVERS } = require('../../bot/shared/services/messaging/channel-registry');
+
+// A literal require (not just the dynamic path.join(MESSAGING_DIR, ...) load
+// inside loadDrivers() below) so tests/setup/orphan-modules.test.js's static
+// require-graph scan keeps tracing an edge to every driver module — that
+// scan only follows string-literal `require()` calls, not ones built from a
+// runtime variable. Unused directly; loadDrivers() still requires by
+// variable path so the driver LIST stays registry-driven (see file header).
+require('../../bot/shared/services/messaging/meta-channel.service');
+require('../../bot/shared/services/messaging/baileys-channel.service');
 
 function parseMethodNames(src) {
   const names = new Set();
@@ -32,6 +50,20 @@ function parseMethodNames(src) {
 
 const REQUIRED_METHODS = parseMethodNames(fs.readFileSync(META_SERVICE, 'utf-8'));
 
+// Per-driver mocks beyond the common set every driver needs (logger, r2).
+// Add an entry here when a new driver's require graph needs something
+// driver-specific stubbed out (e.g. baileys-connection for baileys,
+// @slack/web-api for a future slack entry) — same shape, no restructuring.
+const EXTRA_MOCKS_BY_DRIVER = {
+  baileys: () => {
+    jest.doMock('../../bot/shared/services/messaging/baileys-connection', () => ({
+      getSocket: jest.fn().mockRejectedValue(new Error('not connected in this test')),
+      isConnected: jest.fn().mockReturnValue(false),
+      authDir: jest.fn().mockReturnValue('/tmp/never-used'),
+    }));
+  },
+};
+
 function loadDrivers() {
   jest.resetModules();
   jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
@@ -39,15 +71,14 @@ function loadDrivers() {
     downloadFromR2: jest.fn(),
     extractKeyFromUrl: jest.fn(),
   }));
-  jest.doMock('../../bot/shared/services/messaging/baileys-connection', () => ({
-    getSocket: jest.fn().mockRejectedValue(new Error('not connected in this test')),
-    isConnected: jest.fn().mockReturnValue(false),
-    authDir: jest.fn().mockReturnValue('/tmp/never-used'),
-  }));
-  return {
-    meta: require('../../bot/shared/services/messaging/meta-channel.service'),
-    baileys: require('../../bot/shared/services/messaging/baileys-channel.service'),
-  };
+  for (const name of Object.keys(DRIVERS)) {
+    if (EXTRA_MOCKS_BY_DRIVER[name]) EXTRA_MOCKS_BY_DRIVER[name]();
+  }
+  const loaded = {};
+  for (const [name, modulePath] of Object.entries(DRIVERS)) {
+    loaded[name] = require(path.join(MESSAGING_DIR, modulePath));
+  }
+  return loaded;
 }
 
 afterEach(() => jest.resetModules());
@@ -59,14 +90,11 @@ describe('channel driver parity', () => {
     expect(REQUIRED_METHODS.length).toBeGreaterThan(20);
   });
 
-  it.each(REQUIRED_METHODS)('Meta driver implements %s()', (m) => {
-    const { meta } = loadDrivers();
-    expect(typeof meta[m]).toBe('function');
-  });
-
-  it.each(REQUIRED_METHODS)('Baileys driver implements %s()', (m) => {
-    const { baileys } = loadDrivers();
-    expect(typeof baileys[m]).toBe('function');
+  describe.each(Object.keys(DRIVERS))('%s driver', (driverName) => {
+    it.each(REQUIRED_METHODS)('implements %s()', (m) => {
+      const drivers = loadDrivers();
+      expect(typeof drivers[driverName][m]).toBe('function');
+    });
   });
 
   // Methods with NO Baileys equivalent (Meta-template-specific — see

--- a/tests/messaging/channel-driver-parity.test.js
+++ b/tests/messaging/channel-driver-parity.test.js
@@ -39,6 +39,7 @@ const { DRIVERS } = require('../../bot/shared/services/messaging/channel-registr
 // variable path so the driver LIST stays registry-driven (see file header).
 require('../../bot/shared/services/messaging/meta-channel.service');
 require('../../bot/shared/services/messaging/baileys-channel.service');
+require('../../bot/shared/services/messaging/slack-channel.service');
 
 function parseMethodNames(src) {
   const names = new Set();
@@ -61,6 +62,16 @@ const EXTRA_MOCKS_BY_DRIVER = {
       isConnected: jest.fn().mockReturnValue(false),
       authDir: jest.fn().mockReturnValue('/tmp/never-used'),
     }));
+  },
+  slack: () => {
+    jest.doMock('@slack/web-api', () => ({
+      WebClient: jest.fn().mockImplementation(() => ({
+        conversations: { open: jest.fn().mockRejectedValue(new Error('not connected in this test')) },
+        chat: { postMessage: jest.fn() },
+        reactions: { add: jest.fn() },
+        files: { uploadV2: jest.fn(), info: jest.fn() },
+      })),
+    }), { virtual: true });
   },
 };
 
@@ -149,8 +160,80 @@ describe('channel driver parity', () => {
       '../../bot/shared/services/messaging/meta-channel.service',
       () => { throw new Error('baileys-channel.service.js must not require() meta-channel.service.js'); },
     );
-    require('../../bot/shared/services/messaging/baileys-channel.service');
-    expect(axiosRequired).toBe(false);
-    expect(formDataRequired).toBe(false);
+    try {
+      require('../../bot/shared/services/messaging/baileys-channel.service');
+      expect(axiosRequired).toBe(false);
+      expect(formDataRequired).toBe(false);
+    } finally {
+      // jest.resetModules() clears the module REGISTRY but not a doMock
+      // FACTORY registered in this test — without this, the throwing
+      // meta-channel.service mock above leaks into every test that runs
+      // after this one in the file (a real, pre-existing test-isolation gap
+      // this generalization surfaced, not something new to it).
+      jest.dontMock('../../bot/shared/services/messaging/meta-channel.service');
+    }
+  });
+
+  // Slack's stub set differs from Baileys': no Flow/template/carousel methods
+  // (same reason — needs the unbuilt channel-agnostic template registry), but
+  // ALSO no typing indicator (Slack has no bot typing-indicator API at all,
+  // unlike Baileys' presence-update equivalent) — so this is its own table,
+  // not a reuse of STUB_ASYNC_METHODS/STUB_SYNC_METHODS above.
+  const SLACK_STUB_ASYNC_METHODS = ['sendTemplate', 'sendFlow', 'sendStyleCarousel', 'sendFeatureMenuCarousel'];
+  const SLACK_STUB_SYNC_METHODS = ['buildStyleCarouselPayload', 'buildFeatureMenuCarouselPayload'];
+
+  it.each(SLACK_STUB_ASYNC_METHODS)('Slack %s() has no equivalent yet — logs and resolves false', async (m) => {
+    const { slack } = loadDrivers();
+    await expect(slack[m]('slack:U0123ABC', 'x', 'y', 'z')).resolves.toBe(false);
+  });
+
+  it.each(SLACK_STUB_SYNC_METHODS)('Slack %s() has no equivalent yet — is synchronous and returns null, not a Promise', (m) => {
+    const { slack } = loadDrivers();
+    const result = slack[m]('slack:U0123ABC');
+    expect(result).not.toBeInstanceOf(Promise);
+    expect(result).toBeNull();
+  });
+
+  it('Slack showTypingIndicator() is a documented no-op, not a stub — resolves true without a Slack API call', async () => {
+    const { slack } = loadDrivers();
+    await expect(slack.showTypingIndicator('slack:U0123ABC')).resolves.toBe(true);
+  });
+
+  it('Slack startContinuousTypingIndicator() is synchronous and returns a real, callable no-op controller', () => {
+    const { slack } = loadDrivers();
+    const controller = slack.startContinuousTypingIndicator('slack:U0123ABC');
+    expect(controller).not.toBeInstanceOf(Promise);
+    expect(typeof controller.stop).toBe('function');
+    expect(() => controller.stop()).not.toThrow();
+  });
+
+  it('Slack _removeEmotionTags() is a real, synchronous reimplementation (pure/channel-agnostic), not a stub', () => {
+    const { slack } = loadDrivers();
+    expect(slack._removeEmotionTags('[warmly] hello')).toBe('hello');
+  });
+
+  it('loading the Slack driver never requires Meta\'s HTTP client (axios/form-data) or meta-channel.service.js itself', () => {
+    jest.resetModules();
+    let axiosRequired = false;
+    let formDataRequired = false;
+    jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+    jest.doMock('../../bot/shared/storage/r2', () => ({ downloadFromR2: jest.fn(), extractKeyFromUrl: jest.fn() }));
+    jest.doMock('@slack/web-api', () => ({ WebClient: jest.fn() }), { virtual: true });
+    jest.doMock('axios', () => { axiosRequired = true; return {}; }, { virtual: true });
+    jest.doMock('form-data', () => { formDataRequired = true; return {}; }, { virtual: true });
+    jest.doMock(
+      '../../bot/shared/services/messaging/meta-channel.service',
+      () => { throw new Error('slack-channel.service.js must not require() meta-channel.service.js'); },
+    );
+    try {
+      require('../../bot/shared/services/messaging/slack-channel.service');
+      expect(axiosRequired).toBe(false);
+      expect(formDataRequired).toBe(false);
+    } finally {
+      // See the matching comment on the Baileys isolation test above —
+      // jest.resetModules() does not undo a doMock FACTORY, so this must be
+      // explicitly cleared or it poisons whatever test runs next in the file.
+      jest.dontMock('../../bot/shared/services/messaging/meta-channel.service');
+    }
   });
 });

--- a/tests/messaging/channel-lifecycle.test.js
+++ b/tests/messaging/channel-lifecycle.test.js
@@ -53,11 +53,31 @@ describe('logged-out session is terminal, not a restart loop', () => {
   });
 
   it('the logout handler is a no-op for the meta driver, which has no local session', () => {
+    // exitOnChannelLogout() now loops PERSISTENT_CONNECTION_DRIVERS (currently
+    // just baileys) instead of a single hardcoded driver-name check, so the
+    // "no-op for meta" guarantee is pinned against the registry's isActive()
+    // predicate rather than a literal source-text pattern — same behavior,
+    // registry-shaped so a future persistent-connection driver (e.g. a
+    // Discord Gateway driver) is a new entry here, not a rewrite of this
+    // guard.
     const src = require('fs').readFileSync(
       require('path').resolve(__dirname, '../../bot/whatsapp-bot.js'),
       'utf-8'
     );
-    const fn = src.slice(src.indexOf('function exitOnChannelLogout'));
-    expect(fn).toMatch(/resolveChannelDriver\(process\.env\) !== 'baileys'\) return/);
+    expect(src).toMatch(/PERSISTENT_CONNECTION_DRIVERS/);
+
+    const baileysEntry = src.slice(
+      src.indexOf('const PERSISTENT_CONNECTION_DRIVERS'),
+      src.indexOf('function wireBaileysInboundIfSelected')
+    );
+    expect(baileysEntry).toMatch(/isActive:\s*\(env\)\s*=>.*resolveChannelDriver\(env\)\s*===\s*'baileys'/);
+
+    // Behavioral pin: baileys' isActive() is false for meta, true for
+    // baileys — the actual "no-op for meta" contract, exercised directly
+    // rather than inferred from source shape.
+    const { resolveChannelDriver } = require('../../bot/shared/config/feature-availability');
+    const isActive = (env) => resolveChannelDriver(env) === 'baileys';
+    expect(isActive({ CHANNEL_DRIVER: 'meta' })).toBe(false);
+    expect(isActive({ CHANNEL_DRIVER: 'baileys' })).toBe(true);
   });
 });

--- a/tests/messaging/channel-registry.test.js
+++ b/tests/messaging/channel-registry.test.js
@@ -2,28 +2,49 @@
  * channel-registry — pure data, no env/process logic. Confirms the shape the
  * rest of the messaging module (and feature-availability.js) builds on: a
  * default-sandbox rule with an explicit production allowlist, not a per-driver
- * tag someone has to remember to set.
+ * tag someone has to remember to set. Also confirms the additive-channel
+ * concept (Slack, Discord, ...) — drivers that run ALONGSIDE the one
+ * WhatsApp-family driver (meta|baileys) via their own env-var presence,
+ * never selected through CHANNEL_DRIVER, each carrying a wire prefix so
+ * messaging/index.js's router can dispatch to them by identifier shape.
  */
 
 const registry = require('../../bot/shared/services/messaging/channel-registry');
 
 describe('channel-registry', () => {
-  it('lists meta and baileys as the v1 drivers, defaulting to baileys', () => {
-    expect(Object.keys(registry.DRIVERS).sort()).toEqual(['baileys', 'meta']);
+  it('lists meta and baileys as the WhatsApp-family drivers, defaulting to baileys', () => {
+    expect(Object.keys(registry.DRIVERS)).toEqual(expect.arrayContaining(['baileys', 'meta']));
     expect(registry.DEFAULT_DRIVER).toBe('baileys');
   });
 
-  it('meta is the only production-tier driver — everything else is sandbox by default', () => {
-    expect(registry.PRODUCTION_TIER_DRIVERS).toEqual(['meta']);
+  it('lists slack as an additive channel driver, alongside the WhatsApp-family ones', () => {
+    expect(registry.DRIVERS.slack).toBe('./slack-channel.service');
+  });
+
+  it('meta and slack are the production-tier drivers — baileys is sandbox only', () => {
+    expect(registry.PRODUCTION_TIER_DRIVERS.sort()).toEqual(['meta', 'slack']);
     expect(registry.isProductionTier('meta')).toBe(true);
+    expect(registry.isProductionTier('slack')).toBe(true);
     expect(registry.isProductionTier('baileys')).toBe(false);
     // A hypothetical future driver not yet on the allowlist is sandbox by default.
-    expect(registry.isProductionTier('slack')).toBe(false);
+    expect(registry.isProductionTier('discord')).toBe(false);
   });
 
   it('isKnownDriver reflects exactly the DRIVERS map', () => {
     expect(registry.isKnownDriver('meta')).toBe(true);
     expect(registry.isKnownDriver('baileys')).toBe(true);
+    expect(registry.isKnownDriver('slack')).toBe(true);
     expect(registry.isKnownDriver('telegram')).toBe(false);
+  });
+
+  it('slack carries the "slack:" wire prefix; WhatsApp-family drivers carry none', () => {
+    expect(registry.prefixFor('slack')).toBe('slack');
+    expect(registry.prefixFor('meta')).toBeNull();
+    expect(registry.prefixFor('baileys')).toBeNull();
+  });
+
+  it('driverForIdentifier resolves a prefixed identifier to its driver, and a bare phone number to null', () => {
+    expect(registry.driverForIdentifier('slack:U0123ABC')).toBe('slack');
+    expect(registry.driverForIdentifier('923001234567')).toBeNull();
   });
 });

--- a/tests/messaging/channel-registry.test.js
+++ b/tests/messaging/channel-registry.test.js
@@ -17,34 +17,39 @@ describe('channel-registry', () => {
     expect(registry.DEFAULT_DRIVER).toBe('baileys');
   });
 
-  it('lists slack as an additive channel driver, alongside the WhatsApp-family ones', () => {
+  it('lists slack and discord as additive channel drivers, alongside the WhatsApp-family ones', () => {
     expect(registry.DRIVERS.slack).toBe('./slack-channel.service');
+    expect(registry.DRIVERS.discord).toBe('./discord-channel.service');
   });
 
-  it('meta and slack are the production-tier drivers — baileys is sandbox only', () => {
-    expect(registry.PRODUCTION_TIER_DRIVERS.sort()).toEqual(['meta', 'slack']);
+  it('meta, slack, and discord are the production-tier drivers — baileys is sandbox only', () => {
+    expect(registry.PRODUCTION_TIER_DRIVERS.sort()).toEqual(['discord', 'meta', 'slack']);
     expect(registry.isProductionTier('meta')).toBe(true);
     expect(registry.isProductionTier('slack')).toBe(true);
+    expect(registry.isProductionTier('discord')).toBe(true);
     expect(registry.isProductionTier('baileys')).toBe(false);
     // A hypothetical future driver not yet on the allowlist is sandbox by default.
-    expect(registry.isProductionTier('discord')).toBe(false);
+    expect(registry.isProductionTier('telegram')).toBe(false);
   });
 
   it('isKnownDriver reflects exactly the DRIVERS map', () => {
     expect(registry.isKnownDriver('meta')).toBe(true);
     expect(registry.isKnownDriver('baileys')).toBe(true);
     expect(registry.isKnownDriver('slack')).toBe(true);
+    expect(registry.isKnownDriver('discord')).toBe(true);
     expect(registry.isKnownDriver('telegram')).toBe(false);
   });
 
-  it('slack carries the "slack:" wire prefix; WhatsApp-family drivers carry none', () => {
+  it('slack/discord carry their own wire prefix; WhatsApp-family drivers carry none', () => {
     expect(registry.prefixFor('slack')).toBe('slack');
+    expect(registry.prefixFor('discord')).toBe('discord');
     expect(registry.prefixFor('meta')).toBeNull();
     expect(registry.prefixFor('baileys')).toBeNull();
   });
 
   it('driverForIdentifier resolves a prefixed identifier to its driver, and a bare phone number to null', () => {
     expect(registry.driverForIdentifier('slack:U0123ABC')).toBe('slack');
+    expect(registry.driverForIdentifier('discord:918273645')).toBe('discord');
     expect(registry.driverForIdentifier('923001234567')).toBeNull();
   });
 });

--- a/tests/messaging/discord-channel-service.test.js
+++ b/tests/messaging/discord-channel-service.test.js
@@ -1,0 +1,259 @@
+/**
+ * discord-channel.service.js — behavior of the REAL (discord.js-backed)
+ * methods. discord-connection.js (the shared Gateway client owner) is always
+ * mocked here so nothing ever opens a real socket; the builder classes
+ * (ActionRowBuilder, ButtonBuilder, etc.) are the REAL discord.js exports —
+ * they are pure data builders with no network calls, so mocking them would
+ * just reimplement discord.js badly. tests/messaging/channel-driver-parity.test.js
+ * covers the still-stubbed Meta-template-only methods and cross-driver
+ * existence.
+ */
+
+function loadService({ sendImpl, fetchImpl } = {}) {
+  jest.resetModules();
+  const sentMessages = [];
+  const user = {
+    id: 'U0123ABC',
+    send: jest.fn(sendImpl || (async (payload) => {
+      sentMessages.push(payload);
+      return { id: '1699999999123' };
+    })),
+    dmChannel: null,
+    createDM: jest.fn(async () => user.dmChannel),
+  };
+  const message = { react: jest.fn(async () => ({})) };
+  const dmChannel = {
+    sendTyping: jest.fn(async () => {}),
+    messages: { fetch: jest.fn(async () => message) },
+  };
+  user.dmChannel = dmChannel;
+
+  const client = { users: { fetch: jest.fn(async () => user) } };
+
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/storage/r2', () => ({
+    downloadFromR2: jest.fn(),
+    extractKeyFromUrl: jest.fn((url) => url.split('/').pop()),
+  }));
+  jest.doMock('../../bot/shared/services/messaging/discord-connection', () => ({
+    getClient: jest.fn(async () => client),
+  }));
+
+  if (fetchImpl) global.fetch = fetchImpl;
+
+  const service = require('../../bot/shared/services/messaging/discord-channel.service');
+  const logger = require('../../bot/shared/utils/logger');
+  return { service, client, user, dmChannel, message, logger, sentMessages };
+}
+
+const realFetch = global.fetch;
+
+afterEach(() => {
+  jest.resetModules();
+  global.fetch = realFetch;
+});
+
+const TO = 'discord:U0123ABC';
+
+describe('discord-channel.service — identity', () => {
+  it('strips the "discord:" prefix before ever touching the Discord API', async () => {
+    const { service, client } = loadService();
+    await service.sendMessage(TO, 'hi');
+    expect(client.users.fetch).toHaveBeenCalledWith('U0123ABC');
+  });
+});
+
+describe('discord-channel.service — outbound', () => {
+  it('sendMessage sends to the resolved user and strips emotion tags', async () => {
+    const { service, user } = loadService();
+    const result = await service.sendMessage(TO, '[warmly] Hello there');
+    expect(result).toBe(true);
+    expect(user.send).toHaveBeenCalledWith({ content: 'Hello there' });
+  });
+
+  it('sendMessage returns false (never throws) when the send call rejects', async () => {
+    const { service } = loadService({ sendImpl: async () => { throw new Error('boom'); } });
+    await expect(service.sendMessage(TO, 'hi')).resolves.toBe(false);
+  });
+
+  it('sendTextReturningId returns the sent message id', async () => {
+    const { service } = loadService({ sendImpl: async () => ({ id: '169999' }) });
+    const id = await service.sendTextReturningId(TO, 'hi');
+    expect(id).toBe('169999');
+  });
+
+  it('sendTextReturningId replies via messageReference when a contextMessageId is given', async () => {
+    const { service, user } = loadService();
+    await service.sendTextReturningId(TO, 'hi', { contextMessageId: '169.001' });
+    expect(user.send).toHaveBeenCalledWith(
+      expect.objectContaining({ reply: { messageReference: '169.001' } })
+    );
+  });
+
+  it('sendReaction reacts with the literal unicode emoji — no shortcode translation needed', async () => {
+    const { service, message } = loadService();
+    const result = await service.sendReaction(TO, '169.001', '❤️');
+    expect(result).toBe(true);
+    expect(message.react).toHaveBeenCalledWith('❤️');
+  });
+
+  it('showTypingIndicator is a REAL implementation — calls the DM channel\'s sendTyping', async () => {
+    const { service, dmChannel } = loadService();
+    await expect(service.showTypingIndicator(TO)).resolves.toBe(true);
+    expect(dmChannel.sendTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it('startContinuousTypingIndicator returns a real, callable controller, ticks immediately, and repeats under Discord\'s ~10s auto-expiry', async () => {
+    jest.useFakeTimers();
+    try {
+      const { service, dmChannel } = loadService();
+      const controller = service.startContinuousTypingIndicator(TO);
+      expect(controller).not.toBeInstanceOf(Promise);
+      expect(typeof controller.stop).toBe('function');
+
+      // advanceTimersByTimeAsync (unlike advanceTimersByTime) also flushes
+      // the microtask queue between ticks, which the first tick's async
+      // showTypingIndicator() call needs to actually resolve.
+      await jest.advanceTimersByTimeAsync(0);
+      expect(dmChannel.sendTyping).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(8000);
+      expect(dmChannel.sendTyping).toHaveBeenCalledTimes(2);
+
+      controller.stop();
+      await jest.advanceTimersByTimeAsync(16000);
+      expect(dmChannel.sendTyping).toHaveBeenCalledTimes(2); // no further ticks after stop()
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('discord-channel.service — media (cache-based, not a live API lookup)', () => {
+  it('getMediaInfo throws for an id the inbound adapter never cached — media must be consumed shortly after receipt', async () => {
+    const { service } = loadService();
+    await expect(service.getMediaInfo('discord:F0123FILE')).rejects.toThrow(/no cached media info/);
+  });
+
+  it('getMediaInfo returns whatever the inbound adapter cached via _cacheIncomingMedia', async () => {
+    const { service } = loadService();
+    service._cacheIncomingMedia('discord:F0123FILE', { url: 'https://cdn.discordapp.com/x', mime_type: 'image/png', file_size: 42 });
+    const info = await service.getMediaInfo('discord:F0123FILE');
+    expect(info).toEqual({ url: 'https://cdn.discordapp.com/x', mime_type: 'image/png', file_size: 42 });
+  });
+
+  it('downloadMedia fetches the cached URL with NO Bearer auth header — Discord CDN URLs are pre-signed/public', async () => {
+    const fetchImpl = jest.fn(async () => ({ ok: true, arrayBuffer: async () => Buffer.from('data') }));
+    const { service } = loadService({ fetchImpl });
+    service._cacheIncomingMedia('discord:F0123FILE', { url: 'https://cdn.discordapp.com/x', mime_type: 'image/png', file_size: 42 });
+
+    await service.downloadMedia('discord:F0123FILE');
+
+    expect(fetchImpl).toHaveBeenCalledWith('https://cdn.discordapp.com/x');
+    const [, options] = fetchImpl.mock.calls[0];
+    expect(options).toBeUndefined();
+  });
+
+  it('sendImage rejects a bare media-id (no file path/URL) — Discord has no reusable media-id upload step', async () => {
+    const { service, user } = loadService();
+    const result = await service.sendImage(TO, 'F0123FILE_no_slash');
+    expect(result).toBe(false);
+    expect(user.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('discord-channel.service — video delivery (size-gated upload + URL-based primary path)', () => {
+  it('sendVideo uploads directly when the buffer is under the safe size ceiling', async () => {
+    const { service, user } = loadService();
+    const smallBuffer = Buffer.alloc(1024);
+    const result = await service.sendVideo(TO, smallBuffer, '/tmp', 'caption');
+    expect(result).toBe(true);
+    expect(user.send).toHaveBeenCalledWith(expect.objectContaining({
+      content: 'caption',
+      files: [{ attachment: smallBuffer, name: 'video.mp4' }],
+    }));
+  });
+
+  it('sendVideo refuses to upload an oversized buffer and returns false rather than attempting a likely-failing upload', async () => {
+    const { service, user, logger } = loadService();
+    const oversizedBuffer = Buffer.alloc(9 * 1024 * 1024); // > 8MB safe ceiling
+    const result = await service.sendVideo(TO, oversizedBuffer, '/tmp');
+    expect(result).toBe(false);
+    expect(user.send).not.toHaveBeenCalled();
+    expect(logger.logToFile).toHaveBeenCalledWith(
+      expect.stringContaining('exceeds the safe DM upload size'),
+      expect.objectContaining({ sizeBytes: oversizedBuffer.length })
+    );
+  });
+
+  it('sendVideoFromUrl sends an embed + the bare URL, never uploading raw bytes', async () => {
+    const { service, user } = loadService();
+    const result = await service.sendVideoFromUrl(TO, 'https://r2.example.com/video.mp4', 'Here it is');
+    expect(result).toBe(true);
+    const call = user.send.mock.calls[0][0];
+    expect(call.content).toBe('https://r2.example.com/video.mp4');
+    expect(call.files).toBeUndefined();
+    expect(call.embeds).toHaveLength(1);
+  });
+});
+
+describe('discord-channel.service — interactive components (real discord.js components, not text degradation)', () => {
+  it('sendInteractiveButtons sends real button components carrying the Meta-shaped id as `customId`', async () => {
+    const { service, user } = loadService();
+    const result = await service.sendInteractiveButtons(TO, {
+      body: 'Pick one',
+      buttons: [{ id: 'menu_lesson_plan', title: 'Lesson Plans' }, { id: 'menu_video', title: 'Video' }],
+    });
+    expect(result).toBe(true);
+    const call = user.send.mock.calls[0][0];
+    const row = call.components[0];
+    const buttonsJson = row.components.map((c) => c.toJSON());
+    expect(buttonsJson).toHaveLength(2);
+    expect(buttonsJson[0].custom_id).toBe('menu_lesson_plan');
+    expect(buttonsJson[0].label).toBe('Lesson Plans');
+  });
+
+  it('sendInteractiveMessage sends a real select menu with the Meta-shaped row ids as option values', async () => {
+    const { service, user } = loadService();
+    const result = await service.sendInteractiveMessage(TO, {
+      header: 'Pick a language',
+      action: { button: 'Languages', sections: [{ rows: [{ id: 'lang_en', title: 'English' }, { id: 'lang_ur', title: 'Urdu' }] }] },
+    });
+    expect(result).toBe(true);
+    const call = user.send.mock.calls[0][0];
+    const menuJson = call.components[0].components[0].toJSON();
+    expect(menuJson.options.map((o) => o.value)).toEqual(['lang_en', 'lang_ur']);
+  });
+
+  it('sendInteractiveMessage caps at 25 options — Discord\'s StringSelectMenu hard limit (Slack allows 100)', async () => {
+    const { service, user } = loadService();
+    const rows = Array.from({ length: 40 }, (_, i) => ({ id: `opt_${i}`, title: `Option ${i}` }));
+    await service.sendInteractiveMessage(TO, { header: 'Many', action: { sections: [{ rows }] } });
+    const call = user.send.mock.calls[0][0];
+    const menuJson = call.components[0].components[0].toJSON();
+    expect(menuJson.options).toHaveLength(25);
+  });
+
+  it('sendInteractiveMessage returns false when no rows are provided', async () => {
+    const { service } = loadService();
+    const result = await service.sendInteractiveMessage(TO, { header: 'Empty', action: { sections: [] } });
+    expect(result).toBe(false);
+  });
+
+  it('sendImageWithButtons sends files AND components in ONE message — a real simplification over Slack\'s forced two-message split', async () => {
+    const fetchImpl = jest.fn(async () => ({ ok: true, arrayBuffer: async () => Buffer.from('img') }));
+    const { service, user } = loadService({ fetchImpl });
+    const result = await service.sendImageWithButtons(TO, 'https://example.com/x.png', 'Look', [{ id: 'btn_1', title: 'Go' }]);
+    expect(result).toBe(true);
+    const call = user.send.mock.calls[0][0];
+    expect(call.files).toHaveLength(1);
+    expect(call.components).toHaveLength(1);
+  });
+});
+
+describe('discord-channel.service — stubbed Flow', () => {
+  it('sendFlow logs and resolves false — the modal-workaround renderer is a separate concern, not this call', async () => {
+    const { service } = loadService();
+    await expect(service.sendFlow(TO, {})).resolves.toBe(false);
+  });
+});

--- a/tests/messaging/discord-channel-service.test.js
+++ b/tests/messaging/discord-channel-service.test.js
@@ -92,9 +92,20 @@ describe('discord-channel.service — outbound', () => {
 
   it('sendReaction reacts with the literal unicode emoji — no shortcode translation needed', async () => {
     const { service, message } = loadService();
-    const result = await service.sendReaction(TO, '169.001', '❤️');
+    const result = await service.sendReaction(TO, '1163925485556015134', '❤️');
     expect(result).toBe(true);
     expect(message.react).toHaveBeenCalledWith('❤️');
+  });
+
+  it('sendReaction no-ops on a synthetic slash-command message id (not a real snowflake) — never calls the Discord API', async () => {
+    // Regression test for a real bug, caught live: slash commands have no
+    // reactable Discord message. Reacting to their synthetic
+    // "slash-<timestamp>-<userId>" id (discord-events.adapter.js) fails
+    // every time with a "not snowflake" Invalid Form Body error.
+    const { service, dmChannel } = loadService();
+    const result = await service.sendReaction(TO, 'slash-1787245324-755705811669352490', '❤️');
+    expect(result).toBe(false);
+    expect(dmChannel.messages.fetch).not.toHaveBeenCalled();
   });
 
   it('showTypingIndicator is a REAL implementation — calls the DM channel\'s sendTyping', async () => {

--- a/tests/messaging/discord-connection.test.js
+++ b/tests/messaging/discord-connection.test.js
@@ -1,0 +1,185 @@
+/**
+ * discord-connection.js — the persistent Gateway connection manager.
+ *
+ * `discord.js` is a real, heavy package (opens real sockets), so it's
+ * virtually mocked here the same way baileys-connection.test.js mocks
+ * `baileys` via baileys-lib.js — a real socket/Gateway call must never
+ * happen from a unit test regardless.
+ *
+ * The 'clientReady' event name (NOT 'ready' — discord.js renamed it) is the
+ * one fact this whole test suite exists to pin down; getting it wrong here
+ * would mean getClient() never resolves against the real package.
+ */
+
+function mockDiscordPackage() {
+  const clientEventHandlers = {};
+  const onceHandlers = {};
+  const client = {
+    on: jest.fn((event, handler) => { clientEventHandlers[event] = handler; }),
+    once: jest.fn((event, handler) => { onceHandlers[event] = handler; }),
+    login: jest.fn().mockResolvedValue('logged-in'),
+    destroy: jest.fn().mockResolvedValue(undefined),
+    user: { tag: 'RumiBot#0001' },
+  };
+
+  const Client = jest.fn(() => client);
+  const GatewayIntentBits = { Guilds: 1, GuildMessages: 2, DirectMessages: 4, MessageContent: 8 };
+  const Partials = { Channel: 1, Message: 2 };
+  const Events = {
+    ClientReady: 'clientReady',
+    Error: 'error',
+    ShardDisconnect: 'shardDisconnect',
+    ShardReconnecting: 'shardReconnecting',
+    ShardResume: 'shardResume',
+  };
+
+  jest.doMock('discord.js', () => ({ Client, GatewayIntentBits, Partials, Events }), { virtual: true });
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+
+  return { Client, client, clientEventHandlers, onceHandlers };
+}
+
+/** Flushes microtask ticks until once('clientReady', ...) has been registered. */
+async function waitForReadyHandler(onceHandlers) {
+  for (let i = 0; i < 20 && !onceHandlers.clientReady; i += 1) await Promise.resolve();
+  if (!onceHandlers.clientReady) throw new Error('clientReady handler was never registered');
+}
+
+/** Calls getClient(), waits for connect() to register its ready handler, then fires it. */
+async function connectAndReady(conn, onceHandlers) {
+  const clientPromise = conn.getClient();
+  await waitForReadyHandler(onceHandlers);
+  onceHandlers.clientReady();
+  return clientPromise;
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env.DISCORD_BOT_TOKEN = 'test-token';
+});
+
+afterEach(() => {
+  jest.resetModules();
+  delete process.env.DISCORD_BOT_TOKEN;
+});
+
+describe('discord-connection', () => {
+  it('connects lazily: requiring the module does not call Client or login', () => {
+    const { Client, client } = mockDiscordPackage();
+    require('../../bot/shared/services/messaging/discord-connection');
+    expect(Client).not.toHaveBeenCalled();
+    expect(client.login).not.toHaveBeenCalled();
+  });
+
+  it('getClient() resolves only once clientReady fires — not as soon as the Client is constructed', async () => {
+    const { client, onceHandlers } = mockDiscordPackage();
+    const conn = require('../../bot/shared/services/messaging/discord-connection');
+
+    let resolved = false;
+    const clientPromise = conn.getClient().then((c) => { resolved = true; return c; });
+    await waitForReadyHandler(onceHandlers);
+    expect(client.login).toHaveBeenCalledWith('test-token');
+    expect(resolved).toBe(false);
+
+    onceHandlers.clientReady();
+    await clientPromise;
+    expect(resolved).toBe(true);
+  });
+
+  it('uses the "clientReady" event, not "ready" — discord.js renamed it in the pinned version', async () => {
+    const { onceHandlers } = mockDiscordPackage();
+    const conn = require('../../bot/shared/services/messaging/discord-connection');
+
+    conn.getClient();
+    await waitForReadyHandler(onceHandlers);
+    expect(onceHandlers.clientReady).toBeDefined();
+    expect(onceHandlers.ready).toBeUndefined();
+  });
+
+  it('getClient() is memoized — a second call reuses the same connection without reconnecting', async () => {
+    const { Client, onceHandlers } = mockDiscordPackage();
+    const conn = require('../../bot/shared/services/messaging/discord-connection');
+
+    const first = await connectAndReady(conn, onceHandlers);
+    const second = await conn.getClient();
+
+    expect(first).toBe(second);
+    expect(Client).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when DISCORD_BOT_TOKEN is not set', async () => {
+    mockDiscordPackage();
+    delete process.env.DISCORD_BOT_TOKEN;
+    const conn = require('../../bot/shared/services/messaging/discord-connection');
+
+    await expect(conn.getClient()).rejects.toThrow(/DISCORD_BOT_TOKEN/);
+  });
+
+  it('propagates a login rejection (bad/revoked token) rather than hanging', async () => {
+    const { client } = mockDiscordPackage();
+    client.login.mockRejectedValue(new Error('401: Unauthorized'));
+    const conn = require('../../bot/shared/services/messaging/discord-connection');
+
+    await expect(conn.getClient()).rejects.toThrow(/Unauthorized/);
+  });
+
+  it('marks isConnected() true once ready, false after close()', async () => {
+    const { onceHandlers } = mockDiscordPackage();
+    const conn = require('../../bot/shared/services/messaging/discord-connection');
+
+    expect(conn.isConnected()).toBe(false);
+    await connectAndReady(conn, onceHandlers);
+    expect(conn.isConnected()).toBe(true);
+
+    await conn.close();
+    expect(conn.isConnected()).toBe(false);
+  });
+
+  it('close() calls client.destroy() and lets a fresh getClient() reconnect afterward', async () => {
+    const { Client, client, onceHandlers } = mockDiscordPackage();
+    const conn = require('../../bot/shared/services/messaging/discord-connection');
+
+    await connectAndReady(conn, onceHandlers);
+    await conn.close();
+    expect(client.destroy).toHaveBeenCalledTimes(1);
+
+    // A fresh getClient() after close() must reconnect (new Client()), not
+    // return a stale resolved reference to the destroyed client.
+    const secondReadyHandlers = {};
+    client.once = jest.fn((event, handler) => { secondReadyHandlers[event] = handler; });
+    const secondPromise = conn.getClient();
+    await waitForReadyHandler(secondReadyHandlers);
+    secondReadyHandlers.clientReady();
+    await secondPromise;
+    expect(Client).toHaveBeenCalledTimes(2);
+  });
+
+  it('close() is safe when no connection was ever opened', async () => {
+    mockDiscordPackage();
+    const conn = require('../../bot/shared/services/messaging/discord-connection');
+    await expect(conn.close()).resolves.toBeUndefined();
+  });
+
+  it('events emitter fires "open" on ready', async () => {
+    const { onceHandlers } = mockDiscordPackage();
+    const conn = require('../../bot/shared/services/messaging/discord-connection');
+
+    const opens = jest.fn();
+    conn.events.on('open', opens);
+    await connectAndReady(conn, onceHandlers);
+    expect(opens).toHaveBeenCalledTimes(1);
+  });
+
+  it('events emitter fires "close" on a shard disconnect', async () => {
+    const { onceHandlers, clientEventHandlers } = mockDiscordPackage();
+    const conn = require('../../bot/shared/services/messaging/discord-connection');
+
+    const closes = jest.fn();
+    conn.events.on('close', closes);
+    await connectAndReady(conn, onceHandlers);
+
+    clientEventHandlers.shardDisconnect({ code: 1006 }, 0);
+    expect(closes).toHaveBeenCalledWith(expect.objectContaining({ code: 1006 }));
+    expect(conn.isConnected()).toBe(false);
+  });
+});

--- a/tests/messaging/discord-events-adapter.test.js
+++ b/tests/messaging/discord-events-adapter.test.js
@@ -1,0 +1,407 @@
+/**
+ * discord-events.adapter.js — mapping Discord Gateway events (messageCreate,
+ * interactionCreate) into the Meta-webhook-shaped payload whatsapp-bot.js's
+ * handleWebhookPost already dispatches on. Mirrors baileys-socket.adapter.js's
+ * own test coverage style (a persistent-listener attach(), not an HTTP route
+ * handler like Slack's adapter) — synthetic discord.js-shaped event objects
+ * are fed directly to the mapping functions and to attach()'s registered
+ * listeners, never a real Client/Gateway connection.
+ */
+
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/services/messaging/discord-channel.service', () => ({
+  _cacheIncomingMedia: jest.fn(),
+}));
+
+const {
+  mapMessageToMetaShape,
+  mapAttachmentToMetaShape,
+  mapInteractionToMetaShape,
+  mapSlashCommandToMetaShape,
+  toPrefixedIdentity,
+  toPrefixedMediaId,
+  isDuplicateDelivery,
+  attach,
+  _resetSeenIdsForTests,
+} = require('../../bot/shared/services/messaging/inbound/discord-events.adapter');
+
+afterEach(() => {
+  _resetSeenIdsForTests();
+  jest.clearAllMocks();
+});
+
+describe('toPrefixedIdentity', () => {
+  it('prefixes a bare Discord snowflake with "discord:"', () => {
+    expect(toPrefixedIdentity('918273645')).toBe('discord:918273645');
+  });
+});
+
+describe('toPrefixedMediaId', () => {
+  it('prefixes a bare Discord attachment id with "discord:" — required so the messaging router (channel-registry.js#driverForIdentifier) sends getMediaInfo/downloadMedia to the Discord driver, not the WhatsApp one', () => {
+    expect(toPrefixedMediaId('1122334455')).toBe('discord:1122334455');
+  });
+});
+
+describe('mapMessageToMetaShape', () => {
+  it('maps a plain user DM text message to the Meta text shape, with the prefixed identity', () => {
+    const message = {
+      author: { id: '918273645', bot: false },
+      channel: { type: 1 },
+      content: 'Hello Rumi',
+      id: '1699999999123',
+      createdTimestamp: 1699999999000,
+      attachments: { first: () => undefined },
+    };
+    const mapped = mapMessageToMetaShape(message);
+    expect(mapped).toEqual({
+      from: 'discord:918273645',
+      id: '1699999999123',
+      timestamp: 1699999999,
+      type: 'text',
+      text: { body: 'Hello Rumi' },
+    });
+  });
+
+  it('skips a bot-authored message', () => {
+    const message = {
+      author: { id: '1', bot: true }, channel: { type: 1 }, content: 'echo',
+      id: '1', createdTimestamp: Date.now(), attachments: { first: () => undefined },
+    };
+    expect(mapMessageToMetaShape(message)).toBeNull();
+  });
+
+  it('skips a non-DM channel (guild text channel)', () => {
+    const message = {
+      author: { id: '1', bot: false }, channel: { type: 0 }, content: 'hi',
+      id: '1', createdTimestamp: Date.now(), attachments: { first: () => undefined },
+    };
+    expect(mapMessageToMetaShape(message)).toBeNull();
+  });
+
+  it('skips a message with no text and no attachment', () => {
+    const message = {
+      author: { id: '1', bot: false }, channel: { type: 1 }, content: '',
+      id: '1', createdTimestamp: Date.now(), attachments: { first: () => undefined },
+    };
+    expect(mapMessageToMetaShape(message)).toBeNull();
+  });
+
+  it('delegates to attachment mapping when the message carries a file', () => {
+    const attachment = { id: 'F1', url: 'https://cdn.discordapp.com/x', contentType: 'audio/ogg', size: 42, name: 'voice.ogg' };
+    const message = {
+      author: { id: '918273645', bot: false }, channel: { type: 1 }, content: '',
+      id: '169', createdTimestamp: 169000, attachments: { first: () => attachment },
+    };
+    const mapped = mapMessageToMetaShape(message);
+    expect(mapped.type).toBe('audio');
+    expect(mapped.audio.id).toBe('discord:F1');
+  });
+
+  it('returns null for a nullish message', () => {
+    expect(mapMessageToMetaShape(null)).toBeNull();
+    expect(mapMessageToMetaShape(undefined)).toBeNull();
+  });
+});
+
+describe('mapAttachmentToMetaShape', () => {
+  const discordChannel = require('../../bot/shared/services/messaging/discord-channel.service');
+
+  function baseMessage(content = '') {
+    return { author: { id: '918273645' }, content, id: '169.100', createdTimestamp: 169100 };
+  }
+
+  it('maps an audio attachment to the Meta audio shape, with the media id prefixed for router dispatch, and caches its metadata (NOT a downloaded buffer)', () => {
+    const attachment = { id: 'F0123FILE', url: 'https://cdn.discordapp.com/x', contentType: 'audio/ogg', size: 42, name: 'voice.ogg' };
+    const mapped = mapAttachmentToMetaShape(baseMessage(), attachment);
+    expect(mapped).toEqual({
+      from: 'discord:918273645',
+      id: '169.100',
+      timestamp: 169,
+      type: 'audio',
+      audio: { id: 'discord:F0123FILE', mime_type: 'audio/ogg' },
+    });
+    expect(discordChannel._cacheIncomingMedia).toHaveBeenCalledWith('discord:F0123FILE', {
+      url: 'https://cdn.discordapp.com/x', mime_type: 'audio/ogg', file_size: 42,
+    });
+  });
+
+  it('maps an image attachment to the Meta image shape, carrying the message content as the caption', () => {
+    const attachment = { id: 'F0456FILE', url: 'https://cdn.discordapp.com/y', contentType: 'image/png', size: 100, name: 'photo.png' };
+    const mapped = mapAttachmentToMetaShape(baseMessage('look at this'), attachment);
+    expect(mapped).toEqual({
+      from: 'discord:918273645',
+      id: '169.100',
+      timestamp: 169,
+      type: 'image',
+      image: { id: 'discord:F0456FILE', mime_type: 'image/png', caption: 'look at this' },
+    });
+  });
+
+  it('maps anything else (e.g. a PDF) to the Meta document shape', () => {
+    const attachment = { id: 'F0789FILE', url: 'https://cdn.discordapp.com/z', contentType: 'application/pdf', size: 200, name: 'lesson-plan.pdf' };
+    const mapped = mapAttachmentToMetaShape(baseMessage(), attachment);
+    expect(mapped).toEqual({
+      from: 'discord:918273645',
+      id: '169.100',
+      timestamp: 169,
+      type: 'document',
+      document: { id: 'discord:F0789FILE', mime_type: 'application/pdf', filename: 'lesson-plan.pdf' },
+    });
+  });
+});
+
+describe('mapInteractionToMetaShape', () => {
+  it('maps a button click to the Meta button_reply shape, using customId as both id and title directly (no menu bookkeeping)', () => {
+    const interaction = {
+      user: { id: '918273645' },
+      message: { id: '169.010' },
+      isButton: () => true,
+      isStringSelectMenu: () => false,
+      customId: 'menu_lesson_plan',
+    };
+    const mapped = mapInteractionToMetaShape(interaction);
+    expect(mapped).toEqual({
+      from: 'discord:918273645',
+      id: '169.010',
+      timestamp: expect.any(Number),
+      type: 'interactive',
+      interactive: { type: 'button_reply', button_reply: { id: 'menu_lesson_plan', title: 'menu_lesson_plan' } },
+    });
+  });
+
+  it('maps a select-menu choice to the Meta list_reply shape', () => {
+    const interaction = {
+      user: { id: '918273645' },
+      message: { id: '169.020' },
+      isButton: () => false,
+      isStringSelectMenu: () => true,
+      values: ['lang_ur'],
+    };
+    const mapped = mapInteractionToMetaShape(interaction);
+    expect(mapped.interactive).toEqual({ type: 'list_reply', list_reply: { id: 'lang_ur', title: 'lang_ur' } });
+  });
+
+  it('returns null for an unhandled interaction type', () => {
+    const interaction = { user: { id: '1' }, isButton: () => false, isStringSelectMenu: () => false };
+    expect(mapInteractionToMetaShape(interaction)).toBeNull();
+  });
+
+  it('returns null for a select menu with no chosen value', () => {
+    const interaction = { user: { id: '1' }, isButton: () => false, isStringSelectMenu: () => true, values: [] };
+    expect(mapInteractionToMetaShape(interaction)).toBeNull();
+  });
+});
+
+describe('mapSlashCommandToMetaShape', () => {
+  it('maps a slash command with a registered trailing-text option to the Meta text shape', () => {
+    const interaction = {
+      commandName: 'quiz',
+      user: { id: '918273645' },
+      options: { getString: (name) => (name === 'text' ? 'fractions for grade 5' : null) },
+    };
+    const mapped = mapSlashCommandToMetaShape(interaction);
+    expect(mapped).toEqual({
+      from: 'discord:918273645',
+      id: expect.stringMatching(/^slash-\d+-918273645$/),
+      timestamp: expect.any(Number),
+      type: 'text',
+      text: { body: '/quiz fractions for grade 5' },
+    });
+  });
+
+  it('maps a slash command with no trailing text to just the bare command', () => {
+    const interaction = { commandName: 'menu', user: { id: '918273645' }, options: { getString: () => null } };
+    const mapped = mapSlashCommandToMetaShape(interaction);
+    expect(mapped.text).toEqual({ body: '/menu' });
+  });
+
+  it('drops any trailing text for /readingtest — text-message.handler.js matches it via an exact string, not a prefix', () => {
+    const interaction = {
+      commandName: 'readingtest', user: { id: '918273645' },
+      options: { getString: () => 'grade 5 english' },
+    };
+    const mapped = mapSlashCommandToMetaShape(interaction);
+    expect(mapped.text).toEqual({ body: '/readingtest' });
+  });
+
+  it('returns null when commandName or user id is missing', () => {
+    expect(mapSlashCommandToMetaShape({ user: { id: '1' } })).toBeNull();
+    expect(mapSlashCommandToMetaShape({ commandName: 'quiz' })).toBeNull();
+    expect(mapSlashCommandToMetaShape(null)).toBeNull();
+  });
+});
+
+describe('isDuplicateDelivery', () => {
+  it('returns false for an unseen id and true for the same id seen again', () => {
+    expect(isDuplicateDelivery('msg-1')).toBe(false);
+    expect(isDuplicateDelivery('msg-1')).toBe(true);
+  });
+
+  it('treats an absent id as never a duplicate (never records it)', () => {
+    expect(isDuplicateDelivery(undefined)).toBe(false);
+    expect(isDuplicateDelivery(undefined)).toBe(false);
+  });
+});
+
+describe('attach', () => {
+  function mockDiscordModalInteractions(overrides = {}) {
+    const mod = {
+      handleModalSubmit: jest.fn().mockResolvedValue(undefined),
+      tryHandleCollected: jest.fn().mockReturnValue(false),
+      tryHandleStartFlow: jest.fn().mockResolvedValue(false),
+      tryHandleAttendanceLoopButton: jest.fn().mockResolvedValue(false),
+      ...overrides,
+    };
+    jest.doMock('../../bot/shared/routes/discord-modal-interactions.handler', () => mod, { virtual: true });
+    return mod;
+  }
+
+  function mockConnection() {
+    const handlers = {};
+    const client = { on: jest.fn((event, handler) => { handlers[event] = handler; }) };
+    jest.doMock('../../bot/shared/services/messaging/discord-connection', () => ({
+      getClient: jest.fn().mockResolvedValue(client),
+    }));
+    return { client, handlers };
+  }
+
+  beforeEach(() => jest.resetModules());
+
+  it('registers messageCreate and interactionCreate listeners on the shared client', async () => {
+    mockDiscordModalInteractions();
+    const { handlers } = mockConnection();
+    const { attach: freshAttach } = require('../../bot/shared/services/messaging/inbound/discord-events.adapter');
+
+    const dispatch = jest.fn();
+    await freshAttach(dispatch);
+
+    expect(typeof handlers.messageCreate).toBe('function');
+    expect(typeof handlers.interactionCreate).toBe('function');
+  });
+
+  it('dispatches a mapped text message on messageCreate', async () => {
+    mockDiscordModalInteractions();
+    const { handlers } = mockConnection();
+    const { attach: freshAttach } = require('../../bot/shared/services/messaging/inbound/discord-events.adapter');
+
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    await freshAttach(dispatch);
+
+    const message = {
+      author: { id: '918273645', bot: false }, channel: { type: 1 }, content: 'hi',
+      id: '169.001', createdTimestamp: 169001, attachments: { first: () => undefined },
+    };
+    await handlers.messageCreate(message);
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [dispatchReq] = dispatch.mock.calls[0];
+    expect(dispatchReq.body.entry[0].changes[0].value.messages[0]).toEqual(
+      expect.objectContaining({ from: 'discord:918273645', type: 'text', text: { body: 'hi' } })
+    );
+  });
+
+  it('does not dispatch twice for a redelivered message id', async () => {
+    mockDiscordModalInteractions();
+    const { handlers } = mockConnection();
+    const { attach: freshAttach } = require('../../bot/shared/services/messaging/inbound/discord-events.adapter');
+
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    await freshAttach(dispatch);
+    const message = {
+      author: { id: '1', bot: false }, channel: { type: 1 }, content: 'hi',
+      id: 'dup-1', createdTimestamp: Date.now(), attachments: { first: () => undefined },
+    };
+    await handlers.messageCreate(message);
+    await handlers.messageCreate(message);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('acks a slash command (deferReply) and dispatches the mapped command', async () => {
+    mockDiscordModalInteractions();
+    const { handlers } = mockConnection();
+    const { attach: freshAttach } = require('../../bot/shared/services/messaging/inbound/discord-events.adapter');
+
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    await freshAttach(dispatch);
+
+    const interaction = {
+      id: 'int-1',
+      isChatInputCommand: () => true,
+      isModalSubmit: () => false,
+      isButton: () => false,
+      isStringSelectMenu: () => false,
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      commandName: 'settings',
+      user: { id: '918273645' },
+      options: { getString: () => null },
+    };
+    await handlers.interactionCreate(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes a modal submission to discord-modal-interactions.handler#handleModalSubmit, never through ordinary dispatch', async () => {
+    const modalInteractions = mockDiscordModalInteractions();
+    const { handlers } = mockConnection();
+    const { attach: freshAttach } = require('../../bot/shared/services/messaging/inbound/discord-events.adapter');
+
+    const dispatch = jest.fn();
+    await freshAttach(dispatch);
+
+    const interaction = {
+      isChatInputCommand: () => false, isModalSubmit: () => true,
+      isButton: () => false, isStringSelectMenu: () => false,
+    };
+    await handlers.interactionCreate(interaction);
+
+    expect(modalInteractions.handleModalSubmit).toHaveBeenCalledWith(interaction);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('offers a button/select interaction to the pending-collector registry FIRST — claimed interactions never reach ordinary chat mapping', async () => {
+    const modalInteractions = mockDiscordModalInteractions({ tryHandleCollected: jest.fn().mockResolvedValue(true) });
+    const { handlers } = mockConnection();
+    const { attach: freshAttach } = require('../../bot/shared/services/messaging/inbound/discord-events.adapter');
+
+    const dispatch = jest.fn();
+    await freshAttach(dispatch);
+
+    const interaction = {
+      isChatInputCommand: () => false, isModalSubmit: () => false,
+      isButton: () => true, isStringSelectMenu: () => false,
+      user: { id: '1' }, customId: 'menu_video',
+      deferUpdate: jest.fn(),
+    };
+    await handlers.interactionCreate(interaction);
+
+    expect(modalInteractions.tryHandleCollected).toHaveBeenCalledWith(interaction);
+    expect(interaction.deferUpdate).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('falls through to ordinary chat button mapping when no collector claims the interaction', async () => {
+    mockDiscordModalInteractions({ tryHandleCollected: jest.fn().mockReturnValue(false) });
+    const { handlers } = mockConnection();
+    const { attach: freshAttach } = require('../../bot/shared/services/messaging/inbound/discord-events.adapter');
+
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    await freshAttach(dispatch);
+
+    const interaction = {
+      id: 'int-2',
+      isChatInputCommand: () => false, isModalSubmit: () => false,
+      isButton: () => true, isStringSelectMenu: () => false,
+      user: { id: '918273645' }, customId: 'menu_video', message: { id: '169.030' },
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+    };
+    await handlers.interactionCreate(interaction);
+
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [dispatchReq] = dispatch.mock.calls[0];
+    expect(dispatchReq.body.entry[0].changes[0].value.messages[0]).toEqual(
+      expect.objectContaining({ from: 'discord:918273645', type: 'interactive' })
+    );
+  });
+});

--- a/tests/messaging/discord-events-adapter.test.js
+++ b/tests/messaging/discord-events-adapter.test.js
@@ -337,7 +337,11 @@ describe('attach', () => {
     };
     await handlers.interactionCreate(interaction);
 
-    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    // Regression test: discord.js deprecated the `ephemeral: true` shorthand
+    // in favor of `flags: MessageFlags.Ephemeral` — using the old shape
+    // logged a deprecation warning on every single slash command.
+    const { MessageFlags } = require('discord.js');
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
     expect(dispatch).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/messaging/discord-modal-flow.test.js
+++ b/tests/messaging/discord-modal-flow.test.js
@@ -1,0 +1,434 @@
+/**
+ * discord-modal-flow.js — the Discord modal-workaround renderer.
+ * railway-redis.service.js is always mocked (a real singleton that connects
+ * to Redis at module load) so nothing ever touches a real Redis instance;
+ * discord.js's builder classes are mocked minimally (just enough surface for
+ * customId/label/style to round-trip) since the real ones require the whole
+ * package and this suite tests the FLOW logic, not discord.js's own builders
+ * (those are covered by discord-channel-service.test.js against the real
+ * package).
+ */
+
+function mockRedis() {
+  const store = new Map();
+  const redis = {
+    set: jest.fn(async (key, value, ttl) => { store.set(key, value); return true; }),
+    get: jest.fn(async (key) => (store.has(key) ? store.get(key) : null)),
+    delete: jest.fn(async (key) => { store.delete(key); return true; }),
+  };
+  jest.doMock('../../bot/shared/services/cache/railway-redis.service', () => redis);
+  return redis;
+}
+
+function mockDiscordBuilders() {
+  class FakeActionRowBuilder {
+    constructor() { this.components = []; }
+    addComponents(...items) { this.components.push(...items.flat()); return this; }
+  }
+  class FakeModalBuilder {
+    constructor() { this.rows = []; }
+    setCustomId(id) { this.customId = id; return this; }
+    setTitle(t) { this.title = t; return this; }
+    addComponents(row) { this.rows.push(row); return this; }
+  }
+  class FakeTextInputBuilder {
+    setCustomId(id) { this.customId = id; return this; }
+    setLabel(l) { this.label = l; return this; }
+    setStyle(s) { this.style = s; return this; }
+    setRequired(r) { this.required = r; return this; }
+  }
+  jest.doMock('discord.js', () => ({
+    ActionRowBuilder: FakeActionRowBuilder,
+    ModalBuilder: FakeModalBuilder,
+    TextInputBuilder: FakeTextInputBuilder,
+    TextInputStyle: { Short: 1, Paragraph: 2 },
+  }), { virtual: true });
+}
+
+function loadModule() {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  const redis = mockRedis();
+  mockDiscordBuilders();
+  const mod = require('../../bot/shared/services/messaging/discord-modal-flow');
+  return { mod, redis };
+}
+
+afterEach(() => jest.resetModules());
+
+describe('token/state helpers', () => {
+  it('encodeCustomId/decodeCustomId round-trip a kind and token', () => {
+    const { mod } = loadModule();
+    const encoded = mod.encodeCustomId('registration', 'abc123');
+    expect(encoded).toBe('registration:abc123');
+    expect(mod.decodeCustomId(encoded)).toEqual({ kind: 'registration', token: 'abc123' });
+  });
+
+  it('decodeCustomId handles a missing/malformed customId without throwing', () => {
+    const { mod } = loadModule();
+    expect(mod.decodeCustomId(undefined)).toEqual({ kind: null, token: null });
+    expect(mod.decodeCustomId('no-colon-here')).toEqual({ kind: null, token: null });
+  });
+
+  it('storeModalState/loadModalState round-trip a state object via Redis', async () => {
+    const { mod, redis } = loadModule();
+    const token = await mod.storeModalState({ kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'u1:registration:1', collectedEnumAnswers: { country: 'PK' } });
+    expect(typeof token).toBe('string');
+    expect(redis.set).toHaveBeenCalledWith(`discord_modal:${token}`, expect.objectContaining({ kind: 'registration' }), 300);
+
+    const loaded = await mod.loadModalState(token);
+    expect(loaded).toEqual({ kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'u1:registration:1', collectedEnumAnswers: { country: 'PK' } });
+  });
+
+  it('loadModalState returns null for an unknown/expired token', async () => {
+    const { mod } = loadModule();
+    expect(await mod.loadModalState('never-stored')).toBeNull();
+  });
+
+  it('deleteModalState removes the stored state', async () => {
+    const { mod, redis } = loadModule();
+    const token = await mod.storeModalState({ kind: 'settings', screen: 'SETTINGS_MAIN', flowToken: 'u1:settings:1', collectedEnumAnswers: {} });
+    await mod.deleteModalState(token);
+    expect(redis.delete).toHaveBeenCalledWith(`discord_modal:${token}`);
+  });
+});
+
+describe('collectEnumAnswers', () => {
+  function fakeUser({ interactions }) {
+    // Each dmChannel.send() call returns a message whose awaitMessageComponent()
+    // resolves to the next queued interaction — simulates a real teacher
+    // answering one select menu at a time.
+    let call = 0;
+    const dmChannel = {
+      send: jest.fn(async () => ({
+        awaitMessageComponent: jest.fn(async () => {
+          const interaction = interactions[call];
+          call += 1;
+          if (interaction === 'TIMEOUT') throw new Error('time');
+          return interaction;
+        }),
+      })),
+    };
+    return { id: 'U1', dmChannel, createDM: jest.fn(async () => dmChannel) };
+  }
+
+  function fakeSelectInteraction(values) {
+    return { values, deferUpdate: jest.fn().mockResolvedValue(undefined) };
+  }
+
+  it('collects a single-field answer and leaves the LAST interaction un-acked for the caller to ack', async () => {
+    const { mod } = loadModule();
+    const interaction = fakeSelectInteraction(['lang_en']);
+    const user = fakeUser({ interactions: [interaction] });
+
+    const result = await mod.collectEnumAnswers(user, [
+      { fieldName: 'language', promptText: 'Pick a language', buildMenu: () => ({}) },
+    ]);
+
+    expect(result.answers).toEqual({ language: 'lang_en' });
+    expect(result.lastInteraction).toBe(interaction);
+    expect(interaction.deferUpdate).not.toHaveBeenCalled(); // left for the caller
+  });
+
+  it('acks every step EXCEPT the last, and threads answersSoFar into a dependent 2nd step (region -> country)', async () => {
+    const { mod } = loadModule();
+    const regionInteraction = fakeSelectInteraction(['asia']);
+    const countryInteraction = fakeSelectInteraction(['PK']);
+    const user = fakeUser({ interactions: [regionInteraction, countryInteraction] });
+
+    // buildMenu receives the SAME mutable answers-so-far object on every step, so a jest.fn()'s
+    // recorded call arg would reflect its FINAL state by the time we assert, not its state at
+    // call-time — snapshot it eagerly inside the mock instead of asserting on the captured call.
+    let countryMenuSawAtCallTime = null;
+    const buildCountryMenu = jest.fn((answersSoFar) => {
+      countryMenuSawAtCallTime = { ...answersSoFar };
+      return {};
+    });
+    const result = await mod.collectEnumAnswers(user, [
+      { fieldName: '_region', promptText: 'Pick a region', buildMenu: () => ({}) },
+      { fieldName: 'country', promptText: 'Pick a country', buildMenu: buildCountryMenu },
+    ]);
+
+    expect(regionInteraction.deferUpdate).toHaveBeenCalledTimes(1); // not the last step
+    expect(countryInteraction.deferUpdate).not.toHaveBeenCalled(); // the last step
+    expect(countryMenuSawAtCallTime).toEqual({ _region: 'asia' }); // dependent menu saw the prior answer, and ONLY that
+    expect(result.answers).toEqual({ _region: 'asia', country: 'PK' });
+    expect(result.lastInteraction).toBe(countryInteraction);
+  });
+
+  it('reads ALL selected values for a multi:true step (e.g. subjects)', async () => {
+    const { mod } = loadModule();
+    const interaction = fakeSelectInteraction(['math', 'science']);
+    const user = fakeUser({ interactions: [interaction] });
+
+    const result = await mod.collectEnumAnswers(user, [
+      { fieldName: 'subjects', promptText: 'Pick subjects', buildMenu: () => ({}), multi: true },
+    ]);
+
+    expect(result.answers).toEqual({ subjects: ['math', 'science'] });
+  });
+
+  it('returns null when a step times out', async () => {
+    const { mod } = loadModule();
+    const user = fakeUser({ interactions: ['TIMEOUT'] });
+
+    const result = await mod.collectEnumAnswers(user, [
+      { fieldName: 'language', promptText: 'Pick', buildMenu: () => ({}) },
+    ]);
+
+    expect(result).toBeNull();
+  });
+
+  it('reuses an already-open DM channel instead of calling createDM() again', async () => {
+    const { mod } = loadModule();
+    const interaction = fakeSelectInteraction(['x']);
+    const user = fakeUser({ interactions: [interaction] });
+    await mod.collectEnumAnswers(user, [{ fieldName: 'f', promptText: 'p', buildMenu: () => ({}) }]);
+    expect(user.createDM).not.toHaveBeenCalled(); // user.dmChannel was already set
+  });
+});
+
+describe('openTextFieldsModal', () => {
+  it('stores state under a fresh token and shows a modal with one TextInput per remaining field', async () => {
+    const { mod, redis } = loadModule();
+    const interaction = { showModal: jest.fn().mockResolvedValue(undefined) };
+
+    await mod.openTextFieldsModal({
+      interaction, kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'u1:registration:1',
+      collectedEnumAnswers: { country: 'PK' },
+      textFields: [{ name: 'full_name', label: 'Full name', required: true }],
+      title: 'Personal info',
+    });
+
+    expect(redis.set).toHaveBeenCalledTimes(1);
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    const modal = interaction.showModal.mock.calls[0][0];
+    expect(modal.customId).toMatch(/^registration:[a-f0-9]{16}$/);
+    expect(modal.title).toBe('Personal info');
+    expect(modal.rows).toHaveLength(1);
+    expect(modal.rows[0].components[0].customId).toBe('full_name');
+  });
+});
+
+describe('readModalTextAnswers', () => {
+  it('reads every TextInputComponent value keyed by its customId', () => {
+    const { mod } = loadModule();
+    const interaction = {
+      fields: { fields: new Map([['full_name', { value: 'Zara Abdul' }], ['school_name', { value: 'Sunrise School' }]]) },
+    };
+    expect(mod.readModalTextAnswers(interaction)).toEqual({ full_name: 'Zara Abdul', school_name: 'Sunrise School' });
+  });
+});
+
+describe('buildEndpointModal', () => {
+  function fakeTriggerInteraction() {
+    const user = { id: 'U1', dmChannel: null, createDM: jest.fn() };
+    return {
+      client: { users: { fetch: jest.fn().mockResolvedValue(user) } },
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+      showModal: jest.fn().mockResolvedValue(undefined),
+      user: { id: 'U1' },
+    };
+  }
+
+  it('throws if required config is missing', () => {
+    const { mod } = loadModule();
+    expect(() => mod.buildEndpointModal({})).toThrow(/needs \{ kind, init, exchange/);
+  });
+
+  it('startFlow -> runScreen opens a modal directly for a screen with no enum fields at all', async () => {
+    const { mod } = loadModule();
+    const init = jest.fn().mockResolvedValue({ screen: 'ADD_STUDENT', data: {} });
+    const exchange = jest.fn();
+    const screenToSteps = jest.fn(() => ({ steps: [], textFields: [{ name: 'first_name', label: 'First name' }], title: 'Add student' }));
+    const mergeScreenData = jest.fn();
+
+    const renderer = mod.buildEndpointModal({ kind: 'attendance', init, exchange, screenToSteps, mergeScreenData });
+    const trigger = fakeTriggerInteraction();
+
+    const result = await renderer.startFlow({ userId: 'u1', discordUserId: 'U1', flowToken: 'u1:attendance:1' }, trigger);
+
+    expect(result).toBe('awaiting_modal');
+    expect(trigger.showModal).toHaveBeenCalledTimes(1);
+    expect(exchange).not.toHaveBeenCalled(); // nothing to exchange yet — waiting on the modal submission
+  });
+
+  it('an all-enum screen (no text fields) acks via deferUpdate, calls exchange(), and finishes on a terminal screen', async () => {
+    const { mod } = loadModule();
+    const init = jest.fn().mockResolvedValue({ screen: 'SETTINGS_MAIN', data: {} });
+    const exchange = jest.fn().mockResolvedValue({ screen: 'SUCCESS', data: { confirmation_message: 'Saved!' } });
+    const screenToSteps = jest.fn(() => ({
+      steps: [{ fieldName: 'language', promptText: 'Pick', buildMenu: () => ({}) }],
+      textFields: [], title: 'Settings',
+    }));
+    const mergeScreenData = jest.fn((screen, enumAnswers) => ({ ...enumAnswers }));
+    const onFinish = jest.fn();
+
+    const renderer = mod.buildEndpointModal({ kind: 'settings', init, exchange, screenToSteps, mergeScreenData, onFinish });
+
+    const selectInteraction = { values: ['en'], deferUpdate: jest.fn().mockResolvedValue(undefined) };
+    const dmChannel = { send: jest.fn().mockResolvedValue({ awaitMessageComponent: jest.fn().mockResolvedValue(selectInteraction) }) };
+    const user = { id: 'U1', dmChannel, createDM: jest.fn() };
+    const trigger = { client: { users: { fetch: jest.fn().mockResolvedValue(user) } }, user: { id: 'U1' } };
+
+    const result = await renderer.startFlow({ userId: 'u1', discordUserId: 'U1', flowToken: 'u1:settings:1' }, trigger);
+
+    expect(selectInteraction.deferUpdate).toHaveBeenCalledTimes(1); // acked since no modal follows
+    expect(exchange).toHaveBeenCalledWith(expect.any(Object), 'SETTINGS_MAIN', { language: 'en' });
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(result).toBe('finished');
+  });
+
+  it('recurses into the NEXT screen when exchange() returns a non-terminal screen', async () => {
+    const { mod } = loadModule();
+    const init = jest.fn().mockResolvedValue({ screen: 'SCREEN_A', data: {} });
+    const exchange = jest.fn()
+      .mockResolvedValueOnce({ screen: 'SCREEN_B', data: {} })
+      .mockResolvedValueOnce({ screen: 'SUCCESS', data: {} });
+    const screenToSteps = jest.fn((screen) => ({
+      steps: [], textFields: [{ name: 'field_a', label: 'A' }], title: screen,
+    }));
+    const mergeScreenData = jest.fn(() => ({}));
+
+    const renderer = mod.buildEndpointModal({ kind: 'test', init, exchange, screenToSteps, mergeScreenData });
+    const trigger = fakeTriggerInteraction();
+
+    // SCREEN_A opens a modal (no enum steps, has text fields).
+    const openResult = await renderer.startFlow({ userId: 'u1', discordUserId: 'U1', flowToken: 'u1:test:1' }, trigger);
+    expect(openResult).toBe('awaiting_modal');
+    const [modal] = trigger.showModal.mock.calls[0];
+    const { token } = mod.decodeCustomId(modal.customId);
+    const state = await mod.loadModalState(token);
+    expect(state.screen).toBe('SCREEN_A');
+
+    // Submitting SCREEN_A's modal advances to SCREEN_B, which ALSO opens a
+    // modal (no enum steps) — confirms recursion actually re-runs runScreen.
+    const modalSubmit = {
+      customId: modal.customId,
+      user: { id: 'U1' },
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+      showModal: jest.fn().mockResolvedValue(undefined),
+      client: { users: { fetch: jest.fn().mockResolvedValue({ id: 'U1', dmChannel: null, createDM: jest.fn() }) } },
+      fields: { fields: new Map([['field_a', { value: 'answer' }]]) },
+    };
+    const submitResult = await renderer.handleModalSubmit(modalSubmit, state);
+
+    expect(modalSubmit.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(exchange).toHaveBeenCalledTimes(1); // SCREEN_A's exchange only — SCREEN_B needs its OWN submission
+    expect(submitResult).toBe('awaiting_modal'); // recursed into SCREEN_B's own runScreen, which opened a 2nd modal
+    expect(modalSubmit.showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('threads the screen\'s own init()/exchange() response data through to mergeScreenData as carriedData — e.g. attendance\'s _list_id/_class_display, never collected from the teacher', async () => {
+    const { mod } = loadModule();
+    const init = jest.fn().mockResolvedValue({ screen: 'ADD_STUDENT', data: { list_id: 'list-42', class_display: 'Grade 5 - A' } });
+    const exchange = jest.fn().mockResolvedValue({ screen: 'SUCCESS', data: {} });
+    const screenToSteps = jest.fn(() => ({ steps: [], textFields: [{ name: 'first_name', label: 'First name' }], title: 'Add student' }));
+    const mergeScreenData = jest.fn((screen, enumAnswers, textAnswers, carriedData) => ({
+      first_name: textAnswers.first_name, _list_id: carriedData.list_id, _class_display: carriedData.class_display,
+    }));
+
+    const renderer = mod.buildEndpointModal({ kind: 'attendance', init, exchange, screenToSteps, mergeScreenData });
+    const trigger = fakeTriggerInteraction();
+
+    await renderer.startFlow({ userId: 'u1', discordUserId: 'U1', flowToken: 'u1:attendance:1' }, trigger);
+    const [modal] = trigger.showModal.mock.calls[0];
+    const { token } = mod.decodeCustomId(modal.customId);
+    const state = await mod.loadModalState(token);
+    expect(state.carriedData).toEqual({ list_id: 'list-42', class_display: 'Grade 5 - A' }); // survives the Redis round-trip
+
+    const modalSubmit = {
+      customId: modal.customId, user: { id: 'U1' },
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+      fields: { fields: new Map([['first_name', { value: 'Zara' }]]) },
+    };
+    await renderer.handleModalSubmit(modalSubmit, state);
+
+    expect(mergeScreenData).toHaveBeenCalledWith('ADD_STUDENT', {}, { first_name: 'Zara' }, { list_id: 'list-42', class_display: 'Grade 5 - A' });
+    expect(exchange).toHaveBeenCalledWith(expect.any(Object), 'ADD_STUDENT', { first_name: 'Zara', _list_id: 'list-42', _class_display: 'Grade 5 - A' });
+  });
+
+  it('handleModalSubmit finishes and calls onFinish when exchange() reaches the terminal screen', async () => {
+    const { mod } = loadModule();
+    const exchange = jest.fn().mockResolvedValue({ screen: 'SUCCESS', data: { welcome_message: 'Welcome!' } });
+    const mergeScreenData = jest.fn(() => ({ full_name: 'Zara' }));
+    const onFinish = jest.fn();
+
+    const renderer = mod.buildEndpointModal({
+      kind: 'registration', init: jest.fn(), exchange,
+      screenToSteps: jest.fn(), mergeScreenData, onFinish,
+    });
+
+    const modalSubmit = {
+      user: { id: 'U1' }, deferUpdate: jest.fn().mockResolvedValue(undefined),
+      fields: { fields: new Map([['full_name', { value: 'Zara' }]]) },
+    };
+    const state = { kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'u1:registration:1', collectedEnumAnswers: {} };
+
+    const result = await renderer.handleModalSubmit(modalSubmit, state);
+
+    expect(modalSubmit.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(result).toBe('finished');
+  });
+
+  it('handleModalSubmit reports "finished" (does not crash) when exchange() returns a validation error, since there is no open modal to re-show it on', async () => {
+    const { mod } = loadModule();
+    const exchange = jest.fn().mockResolvedValue({ data: { error: { message: 'That name is too short.' } } });
+    const renderer = mod.buildEndpointModal({
+      kind: 'registration', init: jest.fn(), exchange,
+      screenToSteps: jest.fn(), mergeScreenData: jest.fn(() => ({})),
+    });
+
+    const modalSubmit = { user: { id: 'U1' }, deferUpdate: jest.fn().mockResolvedValue(undefined), fields: { fields: new Map() } };
+    const state = { kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'u1:registration:1', collectedEnumAnswers: {} };
+
+    const result = await renderer.handleModalSubmit(modalSubmit, state);
+    expect(result).toBe('finished');
+  });
+
+  it('handleBack re-runs the previous screen from scratch via runScreen()', async () => {
+    const { mod } = loadModule();
+    const back = jest.fn().mockResolvedValue({ screen: 'PERSONAL_INFO', data: {} });
+    const screenToSteps = jest.fn(() => ({ steps: [], textFields: [{ name: 'full_name', label: 'Name' }], title: 'Back to personal info' }));
+
+    const renderer = mod.buildEndpointModal({
+      kind: 'registration', init: jest.fn(), exchange: jest.fn(),
+      back, screenToSteps, mergeScreenData: jest.fn(),
+    });
+    const trigger = fakeTriggerInteraction();
+
+    const result = await renderer.handleBack({ userId: 'u1', discordUserId: 'U1', flowToken: 'u1:registration:1' }, trigger, 'PROFESSIONAL_INFO');
+
+    expect(back).toHaveBeenCalledWith(expect.any(Object), 'PROFESSIONAL_INFO');
+    expect(result).toBe('awaiting_modal');
+    expect(trigger.showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleBack returns null when the endpoint has no back() function', async () => {
+    const { mod } = loadModule();
+    const renderer = mod.buildEndpointModal({
+      kind: 'settings', init: jest.fn(), exchange: jest.fn(),
+      screenToSteps: jest.fn(), mergeScreenData: jest.fn(),
+    });
+    expect(await renderer.handleBack({}, {}, 'SETTINGS_MAIN')).toBeNull();
+  });
+
+  it('returns "timed_out" when the enum-collection step times out, without ever calling exchange()', async () => {
+    const { mod } = loadModule();
+    const exchange = jest.fn();
+    const screenToSteps = jest.fn(() => ({ steps: [{ fieldName: 'language', promptText: 'Pick', buildMenu: () => ({}) }], textFields: [], title: 'x' }));
+    const renderer = mod.buildEndpointModal({
+      kind: 'settings', init: jest.fn().mockResolvedValue({ screen: 'SETTINGS_MAIN', data: {} }),
+      exchange, screenToSteps, mergeScreenData: jest.fn(),
+    });
+
+    const dmChannel = { send: jest.fn().mockResolvedValue({ awaitMessageComponent: jest.fn().mockRejectedValue(new Error('time')) }) };
+    const user = { id: 'U1', dmChannel, createDM: jest.fn() };
+    const trigger = { client: { users: { fetch: jest.fn().mockResolvedValue(user) } }, user: { id: 'U1' } };
+
+    const result = await renderer.startFlow({ userId: 'u1', discordUserId: 'U1', flowToken: 'u1:settings:1' }, trigger);
+    expect(result).toBe('timed_out');
+    expect(exchange).not.toHaveBeenCalled();
+  });
+});

--- a/tests/messaging/discord-modal-flow.test.js
+++ b/tests/messaging/discord-modal-flow.test.js
@@ -269,10 +269,20 @@ describe('buildEndpointModal', () => {
     const selectInteraction = { values: ['en'], deferUpdate: jest.fn().mockResolvedValue(undefined) };
     const dmChannel = { send: jest.fn().mockResolvedValue({ awaitMessageComponent: jest.fn().mockResolvedValue(selectInteraction) }) };
     const user = { id: 'U1', dmChannel, createDM: jest.fn() };
-    const trigger = { client: { users: { fetch: jest.fn().mockResolvedValue(user) } }, user: { id: 'U1' } };
+    const trigger = {
+      client: { users: { fetch: jest.fn().mockResolvedValue(user) } },
+      user: { id: 'U1' },
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+    };
 
     const result = await renderer.startFlow({ userId: 'u1', discordUserId: 'U1', flowToken: 'u1:settings:1' }, trigger);
 
+    // Regression test: the triggering "Get started" interaction is abandoned
+    // by collectEnumAnswers (it sends a brand new message and awaits a click
+    // on THAT instead) — left un-acked, Discord shows the teacher "Rumi
+    // didn't respond in time" even though the flow keeps working underneath.
+    // Confirmed live against a real Discord workspace, not a guess.
+    expect(trigger.deferUpdate).toHaveBeenCalledTimes(1);
     expect(selectInteraction.deferUpdate).toHaveBeenCalledTimes(1); // acked since no modal follows
     expect(exchange).toHaveBeenCalledWith(expect.any(Object), 'SETTINGS_MAIN', { language: 'en' });
     expect(onFinish).toHaveBeenCalledTimes(1);
@@ -317,6 +327,59 @@ describe('buildEndpointModal', () => {
     expect(exchange).toHaveBeenCalledTimes(1); // SCREEN_A's exchange only — SCREEN_B needs its OWN submission
     expect(submitResult).toBe('awaiting_modal'); // recursed into SCREEN_B's own runScreen, which opened a 2nd modal
     expect(modalSubmit.showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-ack the modal-submit interaction when the NEXT screen has enum steps (regression)', async () => {
+    // Real bug, caught live against Discord (not a guess): runScreen()'s ack
+    // of an abandoned enum-collector trigger must be skipped when the
+    // interaction is already deferred/replied — otherwise recursing from a
+    // just-submitted modal (already deferUpdate()'d by handleModalSubmit)
+    // into a next screen with its OWN enum steps throws
+    // DiscordjsError[InteractionAlreadyReplied], exactly what happened live
+    // going from registration's PERSONAL_INFO (a modal) into REGION_INFO
+    // (an enum-only region/state picker).
+    const { mod } = loadModule();
+    const init = jest.fn().mockResolvedValue({ screen: 'SCREEN_A', data: {} });
+    const exchange = jest.fn()
+      .mockResolvedValueOnce({ screen: 'SCREEN_B', data: {} })
+      .mockResolvedValueOnce({ screen: 'SUCCESS', data: {} });
+    const screenToSteps = jest.fn((screen) => (screen === 'SCREEN_A'
+      ? { steps: [], textFields: [{ name: 'field_a', label: 'A' }], title: 'A' }
+      : { steps: [{ fieldName: 'region', promptText: 'Pick', buildMenu: () => ({}) }], textFields: [], title: 'B' }));
+    const mergeScreenData = jest.fn(() => ({}));
+
+    const renderer = mod.buildEndpointModal({ kind: 'test', init, exchange, screenToSteps, mergeScreenData });
+    const trigger = fakeTriggerInteraction();
+
+    await renderer.startFlow({ userId: 'u1', discordUserId: 'U1', flowToken: 'u1:test:1' }, trigger);
+    const [modal] = trigger.showModal.mock.calls[0];
+    const { token } = mod.decodeCustomId(modal.customId);
+    const state = await mod.loadModalState(token);
+
+    const regionInteraction = { deferUpdate: jest.fn().mockResolvedValue(undefined) };
+    const dmChannel = { send: jest.fn().mockResolvedValue({ awaitMessageComponent: jest.fn().mockResolvedValue(regionInteraction) }) };
+    const discordUser = { id: 'U1', dmChannel, createDM: jest.fn() };
+
+    const modalSubmit = {
+      customId: modal.customId,
+      user: { id: 'U1' },
+      client: { users: { fetch: jest.fn().mockResolvedValue(discordUser) } },
+      fields: { fields: new Map([['field_a', { value: 'answer' }]]) },
+      replied: false,
+      deferred: false,
+      // Mirrors real discord.js: deferUpdate() flips .deferred to true, so a
+      // second deferUpdate() call on the SAME interaction is detectable.
+      deferUpdate: jest.fn().mockImplementation(async function deferUpdate() {
+        this.deferred = true;
+      }),
+    };
+
+    const result = await renderer.handleModalSubmit(modalSubmit, state);
+
+    expect(modalSubmit.deferUpdate).toHaveBeenCalledTimes(1); // only handleModalSubmit's own ack — runScreen must not re-ack
+    expect(regionInteraction.deferUpdate).toHaveBeenCalledTimes(1); // SCREEN_B's own enum-step interaction acks itself
+    expect(exchange).toHaveBeenCalledTimes(2); // SCREEN_A's submit, then SCREEN_B's region answer
+    expect(result).toBe('finished');
   });
 
   it('threads the screen\'s own init()/exchange() response data through to mergeScreenData as carriedData — e.g. attendance\'s _list_id/_class_display, never collected from the teacher', async () => {
@@ -425,7 +488,11 @@ describe('buildEndpointModal', () => {
 
     const dmChannel = { send: jest.fn().mockResolvedValue({ awaitMessageComponent: jest.fn().mockRejectedValue(new Error('time')) }) };
     const user = { id: 'U1', dmChannel, createDM: jest.fn() };
-    const trigger = { client: { users: { fetch: jest.fn().mockResolvedValue(user) } }, user: { id: 'U1' } };
+    const trigger = {
+      client: { users: { fetch: jest.fn().mockResolvedValue(user) } },
+      user: { id: 'U1' },
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+    };
 
     const result = await renderer.startFlow({ userId: 'u1', discordUserId: 'U1', flowToken: 'u1:settings:1' }, trigger);
     expect(result).toBe('timed_out');

--- a/tests/messaging/slack-channel-service.test.js
+++ b/tests/messaging/slack-channel-service.test.js
@@ -1,0 +1,164 @@
+/**
+ * slack-channel.service.js — behavior of the REAL (Slack Web API-backed)
+ * methods. @slack/web-api is always mocked here so nothing ever hits the
+ * real network; tests/messaging/channel-driver-parity.test.js covers the
+ * still-stubbed Meta-template-only methods and cross-driver existence.
+ */
+
+function loadService({ postMessageImpl, conversationsOpenImpl } = {}) {
+  jest.resetModules();
+  const client = {
+    conversations: {
+      open: jest.fn(conversationsOpenImpl || (async () => ({ channel: { id: 'D0123DM' } }))),
+    },
+    chat: {
+      postMessage: jest.fn(postMessageImpl || (async () => ({ ts: '169.001' }))),
+    },
+    reactions: { add: jest.fn(async () => ({})) },
+    files: {
+      uploadV2: jest.fn(async () => ({ files: [{ id: 'F0123FILE' }] })),
+      info: jest.fn(async () => ({ file: { url_private: 'https://files.slack.com/x', mimetype: 'image/png', size: 42 } })),
+    },
+  };
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/storage/r2', () => ({
+    downloadFromR2: jest.fn(),
+    extractKeyFromUrl: jest.fn((url) => url.split('/').pop()),
+  }));
+  jest.doMock('@slack/web-api', () => ({
+    WebClient: jest.fn().mockImplementation(() => client),
+  }), { virtual: true });
+
+  process.env.SLACK_BOT_TOKEN = 'xoxb-test-token';
+  const service = require('../../bot/shared/services/messaging/slack-channel.service');
+  return { service, client };
+}
+
+afterEach(() => {
+  jest.resetModules();
+  delete process.env.SLACK_BOT_TOKEN;
+});
+
+const TO = 'slack:U0123ABC';
+
+describe('slack-channel.service — identity', () => {
+  it('strips the "slack:" prefix before ever touching the Slack API', async () => {
+    const { service, client } = loadService();
+    await service.sendMessage(TO, 'hi');
+    expect(client.conversations.open).toHaveBeenCalledWith({ users: 'U0123ABC' });
+  });
+
+  it('caches the DM channel id — a second send does not re-open the conversation', async () => {
+    const { service, client } = loadService();
+    await service.sendMessage(TO, 'first');
+    await service.sendMessage(TO, 'second');
+    expect(client.conversations.open).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('slack-channel.service — outbound', () => {
+  it('sendMessage posts to the resolved DM channel and strips emotion tags', async () => {
+    const { service, client } = loadService();
+    const result = await service.sendMessage(TO, '[warmly] Hello there');
+    expect(result).toBe(true);
+    expect(client.chat.postMessage).toHaveBeenCalledWith({ channel: 'D0123DM', text: 'Hello there' });
+  });
+
+  it('sendMessage returns false (never throws) when the API call rejects', async () => {
+    const { service } = loadService({ postMessageImpl: async () => { throw new Error('boom'); } });
+    await expect(service.sendMessage(TO, 'hi')).resolves.toBe(false);
+  });
+
+  it('sendTextReturningId returns the message ts', async () => {
+    const { service } = loadService({ postMessageImpl: async () => ({ ts: '169.999' }) });
+    const id = await service.sendTextReturningId(TO, 'hi');
+    expect(id).toBe('169.999');
+  });
+
+  it('sendTextReturningId threads via thread_ts when a contextMessageId is given', async () => {
+    const { service, client } = loadService();
+    await service.sendTextReturningId(TO, 'hi', { contextMessageId: '169.001' });
+    expect(client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread_ts: '169.001' })
+    );
+  });
+
+  it('sendReaction maps a known unicode emoji to its Slack shortcode name', async () => {
+    const { service, client } = loadService();
+    const result = await service.sendReaction(TO, '169.001', '❤️');
+    expect(result).toBe(true);
+    expect(client.reactions.add).toHaveBeenCalledWith({ channel: 'D0123DM', timestamp: '169.001', name: 'heart' });
+  });
+
+  it('showTypingIndicator is a documented no-op — resolves true without calling the Slack API', async () => {
+    const { service, client } = loadService();
+    await expect(service.showTypingIndicator(TO)).resolves.toBe(true);
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('startContinuousTypingIndicator returns a synchronous, real, callable no-op controller', () => {
+    const { service } = loadService();
+    const controller = service.startContinuousTypingIndicator(TO);
+    expect(controller).not.toBeInstanceOf(Promise);
+    expect(typeof controller.stop).toBe('function');
+    expect(() => controller.stop()).not.toThrow();
+  });
+});
+
+describe('slack-channel.service — media', () => {
+  it('getMediaInfo returns Slack file metadata mapped to the Meta-shaped fields', async () => {
+    const { service } = loadService();
+    const info = await service.getMediaInfo('F0123FILE');
+    expect(info).toEqual({ url: 'https://files.slack.com/x', mime_type: 'image/png', file_size: 42 });
+  });
+
+  it('sendImage rejects a bare media-id (no file path/URL) — Slack has no reusable media-id upload step', async () => {
+    const { service, client } = loadService();
+    const result = await service.sendImage(TO, 'F0123FILE_no_slash');
+    expect(result).toBe(false);
+    expect(client.files.uploadV2).not.toHaveBeenCalled();
+  });
+});
+
+describe('slack-channel.service — interactive components (real Block Kit, not text degradation)', () => {
+  it('sendInteractiveButtons posts real Block Kit action buttons carrying the Meta-shaped id as `value`', async () => {
+    const { service, client } = loadService();
+    const result = await service.sendInteractiveButtons(TO, {
+      body: 'Pick one',
+      buttons: [{ id: 'menu_lesson_plan', title: 'Lesson Plans' }, { id: 'menu_video', title: 'Video' }],
+    });
+    expect(result).toBe(true);
+    const call = client.chat.postMessage.mock.calls[0][0];
+    const actionsBlock = call.blocks.find((b) => b.type === 'actions');
+    expect(actionsBlock.elements).toHaveLength(2);
+    expect(actionsBlock.elements[0].value).toBe('menu_lesson_plan');
+    expect(actionsBlock.elements[0].action_id).toBe('menu_lesson_plan');
+  });
+
+  it('sendInteractiveMessage posts a static_select with the Meta-shaped row ids as option values', async () => {
+    const { service, client } = loadService();
+    const result = await service.sendInteractiveMessage(TO, {
+      header: 'Pick a language',
+      action: { button: 'Languages', sections: [{ rows: [{ id: 'lang_en', title: 'English' }, { id: 'lang_ur', title: 'Urdu' }] }] },
+    });
+    expect(result).toBe(true);
+    const call = client.chat.postMessage.mock.calls[0][0];
+    const actionsBlock = call.blocks.find((b) => b.type === 'actions');
+    const select = actionsBlock.elements[0];
+    expect(select.type).toBe('static_select');
+    expect(select.options.map((o) => o.value)).toEqual(['lang_en', 'lang_ur']);
+  });
+
+  it('sendInteractiveMessage returns false when no rows are provided', async () => {
+    const { service } = loadService();
+    const result = await service.sendInteractiveMessage(TO, { header: 'Empty', action: { sections: [] } });
+    expect(result).toBe(false);
+  });
+});
+
+describe('slack-channel.service — stubbed Flow', () => {
+  it('sendFlow logs and resolves false — the modal renderer is a separate concern, not this call', async () => {
+    const { service } = loadService();
+    await expect(service.sendFlow(TO, {})).resolves.toBe(false);
+  });
+});

--- a/tests/messaging/slack-channel-service.test.js
+++ b/tests/messaging/slack-channel-service.test.js
@@ -126,6 +126,12 @@ describe('slack-channel.service — media', () => {
     expect(info).toEqual({ url: 'https://files.slack.com/x', mime_type: 'image/png', file_size: 42 });
   });
 
+  it('getMediaInfo strips a "slack:" prefixed media id before calling the Slack API — the inbound adapter mints ids this way so the messaging router dispatches here instead of the WhatsApp driver', async () => {
+    const { service, client } = loadService();
+    await service.getMediaInfo('slack:F0123FILE');
+    expect(client.files.info).toHaveBeenCalledWith({ file: 'F0123FILE' });
+  });
+
   it('sendImage rejects a bare media-id (no file path/URL) — Slack has no reusable media-id upload step', async () => {
     const { service, client } = loadService();
     const result = await service.sendImage(TO, 'F0123FILE_no_slash');

--- a/tests/messaging/slack-channel-service.test.js
+++ b/tests/messaging/slack-channel-service.test.js
@@ -174,6 +174,31 @@ describe('slack-channel.service — interactive components (real Block Kit, not 
     const result = await service.sendInteractiveMessage(TO, { header: 'Empty', action: { sections: [] } });
     expect(result).toBe(false);
   });
+
+  it('sendInteractiveMessage renders Meta\'s interactive.type:"button" shape (action.buttons) as real Slack buttons, not a select-menu list', async () => {
+    // Regression test for a real, confirmed bug: exam-checker.orchestrator.js sends this exact
+    // button shape (never sections/rows), and the old code silently dropped it — logging "no
+    // options provided for interactive list" and returning false — because it only ever read
+    // action.sections. Exam-checker was completely non-functional on Slack as a result.
+    const { service, client } = loadService();
+    const result = await service.sendInteractiveMessage(TO, {
+      body: { text: 'You have 0 images.' },
+      action: {
+        buttons: [
+          { type: 'reply', reply: { id: 'ech_add_more', title: '📷 Add more' } },
+          { type: 'reply', reply: { id: 'ech_process_now', title: '✅ Process now' } },
+        ],
+      },
+    });
+    expect(result).toBe(true);
+    const call = client.chat.postMessage.mock.calls[0][0];
+    const actionsBlock = call.blocks.find((b) => b.type === 'actions');
+    expect(actionsBlock.elements).toHaveLength(2);
+    expect(actionsBlock.elements[0]).toMatchObject({ type: 'button', value: 'ech_add_more', action_id: 'ech_add_more' });
+    expect(actionsBlock.elements[1]).toMatchObject({ type: 'button', value: 'ech_process_now', action_id: 'ech_process_now' });
+    // never falls into the static_select path when buttons are present
+    expect(actionsBlock.elements.some((e) => e.type === 'static_select')).toBe(false);
+  });
 });
 
 describe('slack-channel.service — stubbed Flow', () => {

--- a/tests/messaging/slack-channel-service.test.js
+++ b/tests/messaging/slack-channel-service.test.js
@@ -20,7 +20,8 @@ function loadService({ postMessageImpl, conversationsOpenImpl } = {}) {
       info: jest.fn(async () => ({ file: { url_private: 'https://files.slack.com/x', mimetype: 'image/png', size: 42 } })),
     },
   };
-  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  const logger = { logToFile: jest.fn() };
+  jest.doMock('../../bot/shared/utils/logger', () => logger);
   jest.doMock('../../bot/shared/storage/r2', () => ({
     downloadFromR2: jest.fn(),
     extractKeyFromUrl: jest.fn((url) => url.split('/').pop()),
@@ -31,7 +32,7 @@ function loadService({ postMessageImpl, conversationsOpenImpl } = {}) {
 
   process.env.SLACK_BOT_TOKEN = 'xoxb-test-token';
   const service = require('../../bot/shared/services/messaging/slack-channel.service');
-  return { service, client };
+  return { service, client, logger };
 }
 
 afterEach(() => {
@@ -67,6 +68,19 @@ describe('slack-channel.service — outbound', () => {
   it('sendMessage returns false (never throws) when the API call rejects', async () => {
     const { service } = loadService({ postMessageImpl: async () => { throw new Error('boom'); } });
     await expect(service.sendMessage(TO, 'hi')).resolves.toBe(false);
+  });
+
+  it('logs the exact missing scope on a missing_scope error, not just the generic API-error message', async () => {
+    const scopeError = new Error('An API error occurred: missing_scope');
+    scopeError.data = { error: 'missing_scope', needed: 'chat:write', provided: 'im:write,reactions:write' };
+    const { service, logger } = loadService({ postMessageImpl: async () => { throw scopeError; } });
+
+    await service.sendMessage(TO, 'hi');
+
+    expect(logger.logToFile).toHaveBeenCalledWith(
+      '❌ Slack: error sending message',
+      expect.objectContaining({ code: 'missing_scope', neededScope: 'chat:write', providedScopes: 'im:write,reactions:write' })
+    );
   });
 
   it('sendTextReturningId returns the message ts', async () => {

--- a/tests/messaging/slack-events-adapter.test.js
+++ b/tests/messaging/slack-events-adapter.test.js
@@ -10,11 +10,15 @@ jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
 
 const {
   mapEventToMetaShape,
+  mapFileShareToMetaShape,
   mapBlockActionToMetaShape,
+  mapSlashCommandToMetaShape,
   toPrefixedIdentity,
+  toPrefixedMediaId,
   isDuplicateDelivery,
   makeEventsHandler,
   makeInteractionsHandler,
+  makeSlashCommandHandler,
   _resetSeenEventsForTests,
 } = require('../../bot/shared/services/messaging/inbound/slack-events.adapter');
 
@@ -23,6 +27,12 @@ afterEach(() => _resetSeenEventsForTests());
 describe('toPrefixedIdentity', () => {
   it('prefixes a bare Slack user id with "slack:"', () => {
     expect(toPrefixedIdentity('U0123ABC')).toBe('slack:U0123ABC');
+  });
+});
+
+describe('toPrefixedMediaId', () => {
+  it('prefixes a bare Slack file id with "slack:" — required so the messaging router (channel-registry.js#driverForIdentifier) sends getMediaInfo/downloadMedia to the Slack driver, not the WhatsApp one', () => {
+    expect(toPrefixedMediaId('F0123FILE')).toBe('slack:F0123FILE');
   });
 });
 
@@ -43,8 +53,18 @@ describe('mapEventToMetaShape', () => {
     expect(mapEventToMetaShape({ type: 'message', bot_id: 'B0123', user: 'U0123ABC', text: 'echo', ts: '169' })).toBeNull();
   });
 
-  it('skips a message with a subtype (edits, deletes, channel-join notices, etc.)', () => {
+  it('skips a message with a non-file subtype (edits, deletes, channel-join notices, etc.)', () => {
     expect(mapEventToMetaShape({ type: 'message', subtype: 'message_changed', user: 'U0123ABC', text: 'edited', ts: '169' })).toBeNull();
+  });
+
+  it('delegates a file_share subtype to mapFileShareToMetaShape instead of skipping it', () => {
+    const event = {
+      type: 'message', subtype: 'file_share', user: 'U0123ABC', ts: '169.500',
+      files: [{ id: 'F0123FILE', mimetype: 'audio/ogg', name: 'voice.ogg' }],
+    };
+    const mapped = mapEventToMetaShape(event);
+    expect(mapped).toEqual(mapFileShareToMetaShape(event));
+    expect(mapped.type).toBe('audio');
   });
 
   it('skips an event with no user or no text', () => {
@@ -55,6 +75,68 @@ describe('mapEventToMetaShape', () => {
   it('returns null for a nullish event', () => {
     expect(mapEventToMetaShape(null)).toBeNull();
     expect(mapEventToMetaShape(undefined)).toBeNull();
+  });
+});
+
+describe('mapFileShareToMetaShape', () => {
+  it('maps an audio file to the Meta audio shape, with the media id prefixed for router dispatch', () => {
+    const event = {
+      user: 'U0123ABC', ts: '169.100',
+      files: [{ id: 'F0123FILE', mimetype: 'audio/ogg', name: 'voice.ogg' }],
+    };
+    expect(mapFileShareToMetaShape(event)).toEqual({
+      from: 'slack:U0123ABC',
+      id: '169.100',
+      timestamp: 169,
+      type: 'audio',
+      audio: { id: 'slack:F0123FILE', mime_type: 'audio/ogg' },
+    });
+  });
+
+  it('maps an image file to the Meta image shape, carrying the event text as the caption', () => {
+    const event = {
+      user: 'U0123ABC', ts: '169.200', text: 'look at this',
+      files: [{ id: 'F0456FILE', mimetype: 'image/png', name: 'photo.png' }],
+    };
+    expect(mapFileShareToMetaShape(event)).toEqual({
+      from: 'slack:U0123ABC',
+      id: '169.200',
+      timestamp: 169,
+      type: 'image',
+      image: { id: 'slack:F0456FILE', mime_type: 'image/png', caption: 'look at this' },
+    });
+  });
+
+  it('maps anything else (e.g. a PDF) to the Meta document shape', () => {
+    const event = {
+      user: 'U0123ABC', ts: '169.300',
+      files: [{ id: 'F0789FILE', mimetype: 'application/pdf', name: 'lesson-plan.pdf' }],
+    };
+    expect(mapFileShareToMetaShape(event)).toEqual({
+      from: 'slack:U0123ABC',
+      id: '169.300',
+      timestamp: 169,
+      type: 'document',
+      document: { id: 'slack:F0789FILE', mime_type: 'application/pdf', filename: 'lesson-plan.pdf' },
+    });
+  });
+
+  it('only maps the first file of a multi-file share', () => {
+    const event = {
+      user: 'U0123ABC', ts: '169.400',
+      files: [
+        { id: 'F0001', mimetype: 'image/png', name: 'first.png' },
+        { id: 'F0002', mimetype: 'image/png', name: 'second.png' },
+      ],
+    };
+    expect(mapFileShareToMetaShape(event).image.id).toBe('slack:F0001');
+  });
+
+  it('returns null when there is no user, no files, or the event is a bot echo', () => {
+    expect(mapFileShareToMetaShape({ ts: '1', files: [{ id: 'F1', mimetype: 'image/png' }] })).toBeNull();
+    expect(mapFileShareToMetaShape({ user: 'U1', ts: '1', files: [] })).toBeNull();
+    expect(mapFileShareToMetaShape({ user: 'U1', bot_id: 'B1', ts: '1', files: [{ id: 'F1', mimetype: 'image/png' }] })).toBeNull();
+    expect(mapFileShareToMetaShape(null)).toBeNull();
   });
 });
 
@@ -166,6 +248,29 @@ describe('makeEventsHandler', () => {
     expect(dispatch).toHaveBeenCalledTimes(1);
   });
 
+  it('acks immediately with 200 and dispatches a mapped audio file_share event', async () => {
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    const handler = makeEventsHandler(dispatch);
+    const req = {
+      body: {
+        type: 'event_callback',
+        event_id: 'Ev010',
+        event: {
+          type: 'message', subtype: 'file_share', user: 'U0123ABC', ts: '169.010',
+          files: [{ id: 'F0123FILE', mimetype: 'audio/ogg', name: 'voice.ogg' }],
+        },
+      },
+    };
+    const res = fakeRes();
+    await handler(req, res);
+    expect(res._calls.status).toEqual([200]);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [dispatchReq] = dispatch.mock.calls[0];
+    expect(dispatchReq.body.entry[0].changes[0].value.messages[0]).toEqual(
+      expect.objectContaining({ from: 'slack:U0123ABC', type: 'audio', audio: { id: 'slack:F0123FILE', mime_type: 'audio/ogg' } })
+    );
+  });
+
   it('does not dispatch for a skippable event (e.g. bot echo)', async () => {
     const dispatch = jest.fn();
     const handler = makeEventsHandler(dispatch);
@@ -177,6 +282,70 @@ describe('makeEventsHandler', () => {
       },
     };
     await handler(req, fakeRes());
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('mapSlashCommandToMetaShape', () => {
+  it('maps a slash command with trailing text to the Meta text shape, reconstructing what the user would have typed on WhatsApp', () => {
+    const body = { command: '/quiz', text: 'fractions for grade 5', user_id: 'U0123ABC' };
+    const mapped = mapSlashCommandToMetaShape(body);
+    expect(mapped).toEqual({
+      from: 'slack:U0123ABC',
+      id: expect.stringMatching(/^slash-\d+-U0123ABC$/),
+      timestamp: expect.any(Number),
+      type: 'text',
+      text: { body: '/quiz fractions for grade 5' },
+    });
+  });
+
+  it('maps a slash command with no trailing text to just the bare command', () => {
+    const mapped = mapSlashCommandToMetaShape({ command: '/menu', text: '', user_id: 'U0123ABC' });
+    expect(mapped.text).toEqual({ body: '/menu' });
+  });
+
+  it('drops any trailing text for /readingtest — text-message.handler.js matches it via an exact string, not a prefix', () => {
+    const mapped = mapSlashCommandToMetaShape({ command: '/readingtest', text: 'grade 5 english', user_id: 'U0123ABC' });
+    expect(mapped.text).toEqual({ body: '/readingtest' });
+  });
+
+  it('returns null when command or user_id is missing', () => {
+    expect(mapSlashCommandToMetaShape({ text: 'x', user_id: 'U1' })).toBeNull();
+    expect(mapSlashCommandToMetaShape({ command: '/quiz', text: 'x' })).toBeNull();
+    expect(mapSlashCommandToMetaShape(null)).toBeNull();
+  });
+});
+
+describe('makeSlashCommandHandler', () => {
+  function fakeRes() {
+    const calls = { status: [], send: [] };
+    const res = {
+      status(code) { calls.status.push(code); return res; },
+      send(body) { calls.send.push(body); return res; },
+    };
+    res._calls = calls;
+    return res;
+  }
+
+  it('acks immediately with an empty 200 and dispatches the mapped command as a text message', async () => {
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    const handler = makeSlashCommandHandler(dispatch);
+    const req = { body: { command: '/settings', text: '', user_id: 'U0123ABC' } };
+    const res = fakeRes();
+    await handler(req, res);
+    expect(res._calls.status).toEqual([200]);
+    expect(res._calls.send).toEqual(['']);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [dispatchReq] = dispatch.mock.calls[0];
+    expect(dispatchReq.body.entry[0].changes[0].value.messages[0]).toEqual(
+      expect.objectContaining({ from: 'slack:U0123ABC', type: 'text', text: { body: '/settings' } })
+    );
+  });
+
+  it('does not dispatch when the payload maps to null', async () => {
+    const dispatch = jest.fn();
+    const handler = makeSlashCommandHandler(dispatch);
+    await handler({ body: { text: 'x' } }, fakeRes());
     expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/tests/messaging/slack-events-adapter.test.js
+++ b/tests/messaging/slack-events-adapter.test.js
@@ -1,0 +1,228 @@
+/**
+ * slack-events.adapter.js — mapping Slack's Events API messages and
+ * block_actions interactivity payloads into the Meta-webhook-shaped payload
+ * whatsapp-bot.js's handleWebhookPost already dispatches on. Mirrors
+ * baileys-socket.adapter.js's own test coverage style, adapted for an
+ * HTTP-handler adapter rather than a persistent-socket listener.
+ */
+
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+
+const {
+  mapEventToMetaShape,
+  mapBlockActionToMetaShape,
+  toPrefixedIdentity,
+  isDuplicateDelivery,
+  makeEventsHandler,
+  makeInteractionsHandler,
+  _resetSeenEventsForTests,
+} = require('../../bot/shared/services/messaging/inbound/slack-events.adapter');
+
+afterEach(() => _resetSeenEventsForTests());
+
+describe('toPrefixedIdentity', () => {
+  it('prefixes a bare Slack user id with "slack:"', () => {
+    expect(toPrefixedIdentity('U0123ABC')).toBe('slack:U0123ABC');
+  });
+});
+
+describe('mapEventToMetaShape', () => {
+  it('maps a plain user text message to the Meta text shape, with the prefixed identity', () => {
+    const event = { type: 'message', user: 'U0123ABC', text: 'Hello Rumi', ts: '1699999999.000100' };
+    const mapped = mapEventToMetaShape(event);
+    expect(mapped).toEqual({
+      from: 'slack:U0123ABC',
+      id: '1699999999.000100',
+      timestamp: 1699999999,
+      type: 'text',
+      text: { body: 'Hello Rumi' },
+    });
+  });
+
+  it('skips a bot message (has bot_id)', () => {
+    expect(mapEventToMetaShape({ type: 'message', bot_id: 'B0123', user: 'U0123ABC', text: 'echo', ts: '169' })).toBeNull();
+  });
+
+  it('skips a message with a subtype (edits, deletes, channel-join notices, etc.)', () => {
+    expect(mapEventToMetaShape({ type: 'message', subtype: 'message_changed', user: 'U0123ABC', text: 'edited', ts: '169' })).toBeNull();
+  });
+
+  it('skips an event with no user or no text', () => {
+    expect(mapEventToMetaShape({ type: 'message', text: 'no user', ts: '169' })).toBeNull();
+    expect(mapEventToMetaShape({ type: 'message', user: 'U0123ABC', ts: '169' })).toBeNull();
+  });
+
+  it('returns null for a nullish event', () => {
+    expect(mapEventToMetaShape(null)).toBeNull();
+    expect(mapEventToMetaShape(undefined)).toBeNull();
+  });
+});
+
+describe('mapBlockActionToMetaShape', () => {
+  it('maps a button click to the Meta button_reply shape, using the button value as the id directly (no menu bookkeeping)', () => {
+    const payload = {
+      user: { id: 'U0123ABC' },
+      container: { message_ts: '1699999999.000100' },
+      actions: [{ type: 'button', value: 'menu_lesson_plan', text: { text: 'Lesson Plans' } }],
+    };
+    const mapped = mapBlockActionToMetaShape(payload);
+    expect(mapped).toEqual({
+      from: 'slack:U0123ABC',
+      id: '1699999999.000100',
+      timestamp: expect.any(Number),
+      type: 'interactive',
+      interactive: { type: 'button_reply', button_reply: { id: 'menu_lesson_plan', title: 'Lesson Plans' } },
+    });
+  });
+
+  it('maps a static_select choice to the Meta list_reply shape', () => {
+    const payload = {
+      user: { id: 'U0123ABC' },
+      container: { message_ts: '1699999999.000100' },
+      actions: [{
+        type: 'static_select',
+        selected_option: { value: 'lang_ur', text: { text: 'اردو' } },
+      }],
+    };
+    const mapped = mapBlockActionToMetaShape(payload);
+    expect(mapped.interactive).toEqual({ type: 'list_reply', list_reply: { id: 'lang_ur', title: 'اردو' } });
+  });
+
+  it('returns null when there is no action, or an unhandled action type', () => {
+    expect(mapBlockActionToMetaShape({ user: { id: 'U1' }, actions: [] })).toBeNull();
+    expect(mapBlockActionToMetaShape({ user: { id: 'U1' }, actions: [{ type: 'overflow' }] })).toBeNull();
+  });
+
+  it('returns null for a static_select with no selected_option', () => {
+    expect(mapBlockActionToMetaShape({ user: { id: 'U1' }, actions: [{ type: 'static_select' }] })).toBeNull();
+  });
+});
+
+describe('isDuplicateDelivery', () => {
+  it('returns false for an unseen id and true for the same id seen again', () => {
+    expect(isDuplicateDelivery('Ev0123')).toBe(false);
+    expect(isDuplicateDelivery('Ev0123')).toBe(true);
+  });
+
+  it('treats an absent id as never a duplicate (never records it)', () => {
+    expect(isDuplicateDelivery(undefined)).toBe(false);
+    expect(isDuplicateDelivery(undefined)).toBe(false);
+  });
+});
+
+describe('makeEventsHandler', () => {
+  function fakeRes() {
+    const calls = { status: [], json: [], send: [] };
+    const res = {
+      status(code) { calls.status.push(code); return res; },
+      json(body) { calls.json.push(body); return res; },
+      send(body) { calls.send.push(body); return res; },
+    };
+    res._calls = calls;
+    return res;
+  }
+
+  it('answers the url_verification handshake by echoing the challenge, unsigned', async () => {
+    const dispatch = jest.fn();
+    const handler = makeEventsHandler(dispatch);
+    const req = { body: { type: 'url_verification', challenge: 'abc123' } };
+    const res = fakeRes();
+    await handler(req, res);
+    expect(res._calls.status).toEqual([200]);
+    expect(res._calls.json).toEqual([{ challenge: 'abc123' }]);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('acks immediately with 200 and dispatches a mapped text event', async () => {
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    const handler = makeEventsHandler(dispatch);
+    const req = {
+      body: {
+        type: 'event_callback',
+        event_id: 'Ev001',
+        event: { type: 'message', user: 'U0123ABC', text: 'hi', ts: '169.001' },
+      },
+    };
+    const res = fakeRes();
+    await handler(req, res);
+    expect(res._calls.status).toEqual([200]);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [dispatchReq] = dispatch.mock.calls[0];
+    expect(dispatchReq.body.entry[0].changes[0].value.messages[0]).toEqual(
+      expect.objectContaining({ from: 'slack:U0123ABC', type: 'text', text: { body: 'hi' } })
+    );
+  });
+
+  it('does not dispatch twice for a redelivered event_id', async () => {
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    const handler = makeEventsHandler(dispatch);
+    const body = {
+      type: 'event_callback',
+      event_id: 'Ev002',
+      event: { type: 'message', user: 'U0123ABC', text: 'hi again', ts: '169.002' },
+    };
+    await handler({ body }, fakeRes());
+    await handler({ body }, fakeRes());
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dispatch for a skippable event (e.g. bot echo)', async () => {
+    const dispatch = jest.fn();
+    const handler = makeEventsHandler(dispatch);
+    const req = {
+      body: {
+        type: 'event_callback',
+        event_id: 'Ev003',
+        event: { type: 'message', bot_id: 'B1', user: 'U0123ABC', text: 'echo', ts: '169.003' },
+      },
+    };
+    await handler(req, fakeRes());
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('makeInteractionsHandler', () => {
+  function fakeRes() {
+    const calls = { status: [], send: [] };
+    const res = {
+      status(code) { calls.status.push(code); return res; },
+      send(body) { calls.send.push(body); return res; },
+    };
+    res._calls = calls;
+    return res;
+  }
+
+  it('parses the form-encoded payload field, acks 200, and dispatches a mapped button click', async () => {
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    const handler = makeInteractionsHandler(dispatch);
+    const payloadObj = {
+      type: 'block_actions',
+      user: { id: 'U0123ABC' },
+      container: { message_ts: '169.010' },
+      actions: [{ type: 'button', value: 'menu_video', text: { text: 'Video' } }],
+    };
+    const req = { body: { payload: JSON.stringify(payloadObj) } };
+    const res = fakeRes();
+    await handler(req, res);
+    expect(res._calls.status).toEqual([200]);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dispatch for a view_submission payload — that is a separate modal-renderer concern', async () => {
+    const dispatch = jest.fn();
+    const handler = makeInteractionsHandler(dispatch);
+    const req = { body: { payload: JSON.stringify({ type: 'view_submission' }) } };
+    await handler(req, fakeRes());
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('responds 400 on unparseable payload JSON', async () => {
+    const dispatch = jest.fn();
+    const handler = makeInteractionsHandler(dispatch);
+    const req = { body: { payload: '{not json' } };
+    const res = fakeRes();
+    await handler(req, res);
+    expect(res._calls.status).toEqual([400]);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/messaging/slack-modal-flow.test.js
+++ b/tests/messaging/slack-modal-flow.test.js
@@ -1,0 +1,123 @@
+/**
+ * slack-modal-flow.js — the Block Kit modal renderer built on an endpoint's
+ * own {init, exchange, back} functions, NOT on text-flow.js's step engine.
+ * Exercised against a small fake endpoint so this test never touches a real
+ * *-endpoint.js file or Redis.
+ */
+
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+
+const { buildEndpointModal, encodeMetadata, decodeMetadata } = require('../../bot/shared/services/messaging/slack-modal-flow');
+
+function fakeEndpoint() {
+  return {
+    init: jest.fn().mockResolvedValue({ screen: 'STEP_ONE', data: { options: [{ id: 'a', title: 'A' }] } }),
+    exchange: jest.fn(),
+    back: jest.fn().mockResolvedValue({ screen: 'STEP_ONE', data: { options: [{ id: 'a', title: 'A' }] } }),
+  };
+}
+
+function fakeScreenToView(screen, data, ctx) {
+  return { type: 'modal', callback_id: 'fake', private_metadata: ctx.metadata, blocks: [], screen };
+}
+
+function fakeViewToScreenData(screen, stateValues) {
+  return stateValues;
+}
+
+describe('encodeMetadata / decodeMetadata', () => {
+  it('round-trips kind, screen, and flowToken', () => {
+    const encoded = encodeMetadata('registration', 'PERSONAL_INFO', 'u1:registration:169');
+    expect(decodeMetadata(encoded)).toEqual({ kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'u1:registration:169' });
+  });
+
+  it('decodeMetadata returns {} for malformed/missing input, never throws', () => {
+    expect(decodeMetadata(undefined)).toEqual({});
+    expect(decodeMetadata('not json')).toEqual({});
+  });
+});
+
+describe('buildEndpointModal', () => {
+  it('throws synchronously if required config is missing', () => {
+    expect(() => buildEndpointModal({})).toThrow(/needs/);
+    expect(() => buildEndpointModal({ kind: 'x' })).toThrow(/needs/);
+  });
+
+  it('buildInitialView calls init() and returns the screen mapped through screenToView, carrying metadata', async () => {
+    const endpoint = fakeEndpoint();
+    const renderer = buildEndpointModal({
+      kind: 'fake', ...endpoint, screenToView: fakeScreenToView, viewToScreenData: fakeViewToScreenData,
+    });
+
+    const view = await renderer.buildInitialView({ userId: 'u1', flowToken: 'u1:fake:169' });
+
+    expect(endpoint.init).toHaveBeenCalledWith({ userId: 'u1', flowToken: 'u1:fake:169' });
+    expect(view.screen).toBe('STEP_ONE');
+    expect(decodeMetadata(view.private_metadata)).toEqual({ kind: 'fake', screen: 'STEP_ONE', flowToken: 'u1:fake:169' });
+  });
+
+  it('handleSubmission on a non-terminal screen returns response_action: push with the next screen view', async () => {
+    const endpoint = fakeEndpoint();
+    endpoint.exchange.mockResolvedValue({ screen: 'STEP_TWO', data: {} });
+    const renderer = buildEndpointModal({
+      kind: 'fake', ...endpoint, screenToView: fakeScreenToView, viewToScreenData: fakeViewToScreenData,
+    });
+
+    const result = await renderer.handleSubmission({ userId: 'u1', flowToken: 'u1:fake:169' }, 'STEP_ONE', { some: 'values' });
+
+    expect(endpoint.exchange).toHaveBeenCalledWith({ userId: 'u1', flowToken: 'u1:fake:169' }, 'STEP_ONE', { some: 'values' });
+    expect(result.response_action).toBe('push');
+    expect(result.view.screen).toBe('STEP_TWO');
+  });
+
+  it('handleSubmission on the SUCCESS screen calls onFinish and returns response_action: clear', async () => {
+    const endpoint = fakeEndpoint();
+    endpoint.exchange.mockResolvedValue({ screen: 'SUCCESS', data: { welcome_message: 'hi' } });
+    const onFinish = jest.fn().mockResolvedValue(undefined);
+    const renderer = buildEndpointModal({
+      kind: 'fake', ...endpoint, screenToView: fakeScreenToView, viewToScreenData: fakeViewToScreenData, onFinish,
+    });
+
+    const ctx = { userId: 'u1', flowToken: 'u1:fake:169', slackUserId: 'U0123ABC' };
+    const result = await renderer.handleSubmission(ctx, 'STEP_ONE', {});
+
+    expect(onFinish).toHaveBeenCalledWith({ screen: 'SUCCESS', data: { welcome_message: 'hi' } }, ctx);
+    expect(result).toEqual({ response_action: 'clear' });
+  });
+
+  it('handleSubmission surfaces a validation error via response_action: errors, attached to the per-screen block id', async () => {
+    const endpoint = fakeEndpoint();
+    endpoint.exchange.mockResolvedValue({ data: { error: { message: 'Name is required' } } });
+    const renderer = buildEndpointModal({
+      kind: 'fake', ...endpoint, screenToView: fakeScreenToView, viewToScreenData: fakeViewToScreenData,
+      firstInputBlockId: { STEP_ONE: 'name_block' },
+    });
+
+    const result = await renderer.handleSubmission({ userId: 'u1', flowToken: 'u1:fake:169' }, 'STEP_ONE', {});
+
+    expect(result).toEqual({ response_action: 'errors', errors: { name_block: 'Name is required' } });
+  });
+
+  it('handleBack calls the endpoint\'s own back() (real server branching), not a client-side stack pop', async () => {
+    const endpoint = fakeEndpoint();
+    const renderer = buildEndpointModal({
+      kind: 'fake', ...endpoint, screenToView: fakeScreenToView, viewToScreenData: fakeViewToScreenData,
+    });
+
+    const view = await renderer.handleBack({ userId: 'u1', flowToken: 'u1:fake:169' }, 'STEP_TWO');
+
+    expect(endpoint.back).toHaveBeenCalledWith({ userId: 'u1', flowToken: 'u1:fake:169' }, 'STEP_TWO');
+    expect(view.screen).toBe('STEP_ONE');
+  });
+
+  it('handleBack returns null when the endpoint has no back() (e.g. settings, a single-screen flow)', async () => {
+    const endpoint = fakeEndpoint();
+    delete endpoint.back;
+    const renderer = buildEndpointModal({
+      kind: 'fake', ...endpoint, screenToView: fakeScreenToView, viewToScreenData: fakeViewToScreenData,
+    });
+
+    const view = await renderer.handleBack({ userId: 'u1' }, 'STEP_ONE');
+    expect(view).toBeNull();
+  });
+});

--- a/tests/messaging/slack-signature-service.test.js
+++ b/tests/messaging/slack-signature-service.test.js
@@ -1,0 +1,120 @@
+/**
+ * slack-signature.service.js — HMAC request-signature verification.
+ * Each test computes its own EXPECTED signature independently via Node's own
+ * crypto (not by calling the service), so this isn't a tautological check of
+ * the service's own math.
+ */
+
+const crypto = require('crypto');
+
+const SIGNING_SECRET = 'test-signing-secret';
+
+function computeSignature(timestamp, rawBody, secret = SIGNING_SECRET) {
+  const base = `v0:${timestamp}:${rawBody}`;
+  return 'v0=' + crypto.createHmac('sha256', secret).update(base).digest('hex');
+}
+
+function loadService() {
+  jest.resetModules();
+  process.env.SLACK_SIGNING_SECRET = SIGNING_SECRET;
+  return require('../../bot/shared/services/slack-signature.service');
+}
+
+afterEach(() => {
+  delete process.env.SLACK_SIGNING_SECRET;
+  jest.resetModules();
+});
+
+describe('slack-signature.service', () => {
+  it('isConfigured() reflects whether SLACK_SIGNING_SECRET is set', () => {
+    jest.resetModules();
+    delete process.env.SLACK_SIGNING_SECRET;
+    const unconfigured = require('../../bot/shared/services/slack-signature.service');
+    expect(unconfigured.isConfigured()).toBe(false);
+
+    const service = loadService();
+    expect(service.isConfigured()).toBe(true);
+  });
+
+  it('accepts a correctly-signed, fresh request', () => {
+    const service = loadService();
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const rawBody = '{"type":"event_callback"}';
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': computeSignature(timestamp, rawBody),
+      },
+      rawBody: Buffer.from(rawBody),
+    };
+    expect(service.verify(req)).toBe(true);
+  });
+
+  it('rejects a tampered body (signature was computed over different bytes)', () => {
+    const service = loadService();
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signedBody = '{"type":"event_callback"}';
+    const tamperedBody = '{"type":"event_callback","extra":"injected"}';
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': computeSignature(timestamp, signedBody),
+      },
+      rawBody: Buffer.from(tamperedBody),
+    };
+    expect(service.verify(req)).toBe(false);
+  });
+
+  it('rejects a request signed with the wrong secret', () => {
+    const service = loadService();
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const rawBody = '{"type":"event_callback"}';
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': computeSignature(timestamp, rawBody, 'wrong-secret'),
+      },
+      rawBody: Buffer.from(rawBody),
+    };
+    expect(service.verify(req)).toBe(false);
+  });
+
+  it('rejects a stale timestamp outside the replay-protection window', () => {
+    const service = loadService();
+    const staleTimestamp = String(Math.floor(Date.now() / 1000) - 60 * 10); // 10 minutes old
+    const rawBody = '{"type":"event_callback"}';
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': staleTimestamp,
+        'x-slack-signature': computeSignature(staleTimestamp, rawBody),
+      },
+      rawBody: Buffer.from(rawBody),
+    };
+    expect(service.verify(req)).toBe(false);
+  });
+
+  it('rejects a request missing either header', () => {
+    const service = loadService();
+    expect(service.verify({ headers: {}, rawBody: Buffer.from('{}') })).toBe(false);
+    expect(service.verify({
+      headers: { 'x-slack-request-timestamp': '169' },
+      rawBody: Buffer.from('{}'),
+    })).toBe(false);
+  });
+
+  it('rejects everything when SLACK_SIGNING_SECRET is not configured', () => {
+    jest.resetModules();
+    delete process.env.SLACK_SIGNING_SECRET;
+    const service = require('../../bot/shared/services/slack-signature.service');
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const rawBody = '{}';
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': computeSignature(timestamp, rawBody),
+      },
+      rawBody: Buffer.from(rawBody),
+    };
+    expect(service.verify(req)).toBe(false);
+  });
+});

--- a/tests/quiz/openai-detect-intent-quiz.test.js
+++ b/tests/quiz/openai-detect-intent-quiz.test.js
@@ -16,6 +16,13 @@ function loadService() {
   jest.resetModules();
   createChatCompletion = jest.fn();
   jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  // openai.service.js requires bot-helpers.js (for getConversationHistory),
+  // which requires the real config/supabase.js -> @supabase/supabase-js — a
+  // bot/-only dependency CI installs AFTER root `npm test` runs (see
+  // CLAUDE.md's "TDD" note). Mocking supabase here, same as every other
+  // suite that touches bot-helpers.js, keeps this test from needing that
+  // package installed at all.
+  jest.doMock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
   jest.doMock('../../bot/shared/services/llm-client', () => ({
     getClient: () => ({ chat: { completions: { create: createChatCompletion } } }),
   }));

--- a/tests/quiz/openai-detect-intent-quiz.test.js
+++ b/tests/quiz/openai-detect-intent-quiz.test.js
@@ -1,0 +1,61 @@
+/**
+ * openai.service.js#detectIntent / _fallbackIntentDetection — the "quiz"
+ * category. Added as defense-in-depth alongside isQuizIntent() (the real,
+ * deterministic gate checked earlier in text-message.handler.js): before
+ * this fix, the LLM prompt only recognized {lesson_plan, presentation,
+ * video, general} — "quiz" was not a legal output at all, and the prompt's
+ * own few-shot examples explicitly taught "topic + grade" phrasing (which a
+ * quiz request like "quiz on X for grade Y" also matches) to map to
+ * lesson_plan. See tests/quiz/quiz-intent-detector.test.js for the primary
+ * regex-based gate this backs up.
+ */
+
+let createChatCompletion;
+
+function loadService() {
+  jest.resetModules();
+  createChatCompletion = jest.fn();
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/services/llm-client', () => ({
+    getClient: () => ({ chat: { completions: { create: createChatCompletion } } }),
+  }));
+  // eslint-disable-next-line global-require
+  return require('../../bot/shared/services/openai.service');
+}
+
+afterEach(() => jest.resetModules());
+
+describe('detectIntent — quiz category', () => {
+  it('returns {type: "quiz"} when the LLM classifies the message as quiz', async () => {
+    const OpenAIService = loadService();
+    createChatCompletion.mockResolvedValue({ choices: [{ message: { content: 'quiz' } }] });
+
+    const result = await OpenAIService.detectIntent('create a quiz on operating systems for grade 12');
+    expect(result).toEqual({ type: 'quiz', message: 'create a quiz on operating systems for grade 12' });
+  });
+
+  it('falls back to keyword detection (still recognizing quiz) when the LLM call throws', async () => {
+    const OpenAIService = loadService();
+    createChatCompletion.mockRejectedValue(new Error('rate limited'));
+
+    const result = await OpenAIService.detectIntent('quiz banao on fractions');
+    expect(result.type).toBe('quiz');
+  });
+});
+
+describe('_fallbackIntentDetection — quiz keyword', () => {
+  it('recognizes "quiz" ahead of the lesson-plan keyword list', () => {
+    const OpenAIService = loadService();
+    expect(OpenAIService._fallbackIntentDetection('create a quiz on operating systems for grade 12').type).toBe('quiz');
+  });
+
+  it('recognizes the Urdu "کوئز" keyword', () => {
+    const OpenAIService = loadService();
+    expect(OpenAIService._fallbackIntentDetection('کوئز بنائیں').type).toBe('quiz');
+  });
+
+  it('still falls back to lesson_plan for a message with no quiz keyword', () => {
+    const OpenAIService = loadService();
+    expect(OpenAIService._fallbackIntentDetection('lesson plan on photosynthesis').type).toBe('lesson_plan');
+  });
+});

--- a/tests/quiz/quiz-intent-router-confirmation.test.js
+++ b/tests/quiz/quiz-intent-router-confirmation.test.js
@@ -1,0 +1,103 @@
+/**
+ * quiz-intent-router.service.js — promptQuizConfirmation(), the front half
+ * of the two-button quiz-intent flow. Was previously dead: text-message.handler.js
+ * never called isQuizIntent()/this function, so "create a quiz on X for grade Y"
+ * fell through to the generic lesson_plan/presentation/video/general LLM
+ * classifier and was misrouted to lesson_plan. See handleConfirmationButton's
+ * own tests (none existed before this file) for the back half.
+ */
+
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/services/cache/railway-redis.service', () => ({
+  get: jest.fn(), set: jest.fn().mockResolvedValue(true), delete: jest.fn(),
+}));
+jest.mock('../../bot/shared/services/whatsapp.service', () => ({
+  sendMessage: jest.fn().mockResolvedValue(true),
+  sendInteractiveButtons: jest.fn().mockResolvedValue(true),
+}));
+jest.mock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
+jest.mock('../../bot/shared/services/openai.service', () => ({
+  createChatCompletion: jest.fn().mockResolvedValue({
+    choices: [{ message: { content: 'operating systems' } }],
+  }),
+}));
+
+const RedisService = require('../../bot/shared/services/cache/railway-redis.service');
+const WhatsAppService = require('../../bot/shared/services/whatsapp.service');
+const OpenAIService = require('../../bot/shared/services/openai.service');
+const QuizIntentRouter = require('../../bot/shared/services/quiz/quiz-intent-router.service');
+
+const USER = { id: 'user-1' };
+const FROM = 'slack:U0123ABC';
+
+afterEach(() => jest.clearAllMocks());
+
+describe('promptQuizConfirmation', () => {
+  it('extracts the topic via a small LLM call and stashes {topic, language} under quiz_intent_pending:<userId>', async () => {
+    await QuizIntentRouter.promptQuizConfirmation(USER, FROM, 'create a quiz on operating systems for grade 12', 'en');
+
+    expect(OpenAIService.createChatCompletion).toHaveBeenCalledTimes(1);
+    expect(RedisService.set).toHaveBeenCalledWith(
+      QuizIntentRouter._PENDING_INTENT_KEY(USER.id),
+      JSON.stringify({ topic: 'operating systems', language: 'en' }),
+      QuizIntentRouter._PENDING_INTENT_TTL_SEC
+    );
+  });
+
+  it('shows the two-button confirmation (Send to class / Show in chat) with the topic in the body', async () => {
+    await QuizIntentRouter.promptQuizConfirmation(USER, FROM, 'create a quiz on operating systems for grade 12', 'en');
+
+    expect(WhatsAppService.sendInteractiveButtons).toHaveBeenCalledWith(FROM, expect.objectContaining({
+      body: expect.stringContaining('operating systems'),
+      buttons: [
+        { id: 'quiz_send_to_class', title: 'Send to class' },
+        { id: 'quiz_show_in_chat', title: 'Show in chat' },
+      ],
+    }));
+  });
+
+  it('renders Urdu button titles and body when language is "ur"', async () => {
+    await QuizIntentRouter.promptQuizConfirmation(USER, FROM, 'کوئز بنائیں', 'ur');
+
+    const call = WhatsAppService.sendInteractiveButtons.mock.calls[0][1];
+    expect(call.buttons[0].title).toBe('کلاس کو بھیجیں');
+    expect(call.buttons[1].title).toBe('چیٹ میں دکھائیں');
+  });
+
+  it('defaults to English when no language is given', async () => {
+    await QuizIntentRouter.promptQuizConfirmation(USER, FROM, 'quiz me', undefined);
+    const call = WhatsAppService.sendInteractiveButtons.mock.calls[0][1];
+    expect(call.buttons[0].title).toBe('Send to class');
+  });
+
+  it('still shows the confirmation with generic copy when topic extraction returns null', async () => {
+    OpenAIService.createChatCompletion.mockResolvedValueOnce({ choices: [{ message: { content: 'null' } }] });
+
+    await QuizIntentRouter.promptQuizConfirmation(USER, FROM, 'quiz me', 'en');
+
+    expect(RedisService.set).toHaveBeenCalledWith(
+      QuizIntentRouter._PENDING_INTENT_KEY(USER.id),
+      JSON.stringify({ topic: '', language: 'en' }),
+      QuizIntentRouter._PENDING_INTENT_TTL_SEC
+    );
+    const call = WhatsAppService.sendInteractiveButtons.mock.calls[0][1];
+    expect(call.body).not.toContain('undefined');
+    expect(call.body).not.toContain('null');
+  });
+
+  it('still shows the confirmation (with no topic) when topic extraction itself throws', async () => {
+    OpenAIService.createChatCompletion.mockRejectedValueOnce(new Error('rate limited'));
+
+    await QuizIntentRouter.promptQuizConfirmation(USER, FROM, 'quiz me', 'en');
+
+    expect(WhatsAppService.sendInteractiveButtons).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when user is missing or has no id', async () => {
+    await QuizIntentRouter.promptQuizConfirmation(null, FROM, 'quiz me', 'en');
+    await QuizIntentRouter.promptQuizConfirmation({}, FROM, 'quiz me', 'en');
+
+    expect(WhatsAppService.sendInteractiveButtons).not.toHaveBeenCalled();
+    expect(RedisService.set).not.toHaveBeenCalled();
+  });
+});

--- a/tests/quiz/quiz-job-handler.test.js
+++ b/tests/quiz/quiz-job-handler.test.js
@@ -72,24 +72,41 @@ describe('handleQuizReport', () => {
     expect(quizReport.generateReport).not.toHaveBeenCalled();
   });
 
-  it('fires the report when all sessions terminal and a teacher phone resolves', async () => {
+  it('fires the report when all sessions terminal and payload.teacherPhone is present', async () => {
     const h = load();
     supabaseTables.quizzes = { single: { data: { id: 'q1', teacher_id: 't1', created_at: new Date().toISOString(), status: 'sent' } } };
     supabaseTables.quiz_sessions = { list: { data: [{ status: 'completed' }] } };
-    supabaseTables.users = { single: { data: { phone_number: '12025550100' } } };
-    const r = await h.handleQuizReport({ groupId: 'q1', payload: {} });
+    const r = await h.handleQuizReport({ groupId: 'q1', payload: { teacherPhone: '12025550100' } });
     expect(r).toEqual({ ok: true });
     expect(quizReport.generateReport).toHaveBeenCalledTimes(1);
+    expect(quizReport.generateReport).toHaveBeenCalledWith('q1', expect.objectContaining({ teacherPhone: '12025550100' }));
     expect(redis.set).toHaveBeenCalledWith('quiz_report_sent:q1', '1', 86400);
   });
 
-  it('does NOT set the sent flag when no teacher phone resolves', async () => {
+  it('fires the report when payload.teacherPhone is a Slack identifier — delivers to the SAME channel the quiz was requested on, never a re-derived WhatsApp number', async () => {
     const h = load();
-    supabaseTables.quizzes = { single: { data: { id: 'q1', teacher_id: null, created_at: new Date().toISOString(), status: 'sent' } } };
+    supabaseTables.quizzes = { single: { data: { id: 'q1', teacher_id: 't1', created_at: new Date().toISOString(), status: 'sent' } } };
     supabaseTables.quiz_sessions = { list: { data: [{ status: 'completed' }] } };
+    // Deliberately leave supabaseTables.users unset/absent — if any fallback
+    // to a users.phone_number lookup still existed, this would either throw
+    // or silently substitute a different (wrong) channel.
+    const r = await h.handleQuizReport({ groupId: 'q1', payload: { teacherPhone: 'slack:U0123ABC' } });
+    expect(r).toEqual({ ok: true });
+    expect(quizReport.generateReport).toHaveBeenCalledWith('q1', expect.objectContaining({ teacherPhone: 'slack:U0123ABC' }));
+  });
+
+  it('does NOT set the sent flag when payload.teacherPhone is absent, and NEVER falls back to a users.phone_number lookup', async () => {
+    const h = load();
+    supabaseTables.quizzes = { single: { data: { id: 'q1', teacher_id: 't1', created_at: new Date().toISOString(), status: 'sent' } } };
+    supabaseTables.quiz_sessions = { list: { data: [{ status: 'completed' }] } };
+    // A users row IS present here — if the removed fallback ever regressed
+    // back in, this test would start passing on the old (wrong) behavior
+    // instead of skipping, which is exactly the bug this guards against.
+    supabaseTables.users = { single: { data: { phone_number: '12025550100' } } };
     const r = await h.handleQuizReport({ groupId: 'q1', payload: {} });
     expect(r.reason).toBe('no_teacher_phone');
     expect(redis.set).not.toHaveBeenCalled();
+    expect(quizReport.generateReport).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/registration/registration-endpoint.test.js
+++ b/tests/registration/registration-endpoint.test.js
@@ -9,11 +9,23 @@
  * Bead: bd-396
  */
 
-// Mock redis before requiring the module
+// Mock redis before requiring the module. get() parses JSON and returns the
+// deserialized value (falling back to the raw string) — matching the REAL
+// railway-redis.service.js#get() contract exactly. A mock that instead
+// returned the raw stored string (as this one previously did) hid a real
+// bug: registration-endpoint.js's own getRegData() called JSON.parse() a
+// SECOND time on top of that, which throws once get() returns the real
+// service's already-parsed object, silently discarding full_name/country
+// on every screen after PERSONAL_INFO. Confirmed live against a real
+// Discord workspace, not a guess.
 jest.mock('../../bot/shared/services/cache/railway-redis.service', () => {
   const store = {};
   return {
-    get: jest.fn(async (key) => store[key] || null),
+    get: jest.fn(async (key) => {
+      const raw = store[key];
+      if (!raw) return null;
+      try { return JSON.parse(raw); } catch { return raw; }
+    }),
     set: jest.fn(async (key, value) => { store[key] = value; }),
     _store: store,
     _clear: () => { Object.keys(store).forEach(k => delete store[k]); }

--- a/tests/routes/discord-flow-registry.test.js
+++ b/tests/routes/discord-flow-registry.test.js
@@ -1,0 +1,303 @@
+/**
+ * discord-flow-registry.js — wires registration/settings/attendance/
+ * exam_confirm/reading_assessment endpoints + their Discord views into
+ * buildEndpointModal, mirroring tests/routes/slack-flow-registry.test.js's
+ * conventions: mock the real endpoint modules, drive the renderer, assert
+ * against the mock's calls.
+ */
+
+jest.mock('../../bot/shared/routes/registration-endpoint', () => ({
+  handleRegistrationInit: jest.fn(async () => ({ screen: 'PERSONAL_INFO', data: {} })),
+  handleRegistrationDataExchange: jest.fn(async () => ({ screen: 'SUCCESS', data: { welcome_message: 'Welcome!', portal_message: 'Portal ready' } })),
+  handleRegistrationBack: jest.fn(async () => ({ screen: 'PERSONAL_INFO', data: {} })),
+}));
+jest.mock('../../bot/shared/routes/settings-endpoint', () => ({
+  handleSettingsInit: jest.fn(async () => ({ screen: 'SETTINGS_MAIN', data: { languages: [], frameworks: [], current_language: 'en', current_framework: 'oecd' } })),
+  handleSettingsDataExchange: jest.fn(async () => ({ screen: 'SUCCESS', data: { confirmation_message: 'Saved.', details_message: 'Language: English' } })),
+  handleSettingsBack: jest.fn(async () => ({ screen: 'SETTINGS_MAIN', data: {} })),
+}));
+jest.mock('../../bot/shared/routes/attendance-setup-endpoint', () => ({
+  handleSetupInit: jest.fn(async () => ({ screen: 'CLASS_INFO', data: {} })),
+  handleSetupDataExchange: jest.fn(async () => ({
+    screen: 'ADD_STUDENT',
+    data: { list_id: 'list-1', class_display: 'Grade 3 - A', heading: 'Add Student #1' },
+  })),
+  handleDoneAction: jest.fn(async () => ({ screen: 'SUCCESS', data: { success_message: 'Class ready with 3 students.' } })),
+}));
+jest.mock('../../bot/shared/routes/exam-confirm-endpoint', () => ({
+  handleExamConfirmInit: jest.fn(async () => ({ screen: 'CONFIRM_STUDENTS', data: { students: [{ id: '0', title: '1. Zara' }] } })),
+  handleExamConfirmDataExchange: jest.fn(async () => ({
+    screen: 'SUCCESS',
+    data: { extension_message_response: { params: { flow_token: 'session-1', confirmed_students: ['0'] } } },
+  })),
+  handleExamConfirmBack: jest.fn(async () => ({ screen: 'CONFIRM_STUDENTS', data: {} })),
+}));
+jest.mock('../../bot/shared/routes/reading-assessment-endpoint', () => ({
+  handleReadingAssessmentInit: jest.fn(async () => ({
+    screen: 'BASIC_INFO',
+    data: { languages: [{ id: '0_English', title: 'English' }], assessment_modes: [{ id: '0_Auto', title: 'Auto' }] },
+  })),
+  handleReadingAssessmentDataExchange: jest.fn(async () => ({
+    screen: 'SUCCESS',
+    data: { student_full_name: 'Zara', Language: '0_English', assessment_mode: '0_Auto' },
+  })),
+  startAssessment: jest.fn(async () => ({ assessmentId: 'assessment-1' })),
+}));
+jest.mock('../../bot/shared/services/exam-checker/exam-session.service', () => ({
+  getById: jest.fn(async () => ({ id: 'session-1', user_id: 'u1', recipient_identifier: 'discord:D0123' })),
+}));
+jest.mock('../../bot/shared/services/exam-checker/exam-checker.orchestrator', () => ({
+  ExamCheckerOrchestrator: { process: jest.fn(async () => ({})) },
+}));
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/services/messaging/discord-channel.service', () => ({
+  sendMessage: jest.fn().mockResolvedValue(true),
+  sendInteractiveButtons: jest.fn().mockResolvedValue(true),
+}));
+
+function load() {
+  jest.resetModules();
+  jest.clearAllMocks();
+  return require('../../bot/shared/routes/discord-flow-registry');
+}
+
+/**
+ * A trigger interaction whose client.users.fetch() resolves to a real DM
+ * channel — needed only by startFlow() tests, since startFlow() runs
+ * runScreen(), which calls collectEnumAnswers() for any screen with enum
+ * fields (CLASS_INFO/CONFIRM_STUDENTS/BASIC_INFO all have at least one).
+ * Each select-menu message's awaitMessageComponent() resolves immediately
+ * with a fake selection, so startFlow() completes without hanging.
+ */
+function fakeTrigger() {
+  const selectInteraction = { values: ['some_value'], deferUpdate: jest.fn().mockResolvedValue(undefined), showModal: jest.fn().mockResolvedValue(undefined) };
+  const dmChannel = { send: jest.fn().mockResolvedValue({ awaitMessageComponent: jest.fn().mockResolvedValue(selectInteraction) }) };
+  const user = { id: 'D0123', dmChannel, createDM: jest.fn().mockResolvedValue(dmChannel) };
+  return { client: { users: { fetch: jest.fn().mockResolvedValue(user) } }, deferUpdate: jest.fn(), showModal: jest.fn() };
+}
+
+describe('discord-flow-registry', () => {
+  it('ensureRegistered() registers all five renderers', () => {
+    const registry = load();
+    registry.ensureRegistered();
+    expect(registry.get('registration')).toBeTruthy();
+    expect(registry.get('settings')).toBeTruthy();
+    expect(registry.get('attendance')).toBeTruthy();
+    expect(registry.get('exam_confirm')).toBeTruthy();
+    expect(registry.get('reading_assessment')).toBeTruthy();
+    expect(registry.get('nonexistent')).toBeUndefined();
+  });
+
+  it('ensureRegistered() is idempotent — a second call does not re-register', () => {
+    const registry = load();
+    registry.ensureRegistered();
+    const first = registry.get('registration');
+    registry.ensureRegistered();
+    expect(registry.get('registration')).toBe(first);
+  });
+
+  it('_resetForTests() forces the next ensureRegistered() to re-run registerAll()', () => {
+    const registry = load();
+    registry.ensureRegistered();
+    expect(registry.get('registration')).toBeTruthy();
+    registry._resetForTests();
+    expect(registry.get('registration')).toBeUndefined();
+    registry.ensureRegistered();
+    expect(registry.get('registration')).toBeTruthy();
+  });
+
+  it('buildFlowToken follows the "userId:kind:timestamp" convention', () => {
+    const registry = load();
+    const token = registry.buildFlowToken('u1', 'registration');
+    expect(token).toMatch(/^u1:registration:\d+$/);
+  });
+
+  it('registration renderer\'s onFinish sends the welcome/portal message to the Discord user', async () => {
+    const registry = load();
+    registry.ensureRegistered();
+    const discordChannel = require('../../bot/shared/services/messaging/discord-channel.service');
+    const registration = require('../../bot/shared/routes/registration-endpoint');
+    registration.handleRegistrationDataExchange.mockResolvedValueOnce({
+      screen: 'SUCCESS', data: { welcome_message: 'Welcome!', portal_message: 'Portal ready' },
+    });
+
+    const renderer = registry.get('registration');
+    const ctx = { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:registration:169' };
+    await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'PERSONAL_INFO', {});
+
+    expect(discordChannel.sendMessage).toHaveBeenCalledWith('discord:D0123', 'Welcome!\n\nPortal ready');
+  });
+
+  it('settings renderer\'s onFinish sends the confirmation + details message', async () => {
+    const registry = load();
+    registry.ensureRegistered();
+    const discordChannel = require('../../bot/shared/services/messaging/discord-channel.service');
+
+    const renderer = registry.get('settings');
+    const ctx = { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:settings:169' };
+    await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'SETTINGS_MAIN', {});
+
+    expect(discordChannel.sendMessage).toHaveBeenCalledWith('discord:D0123', 'Saved.\nLanguage: English');
+  });
+
+  describe('attendance renderer', () => {
+    it('calls handleSetupInit with the resolved userId', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const { handleSetupInit } = require('../../bot/shared/routes/attendance-setup-endpoint');
+
+      const renderer = registry.get('attendance');
+      await renderer.startFlow(
+        { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:attendance:169' },
+        fakeTrigger(),
+      );
+
+      expect(handleSetupInit).toHaveBeenCalledWith('u1');
+    });
+
+    it('ADD_STUDENT is a loopScreens entry — onFinish is never called for it, onScreenLoop fires instead', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const discordChannel = require('../../bot/shared/services/messaging/discord-channel.service');
+
+      const renderer = registry.get('attendance');
+      const ctx = { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:attendance:169' };
+      const result = await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'CLASS_INFO', {});
+
+      expect(result).toBe('awaiting_choice');
+      expect(discordChannel.sendInteractiveButtons).toHaveBeenCalledWith('discord:D0123', expect.objectContaining({
+        buttons: [
+          { id: 'discord_attendance_add:u1:attendance:169', title: 'Add Another' },
+          { id: 'discord_attendance_done:u1:attendance:169', title: "I'm Done" },
+        ],
+      }));
+    });
+
+    it('onFinish sends the success_message once the flow reaches SUCCESS', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const discordChannel = require('../../bot/shared/services/messaging/discord-channel.service');
+      const attendance = require('../../bot/shared/routes/attendance-setup-endpoint');
+      attendance.handleSetupDataExchange.mockResolvedValueOnce({ screen: 'SUCCESS', data: { success_message: 'Class ready with 3 students.' } });
+
+      const renderer = registry.get('attendance');
+      const ctx = { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:attendance:169' };
+      await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'ADD_STUDENT', {});
+
+      expect(discordChannel.sendMessage).toHaveBeenCalledWith('discord:D0123', 'Class ready with 3 students.');
+    });
+  });
+
+  describe('exam_confirm renderer', () => {
+    it('calls handleExamConfirmInit with the session id passed as flowToken (not a minted token)', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const { handleExamConfirmInit } = require('../../bot/shared/routes/exam-confirm-endpoint');
+
+      const renderer = registry.get('exam_confirm');
+      await renderer.startFlow(
+        { userId: null, discordUserId: 'D0123', flowToken: 'session-1' },
+        fakeTrigger(),
+      );
+
+      expect(handleExamConfirmInit).toHaveBeenCalledWith('session-1');
+    });
+
+    it('onFinish looks up the session by id and hands off to ExamCheckerOrchestrator.process with the confirmed students', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const ExamSessionService = require('../../bot/shared/services/exam-checker/exam-session.service');
+      const { ExamCheckerOrchestrator } = require('../../bot/shared/services/exam-checker/exam-checker.orchestrator');
+
+      const renderer = registry.get('exam_confirm');
+      const ctx = { userId: null, discordUserId: 'D0123', flowToken: 'session-1' };
+      await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'CONFIRM_STUDENTS', {});
+
+      expect(ExamSessionService.getById).toHaveBeenCalledWith('session-1');
+      expect(ExamCheckerOrchestrator.process).toHaveBeenCalledWith(
+        { type: 'flow', flowResponse: { confirmed_students: ['0'] } },
+        'u1',
+        'discord:D0123',
+      );
+    });
+
+    it('onFinish is a no-op when the session no longer exists (expired/deleted)', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const ExamSessionService = require('../../bot/shared/services/exam-checker/exam-session.service');
+      ExamSessionService.getById.mockResolvedValueOnce(null);
+      const { ExamCheckerOrchestrator } = require('../../bot/shared/services/exam-checker/exam-checker.orchestrator');
+
+      const renderer = registry.get('exam_confirm');
+      const ctx = { userId: null, discordUserId: 'D0123', flowToken: 'session-gone' };
+      await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'CONFIRM_STUDENTS', {});
+
+      expect(ExamCheckerOrchestrator.process).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reading_assessment renderer', () => {
+    it('calls handleReadingAssessmentInit with the resolved userId', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const { handleReadingAssessmentInit } = require('../../bot/shared/routes/reading-assessment-endpoint');
+
+      const renderer = registry.get('reading_assessment');
+      await renderer.startFlow(
+        { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:reading_assessment:169' },
+        fakeTrigger(),
+      );
+
+      expect(handleReadingAssessmentInit).toHaveBeenCalledWith('u1');
+    });
+
+    it('onFinish calls startAssessment with fields parsed from the SUCCESS screen data', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const { startAssessment } = require('../../bot/shared/routes/reading-assessment-endpoint');
+
+      const renderer = registry.get('reading_assessment');
+      const ctx = { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:reading_assessment:169' };
+      await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'BASIC_INFO', {});
+
+      expect(startAssessment).toHaveBeenCalledWith('u1', 'discord:D0123', {
+        studentName: 'Zara', language: 'en', isAutoMode: true, levelIndex: '0', comprehensionRequired: false,
+      });
+    });
+
+    it('onFinish sends an error message and does not throw when startAssessment fails', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const discordChannel = require('../../bot/shared/services/messaging/discord-channel.service');
+      const { startAssessment } = require('../../bot/shared/routes/reading-assessment-endpoint');
+      startAssessment.mockRejectedValueOnce(new Error('DB unreachable'));
+
+      const renderer = registry.get('reading_assessment');
+      const ctx = { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:reading_assessment:169' };
+      await expect(renderer._advance(ctx, { deferUpdate: jest.fn() }, 'BASIC_INFO', {})).resolves.not.toThrow();
+
+      expect(discordChannel.sendMessage).toHaveBeenCalledWith('discord:D0123', expect.stringMatching(/something went wrong/i));
+    });
+
+    it('extracts manual-mode Urdu + comprehension fields correctly', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const readingAssessment = require('../../bot/shared/routes/reading-assessment-endpoint');
+      readingAssessment.handleReadingAssessmentDataExchange.mockResolvedValueOnce({
+        screen: 'SUCCESS',
+        data: {
+          student_full_name: 'Ayesha', Language: '1_Urdu', assessment_mode: '1_Manual',
+          select_the_reading_level: '2_Sentences_(Grade_1-2)', scope_of_assessment_: '1_Fluency_+_Comprehension',
+        },
+      });
+
+      const renderer = registry.get('reading_assessment');
+      const ctx = { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:reading_assessment:169' };
+      await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'OPTIONS', {});
+
+      expect(readingAssessment.startAssessment).toHaveBeenCalledWith('u1', 'discord:D0123', {
+        studentName: 'Ayesha', language: 'ur', isAutoMode: false, levelIndex: '2', comprehensionRequired: true,
+      });
+    });
+  });
+});

--- a/tests/routes/discord-modal-interactions-handler.test.js
+++ b/tests/routes/discord-modal-interactions-handler.test.js
@@ -1,0 +1,323 @@
+/**
+ * discord-modal-interactions.handler.js — dispatches the Discord-specific
+ * modal-workaround interaction shapes: starting a flow from a "Get started"
+ * button, claiming collector-active interactions, modal submissions, and
+ * attendance's "Add Another"/"I'm Done" loop buttons. Mirrors
+ * tests/routes/slack-modal-interactions-handler.test.js's conventions.
+ */
+
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/database/bot-helpers', () => ({
+  getOrCreateUserByChannel: jest.fn(async () => ({ id: 'db-user-1' })),
+}));
+
+function loadHandler({ renderer, isCollectorActiveForMessage } = {}) {
+  jest.resetModules();
+  const flowRegistry = {
+    ensureRegistered: jest.fn(),
+    get: jest.fn(() => renderer),
+    buildFlowToken: jest.fn((userId, kind) => `${userId}:${kind}:169`),
+  };
+  jest.doMock('../../bot/shared/routes/discord-flow-registry', () => flowRegistry);
+
+  const discordModalFlow = {
+    decodeCustomId: jest.fn((customId) => {
+      const idx = String(customId || '').indexOf(':');
+      if (idx === -1) return { kind: null, token: null };
+      return { kind: customId.slice(0, idx), token: customId.slice(idx + 1) };
+    }),
+    loadModalState: jest.fn(async () => null),
+    deleteModalState: jest.fn(async () => {}),
+    isCollectorActiveForMessage: isCollectorActiveForMessage || jest.fn(() => false),
+    loadLoopScreenData: jest.fn(async () => null),
+    deleteLoopScreenData: jest.fn(async () => {}),
+  };
+  jest.doMock('../../bot/shared/services/messaging/discord-modal-flow', () => discordModalFlow);
+
+  const discordChannel = { sendMessage: jest.fn().mockResolvedValue(true) };
+  jest.doMock('../../bot/shared/services/messaging/discord-channel.service', () => discordChannel);
+
+  const handler = require('../../bot/shared/routes/discord-modal-interactions.handler');
+  const { getOrCreateUserByChannel } = require('../../bot/shared/database/bot-helpers');
+  return { handler, flowRegistry, discordModalFlow, discordChannel, getOrCreateUserByChannel };
+}
+
+describe('isStartFlowAction / kindFromStartFlowAction / parseStartFlowAction', () => {
+  it('recognizes the discord_start_flow: prefix', () => {
+    const { handler } = loadHandler();
+    expect(handler.isStartFlowAction('discord_start_flow:registration')).toBe(true);
+    expect(handler.isStartFlowAction('menu_lesson_plan')).toBe(false);
+  });
+
+  it('kindFromStartFlowAction returns just the kind for a plain customId with no embedded session id', () => {
+    const { handler } = loadHandler();
+    expect(handler.kindFromStartFlowAction('discord_start_flow:registration')).toBe('registration');
+    expect(handler.kindFromStartFlowAction('discord_start_flow:attendance')).toBe('attendance');
+  });
+
+  it('parseStartFlowAction splits a plain customId with sessionId: null', () => {
+    const { handler } = loadHandler();
+    expect(handler.parseStartFlowAction('discord_start_flow:registration')).toEqual({ kind: 'registration', sessionId: null });
+  });
+
+  it('parseStartFlowAction splits "discord_start_flow:exam_confirm:<sessionId>" on the FIRST colon after the prefix', () => {
+    const { handler } = loadHandler();
+    expect(handler.parseStartFlowAction('discord_start_flow:exam_confirm:sess-123')).toEqual({
+      kind: 'exam_confirm', sessionId: 'sess-123',
+    });
+  });
+
+  it('kindFromStartFlowAction returns just the kind even when a sessionId is embedded', () => {
+    const { handler } = loadHandler();
+    expect(handler.kindFromStartFlowAction('discord_start_flow:exam_confirm:sess-123')).toBe('exam_confirm');
+  });
+});
+
+describe('tryHandleCollected', () => {
+  it('returns whatever isCollectorActiveForMessage says for this interaction\'s message id', () => {
+    const isCollectorActiveForMessage = jest.fn((id) => id === 'msg-active');
+    const { handler } = loadHandler({ isCollectorActiveForMessage });
+
+    expect(handler.tryHandleCollected({ message: { id: 'msg-active' } })).toBe(true);
+    expect(handler.tryHandleCollected({ message: { id: 'msg-other' } })).toBe(false);
+    expect(handler.tryHandleCollected({})).toBe(false);
+  });
+});
+
+describe('tryHandleStartFlow', () => {
+  it('returns false for a non-button interaction', async () => {
+    const { handler } = loadHandler();
+    const handled = await handler.tryHandleStartFlow({ isButton: () => false });
+    expect(handled).toBe(false);
+  });
+
+  it('returns false for a button whose customId is not discord_start_flow:', async () => {
+    const { handler } = loadHandler();
+    const handled = await handler.tryHandleStartFlow({ isButton: () => true, customId: 'menu_lesson_plan' });
+    expect(handled).toBe(false);
+  });
+
+  it('resolves the DB user, mints a flow token, and calls startFlow — for a userId-keyed kind', async () => {
+    const renderer = { startFlow: jest.fn().mockResolvedValue('awaiting_modal') };
+    const { handler, getOrCreateUserByChannel, flowRegistry } = loadHandler({ renderer });
+
+    const interaction = {
+      isButton: () => true,
+      customId: 'discord_start_flow:registration',
+      user: { id: 'D0123' },
+      deferUpdate: jest.fn(),
+    };
+    const handled = await handler.tryHandleStartFlow(interaction);
+
+    expect(handled).toBe(true);
+    expect(getOrCreateUserByChannel).toHaveBeenCalledWith('discord', 'D0123');
+    expect(flowRegistry.buildFlowToken).toHaveBeenCalledWith('db-user-1', 'registration');
+    expect(renderer.startFlow).toHaveBeenCalledWith(
+      { userId: 'db-user-1', discordUserId: 'D0123', flowToken: 'db-user-1:registration:169' },
+      interaction,
+    );
+  });
+
+  it('exam_confirm: uses the embedded sessionId directly as flowToken, userId is null, never calls buildFlowToken or getOrCreateUserByChannel', async () => {
+    const renderer = { startFlow: jest.fn().mockResolvedValue('awaiting_modal') };
+    const { handler, getOrCreateUserByChannel, flowRegistry } = loadHandler({ renderer });
+
+    const interaction = {
+      isButton: () => true,
+      customId: 'discord_start_flow:exam_confirm:sess-789',
+      user: { id: 'D0123' },
+    };
+    const handled = await handler.tryHandleStartFlow(interaction);
+
+    expect(handled).toBe(true);
+    expect(getOrCreateUserByChannel).not.toHaveBeenCalled();
+    expect(flowRegistry.buildFlowToken).not.toHaveBeenCalled();
+    expect(renderer.startFlow).toHaveBeenCalledWith(
+      { userId: null, discordUserId: 'D0123', flowToken: 'sess-789' },
+      interaction,
+    );
+  });
+
+  it('does not throw when no renderer is registered for the kind — logs, defers, and returns true', async () => {
+    const { handler } = loadHandler({ renderer: undefined });
+    const interaction = { isButton: () => true, customId: 'discord_start_flow:unknown_kind', user: { id: 'D1' }, deferUpdate: jest.fn().mockResolvedValue(undefined) };
+    const handled = await handler.tryHandleStartFlow(interaction);
+    expect(handled).toBe(true);
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when renderer.startFlow itself throws', async () => {
+    const renderer = { startFlow: jest.fn().mockRejectedValue(new Error('boom')) };
+    const { handler } = loadHandler({ renderer });
+    const interaction = { isButton: () => true, customId: 'discord_start_flow:registration', user: { id: 'D1' } };
+    await expect(handler.tryHandleStartFlow(interaction)).resolves.toBe(true);
+  });
+
+  it('tells the teacher the flow gave up when startFlow times out, instead of leaving them with no explanation', async () => {
+    const renderer = { startFlow: jest.fn().mockResolvedValue('timed_out') };
+    const { handler, discordChannel } = loadHandler({ renderer });
+    const interaction = { isButton: () => true, customId: 'discord_start_flow:settings', user: { id: 'D0123' } };
+
+    await handler.tryHandleStartFlow(interaction);
+
+    expect(discordChannel.sendMessage).toHaveBeenCalledWith('discord:D0123', expect.stringMatching(/took too long/i));
+  });
+
+  it('sends nothing extra when startFlow finishes normally (not timed_out)', async () => {
+    const renderer = { startFlow: jest.fn().mockResolvedValue('finished') };
+    const { handler, discordChannel } = loadHandler({ renderer });
+    const interaction = { isButton: () => true, customId: 'discord_start_flow:settings', user: { id: 'D0123' } };
+
+    await handler.tryHandleStartFlow(interaction);
+
+    expect(discordChannel.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleModalSubmit', () => {
+  it('logs, defers, and returns early when no renderer is registered for the decoded kind', async () => {
+    const { handler } = loadHandler({ renderer: undefined });
+    const interaction = { customId: 'unknown_kind:token123', deferUpdate: jest.fn().mockResolvedValue(undefined) };
+    await handler.handleModalSubmit(interaction);
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers and returns early when the modal state has expired/is missing', async () => {
+    const renderer = { handleModalSubmit: jest.fn() };
+    const { handler, discordModalFlow } = loadHandler({ renderer });
+    discordModalFlow.loadModalState.mockResolvedValueOnce(null);
+
+    const interaction = { customId: 'registration:tok', deferUpdate: jest.fn().mockResolvedValue(undefined) };
+    await handler.handleModalSubmit(interaction);
+
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(renderer.handleModalSubmit).not.toHaveBeenCalled();
+  });
+
+  it('deletes the modal state (once consumed) and calls the renderer\'s handleModalSubmit with the recovered state', async () => {
+    const renderer = { handleModalSubmit: jest.fn().mockResolvedValue('finished') };
+    const { handler, discordModalFlow } = loadHandler({ renderer });
+    const state = { kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'db-user-1:registration:169', collectedEnumAnswers: {} };
+    discordModalFlow.loadModalState.mockResolvedValueOnce(state);
+
+    const interaction = { customId: 'registration:tok123', fields: { fields: new Map() } };
+    await handler.handleModalSubmit(interaction);
+
+    expect(discordModalFlow.deleteModalState).toHaveBeenCalledWith('tok123');
+    expect(renderer.handleModalSubmit).toHaveBeenCalledWith(interaction, state);
+  });
+
+  it('does not throw when renderer.handleModalSubmit itself throws', async () => {
+    const renderer = { handleModalSubmit: jest.fn().mockRejectedValue(new Error('boom')) };
+    const { handler, discordModalFlow } = loadHandler({ renderer });
+    discordModalFlow.loadModalState.mockResolvedValueOnce({ kind: 'registration', screen: 'X', flowToken: 't' });
+
+    const interaction = { customId: 'registration:tok', fields: { fields: new Map() } };
+    await expect(handler.handleModalSubmit(interaction)).resolves.toBeUndefined();
+  });
+});
+
+describe('tryHandleAttendanceLoopButton', () => {
+  it('returns false for a non-button interaction', async () => {
+    const { handler } = loadHandler();
+    const handled = await handler.tryHandleAttendanceLoopButton({ isButton: () => false });
+    expect(handled).toBe(false);
+  });
+
+  it('returns false for a button whose customId matches neither the add nor done prefix', async () => {
+    const { handler } = loadHandler();
+    const handled = await handler.tryHandleAttendanceLoopButton({ isButton: () => true, customId: 'menu_lesson_plan' });
+    expect(handled).toBe(false);
+  });
+
+  it('"Add Another" calls renderer.resumeLoopScreen with a ctx built from the embedded flowToken', async () => {
+    const renderer = { resumeLoopScreen: jest.fn().mockResolvedValue('awaiting_modal') };
+    const { handler } = loadHandler({ renderer });
+
+    const interaction = {
+      isButton: () => true,
+      customId: 'discord_attendance_add:u1:attendance:169',
+      user: { id: 'D0123' },
+    };
+    const handled = await handler.tryHandleAttendanceLoopButton(interaction);
+
+    expect(handled).toBe(true);
+    expect(renderer.resumeLoopScreen).toHaveBeenCalledWith(
+      { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:attendance:169' },
+      interaction,
+    );
+  });
+
+  it('"I\'m Done" recovers the carried {list_id, class_display}, defers, and calls renderer._advance with _action: done', async () => {
+    const renderer = { _advance: jest.fn().mockResolvedValue('finished') };
+    const { handler, discordModalFlow } = loadHandler({ renderer });
+    discordModalFlow.loadLoopScreenData.mockResolvedValueOnce({
+      screen: 'ADD_STUDENT', data: { list_id: 'list-1', class_display: 'Grade 3 - A' },
+    });
+
+    const interaction = {
+      isButton: () => true,
+      customId: 'discord_attendance_done:u1:attendance:169',
+      user: { id: 'D0123' },
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+    };
+    const handled = await handler.tryHandleAttendanceLoopButton(interaction);
+
+    expect(handled).toBe(true);
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(discordModalFlow.deleteLoopScreenData).toHaveBeenCalledWith('u1:attendance:169');
+    expect(renderer._advance).toHaveBeenCalledWith(
+      { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:attendance:169' },
+      interaction,
+      'ADD_STUDENT',
+      { _action: 'done', _list_id: 'list-1', _class_display: 'Grade 3 - A' },
+    );
+  });
+
+  it('"I\'m Done" is a safe no-op (still handled, still deferred) when the loop state has expired', async () => {
+    const renderer = { _advance: jest.fn() };
+    const { handler, discordModalFlow } = loadHandler({ renderer });
+    discordModalFlow.loadLoopScreenData.mockResolvedValueOnce(null);
+
+    const interaction = {
+      isButton: () => true,
+      customId: 'discord_attendance_done:u1:attendance:169',
+      user: { id: 'D0123' },
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+    };
+    const handled = await handler.tryHandleAttendanceLoopButton(interaction);
+
+    expect(handled).toBe(true);
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(renderer._advance).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when no renderer is registered for attendance at all', async () => {
+    const { handler } = loadHandler({ renderer: undefined });
+    const interaction = {
+      isButton: () => true,
+      customId: 'discord_attendance_add:u1:attendance:169',
+      user: { id: 'D0123' },
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+    };
+    await expect(handler.tryHandleAttendanceLoopButton(interaction)).resolves.toBe(true);
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when renderer.resumeLoopScreen itself throws', async () => {
+    const renderer = { resumeLoopScreen: jest.fn().mockRejectedValue(new Error('boom')) };
+    const { handler } = loadHandler({ renderer });
+    const interaction = { isButton: () => true, customId: 'discord_attendance_add:u1:attendance:169', user: { id: 'D1' } };
+    await expect(handler.tryHandleAttendanceLoopButton(interaction)).resolves.toBe(true);
+  });
+
+  it('"Add Another" tells the teacher the flow gave up when resumeLoopScreen times out', async () => {
+    const renderer = { resumeLoopScreen: jest.fn().mockResolvedValue('timed_out') };
+    const { handler, discordChannel } = loadHandler({ renderer });
+    const interaction = { isButton: () => true, customId: 'discord_attendance_add:u1:attendance:169', user: { id: 'D0123' } };
+
+    await handler.tryHandleAttendanceLoopButton(interaction);
+
+    expect(discordChannel.sendMessage).toHaveBeenCalledWith('discord:D0123', expect.stringMatching(/took too long/i));
+  });
+});

--- a/tests/routes/discord-views.test.js
+++ b/tests/routes/discord-views.test.js
@@ -1,0 +1,157 @@
+/**
+ * discord-views/registration.view.js and settings.view.js — the concrete
+ * screen <-> collectEnumAnswers()-steps/textFields mapping. Pins the exact
+ * customId/option shapes discord-modal-flow.js reads back, since a mismatch
+ * here would silently drop a field with no error at all — same rationale as
+ * tests/routes/slack-views.test.js for the Slack side.
+ *
+ * discord.js is a bot-only dependency (installed under bot/node_modules,
+ * not the repo root) — mocked virtual: true so this suite passes in real CI,
+ * which installs it only AFTER the root test suite runs. StringSelectMenuBuilder
+ * is real chainable-builder shaped (not just a stub) since these views call
+ * it for real and this suite asserts on its .toJSON() output.
+ */
+jest.mock('discord.js', () => {
+  class FakeStringSelectMenuBuilder {
+    constructor() { this.options = []; }
+    setCustomId(id) { this.customId = id; return this; }
+    setPlaceholder(p) { this.placeholder = p; return this; }
+    setMinValues(n) { this.minValues = n; return this; }
+    setMaxValues(n) { this.maxValues = n; return this; }
+    addOptions(opts) { this.options.push(...opts); return this; }
+    toJSON() {
+      return {
+        custom_id: this.customId, placeholder: this.placeholder, options: this.options,
+        ...(this.minValues !== undefined ? { min_values: this.minValues } : {}),
+        ...(this.maxValues !== undefined ? { max_values: this.maxValues } : {}),
+      };
+    }
+  }
+  return { StringSelectMenuBuilder: FakeStringSelectMenuBuilder };
+}, { virtual: true });
+
+const registrationView = require('../../bot/shared/routes/discord-views/registration.view');
+const settingsView = require('../../bot/shared/routes/discord-views/settings.view');
+
+describe('registration.view — screenToSteps', () => {
+  it('PERSONAL_INFO returns a 2-step country picker (region bucket, then country) plus a full_name text field', () => {
+    const { steps, textFields } = registrationView.screenToSteps('PERSONAL_INFO', {});
+    expect(steps.map((s) => s.fieldName)).toEqual([registrationView.BUCKET_FIELD, 'country']);
+    expect(textFields).toEqual([{ name: 'full_name', label: 'Full name', required: true }]);
+
+    const bucketMenu = steps[0].buildMenu({});
+    const bucketJson = bucketMenu.toJSON();
+    expect(bucketJson.custom_id).toBe(registrationView.BUCKET_FIELD);
+    expect(bucketJson.options.length).toBeGreaterThan(0);
+    expect(bucketJson.options.length).toBeLessThanOrEqual(25);
+
+    const firstBucketId = bucketJson.options[0].value;
+    const countryMenu = steps[1].buildMenu({ [registrationView.BUCKET_FIELD]: firstBucketId });
+    const countryJson = countryMenu.toJSON();
+    expect(countryJson.custom_id).toBe('country');
+    expect(countryJson.options.length).toBeGreaterThan(0);
+    expect(countryJson.options.length).toBeLessThanOrEqual(25);
+  });
+
+  it('REGION_INFO splits Pakistan (7) vs India (22) into a 2-step picker, both under the 25-option cap', () => {
+    const { steps, textFields } = registrationView.screenToSteps('REGION_INFO', {});
+    expect(steps.map((s) => s.fieldName)).toEqual([registrationView.PK_IN_FIELD, 'region']);
+    expect(textFields).toEqual([]);
+
+    const pkMenu = steps[1].buildMenu({ [registrationView.PK_IN_FIELD]: 'PK' }).toJSON();
+    expect(pkMenu.options).toHaveLength(7);
+
+    const inMenu = steps[1].buildMenu({ [registrationView.PK_IN_FIELD]: 'IN' }).toJSON();
+    expect(inMenu.options).toHaveLength(22);
+  });
+
+  it('PROFESSIONAL_INFO returns 3 enum steps (organization, grade, multi-select subjects) plus an optional school_name text field', () => {
+    const data = {
+      organizations: [{ id: 'fde', title: 'FDE' }],
+      grades: [{ id: 'grade_1', title: 'Grade 1' }],
+      subjects: [{ id: 'maths', title: 'Maths' }, { id: 'english', title: 'English' }],
+    };
+    const { steps, textFields } = registrationView.screenToSteps('PROFESSIONAL_INFO', data);
+    expect(steps.map((s) => s.fieldName)).toEqual(['organization', 'grade', 'subjects']);
+    expect(textFields).toEqual([{ name: 'school_name', label: 'School name (optional)', required: false }]);
+
+    const subjectsStep = steps.find((s) => s.fieldName === 'subjects');
+    expect(subjectsStep.multi).toBe(true);
+    const subjectsJson = subjectsStep.buildMenu().toJSON();
+    expect(subjectsJson.min_values).toBe(1);
+    expect(subjectsJson.max_values).toBe(2);
+    expect(subjectsJson.options).toHaveLength(2);
+  });
+
+  it('ORG_DETAILS has no enum steps at all — modal opens directly', () => {
+    const { steps, textFields } = registrationView.screenToSteps('ORG_DETAILS', {});
+    expect(steps).toEqual([]);
+    expect(textFields).toEqual([{ name: 'organization_other', label: 'Organization name', required: true }]);
+  });
+
+  it('throws for an unmapped screen — a silent fallback would open a blank modal', () => {
+    expect(() => registrationView.screenToSteps('NOT_A_SCREEN', {})).toThrow(/no screen mapping/);
+  });
+});
+
+describe('registration.view — mergeScreenData', () => {
+  it('PERSONAL_INFO merges the collected country with the modal-submitted full_name', () => {
+    expect(registrationView.mergeScreenData('PERSONAL_INFO', { country: 'PK' }, { full_name: 'Ayesha Khan' }))
+      .toEqual({ full_name: 'Ayesha Khan', country: 'PK' });
+  });
+
+  it('REGION_INFO merges just the collected region (no text fields on this screen)', () => {
+    expect(registrationView.mergeScreenData('REGION_INFO', { region: 'in_punjab' }, {})).toEqual({ region: 'in_punjab' });
+  });
+
+  it('PROFESSIONAL_INFO merges organization/grade/subjects with the modal-submitted school_name', () => {
+    expect(registrationView.mergeScreenData(
+      'PROFESSIONAL_INFO',
+      { organization: 'fde', grade: 'grade_1', subjects: ['maths', 'english'] },
+      { school_name: 'Sunrise School' },
+    )).toEqual({ organization: 'fde', school_name: 'Sunrise School', grade: 'grade_1', subjects: ['maths', 'english'] });
+  });
+
+  it('ORG_DETAILS merges just the modal-submitted organization_other', () => {
+    expect(registrationView.mergeScreenData('ORG_DETAILS', {}, { organization_other: 'My School' }))
+      .toEqual({ organization_other: 'My School' });
+  });
+});
+
+describe('settings.view — screenToSteps', () => {
+  it('SETTINGS_MAIN returns 2 enum steps and NO text fields at all — no modal needed for this screen', () => {
+    const data = {
+      languages: [{ id: 'en', title: 'English' }, { id: 'ur', title: 'Urdu' }],
+      frameworks: [{ id: 'oecd', title: 'OECD' }],
+      current_language: 'ur',
+      current_framework: 'oecd',
+    };
+    const { steps, textFields } = settingsView.screenToSteps('SETTINGS_MAIN', data);
+    expect(steps.map((s) => s.fieldName)).toEqual(['language', 'observation_framework']);
+    expect(textFields).toEqual([]);
+
+    // No option is pre-selected (`default`) — Discord's client treats
+    // re-picking an already-selected option as no change, sending no
+    // interaction at all, which previously stalled the flow until it timed
+    // out. The current value is surfaced in the placeholder instead, so a
+    // re-pick of the SAME value is still a real interaction.
+    const langJson = steps[0].buildMenu().toJSON();
+    expect(langJson.options.every((o) => !o.default)).toBe(true);
+    expect(langJson.placeholder).toContain('Urdu');
+  });
+
+  it('throws for an unmapped screen', () => {
+    expect(() => settingsView.screenToSteps('NOT_A_SCREEN', {})).toThrow(/no screen mapping/);
+  });
+});
+
+describe('settings.view — mergeScreenData', () => {
+  it('defaults language/framework when unanswered', () => {
+    expect(settingsView.mergeScreenData('SETTINGS_MAIN', {})).toEqual({ language: 'en', observation_framework: 'oecd' });
+  });
+
+  it('carries through the collected enum answers', () => {
+    expect(settingsView.mergeScreenData('SETTINGS_MAIN', { language: 'ur', observation_framework: 'ecers' }))
+      .toEqual({ language: 'ur', observation_framework: 'ecers' });
+  });
+});

--- a/tests/routes/reading-assessment-endpoint.test.js
+++ b/tests/routes/reading-assessment-endpoint.test.js
@@ -1,0 +1,104 @@
+/**
+ * reading-assessment-endpoint.js — extracted from flow-response.handler.js's
+ * former inline levelMapping/wordCountMap object literals (see that file's
+ * git history), plus a genuine {init, exchange} contract for Discord's
+ * modal-workaround renderer. The source Meta Flow
+ * (docs/flows/reading-assessment-flow-v2.json) is purely NAVIGATE-style —
+ * exchange() here does NOT create the assessment record or generate a
+ * passage; that stays flow-response.handler.js's job (see this endpoint's
+ * own header comment).
+ */
+
+const {
+  handleReadingAssessmentInit,
+  handleReadingAssessmentDataExchange,
+  mapLevelToPassage,
+  wordCountFor,
+} = require('../../bot/shared/routes/reading-assessment-endpoint');
+
+describe('mapLevelToPassage', () => {
+  it('auto mode always starts at story level (4), regardless of levelIndex', () => {
+    expect(mapLevelToPassage('0', true)).toEqual({ passageType: 'story', gradeNumeric: 4 });
+    expect(mapLevelToPassage('3', true)).toEqual({ passageType: 'story', gradeNumeric: 4 });
+    expect(mapLevelToPassage(undefined, true)).toEqual({ passageType: 'story', gradeNumeric: 4 });
+  });
+
+  it('manual mode maps each level index to its passage type — matching the original inline levelMapping exactly', () => {
+    expect(mapLevelToPassage('0', false)).toEqual({ passageType: 'letters', gradeNumeric: 0 });
+    expect(mapLevelToPassage('1', false)).toEqual({ passageType: 'words', gradeNumeric: 1 });
+    expect(mapLevelToPassage('2', false)).toEqual({ passageType: 'sentences', gradeNumeric: 2 });
+    expect(mapLevelToPassage('3', false)).toEqual({ passageType: 'paragraph', gradeNumeric: 3 });
+  });
+
+  it('accepts a numeric levelIndex, not just a string (parsed off "2_Sentences_..." elsewhere)', () => {
+    expect(mapLevelToPassage(2, false)).toEqual({ passageType: 'sentences', gradeNumeric: 2 });
+  });
+
+  it('falls back to paragraph/grade 2 for an unrecognized manual-mode level index — matching the original fallback', () => {
+    expect(mapLevelToPassage('99', false)).toEqual({ passageType: 'paragraph', gradeNumeric: 2 });
+    expect(mapLevelToPassage('', false)).toEqual({ passageType: 'paragraph', gradeNumeric: 2 });
+  });
+});
+
+describe('wordCountFor', () => {
+  it('maps each passage type to its word count — matching the original inline wordCountMap exactly', () => {
+    expect(wordCountFor('letters')).toBe(14);
+    expect(wordCountFor('words')).toBe(14);
+    expect(wordCountFor('sentences')).toBe(40);
+    expect(wordCountFor('paragraph')).toBe(60);
+    expect(wordCountFor('story')).toBe(100);
+  });
+
+  it('falls back to 50 for an unrecognized passage type', () => {
+    expect(wordCountFor('unknown')).toBe(50);
+  });
+});
+
+describe('handleReadingAssessmentInit', () => {
+  it('returns the BASIC_INFO screen with language and assessment-mode options', async () => {
+    const response = await handleReadingAssessmentInit();
+    expect(response.screen).toBe('BASIC_INFO');
+    expect(response.data.languages).toEqual([
+      { id: '0_English', title: 'English' },
+      { id: '1_Urdu', title: 'Urdu / اردو' },
+    ]);
+    expect(response.data.assessment_modes).toHaveLength(2);
+  });
+});
+
+describe('handleReadingAssessmentDataExchange', () => {
+  it('BASIC_INFO -> OPTIONS for manual mode, carrying the level/scope option lists', async () => {
+    const response = await handleReadingAssessmentDataExchange('u1', 'BASIC_INFO', {
+      student_full_name: 'Zara Abdul', assessment_mode: '1_Manual',
+    });
+    expect(response.screen).toBe('OPTIONS');
+    expect(response.data.levels).toHaveLength(4);
+    expect(response.data.scopes).toHaveLength(2);
+    expect(response.data.student_full_name).toBe('Zara Abdul');
+  });
+
+  it('BASIC_INFO -> SUCCESS directly for auto mode — OPTIONS has nothing left to ask', async () => {
+    const response = await handleReadingAssessmentDataExchange('u1', 'BASIC_INFO', {
+      student_full_name: 'Zara Abdul', assessment_mode: '0_Auto',
+    });
+    expect(response.screen).toBe('SUCCESS');
+  });
+
+  it('BASIC_INFO rejects a missing student name', async () => {
+    const response = await handleReadingAssessmentDataExchange('u1', 'BASIC_INFO', { assessment_mode: '0_Auto' });
+    expect(response.data.error.message).toMatch(/name is required/i);
+  });
+
+  it('OPTIONS -> SUCCESS, carrying the submitted level/scope through', async () => {
+    const response = await handleReadingAssessmentDataExchange('u1', 'OPTIONS', {
+      student_full_name: 'Zara Abdul', select_the_reading_level: '2_Sentences_(Grade_1-2)',
+    });
+    expect(response.screen).toBe('SUCCESS');
+    expect(response.data.select_the_reading_level).toBe('2_Sentences_(Grade_1-2)');
+  });
+
+  it('returns an error for an unknown screen', async () => {
+    const response = await handleReadingAssessmentDataExchange('u1', 'NOT_A_SCREEN', {});
+    expect(response.data.error.message).toMatch(/unknown screen/i);
+  });
+});

--- a/tests/routes/slack-flow-registry.test.js
+++ b/tests/routes/slack-flow-registry.test.js
@@ -1,0 +1,103 @@
+/**
+ * slack-flow-registry.js — wires registration/settings endpoints + their
+ * views into buildEndpointModal, exactly the pattern
+ * tests/messaging/text-flow-definitions.test.js already uses: mock the real
+ * endpoint modules, drive the renderer, assert against the mock's calls.
+ */
+
+jest.mock('../../bot/shared/routes/registration-endpoint', () => ({
+  handleRegistrationInit: jest.fn(async () => ({ screen: 'PERSONAL_INFO', data: { countries: [{ id: 'PK', title: 'Pakistan' }] } })),
+  handleRegistrationDataExchange: jest.fn(async () => ({ screen: 'SUCCESS', data: { welcome_message: 'Welcome!' } })),
+  handleRegistrationBack: jest.fn(async () => ({ screen: 'PERSONAL_INFO', data: { countries: [] } })),
+}));
+jest.mock('../../bot/shared/routes/settings-endpoint', () => ({
+  handleSettingsInit: jest.fn(async () => ({
+    screen: 'SETTINGS_MAIN',
+    data: { languages: [{ id: 'en', title: 'English' }], frameworks: [{ id: 'oecd', title: 'OECD' }], current_language: 'en', current_framework: 'oecd' },
+  })),
+  handleSettingsDataExchange: jest.fn(async () => ({ screen: 'SUCCESS', data: { confirmation_message: 'Saved.' } })),
+  handleSettingsBack: jest.fn(async () => ({
+    screen: 'SETTINGS_MAIN',
+    data: { languages: [], frameworks: [], current_language: 'en', current_framework: 'oecd' },
+  })),
+}));
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/services/messaging/slack-web-client', () => ({
+  postMessage: jest.fn().mockResolvedValue(undefined),
+  openView: jest.fn().mockResolvedValue(undefined),
+  pushView: jest.fn().mockResolvedValue(undefined),
+  updateView: jest.fn().mockResolvedValue(undefined),
+}));
+
+function load() {
+  jest.resetModules();
+  jest.clearAllMocks();
+  return require('../../bot/shared/routes/slack-flow-registry');
+}
+
+describe('slack-flow-registry', () => {
+  it('ensureRegistered() registers both registration and settings renderers', () => {
+    const registry = load();
+    registry.ensureRegistered();
+    expect(registry.get('registration')).toBeTruthy();
+    expect(registry.get('settings')).toBeTruthy();
+    expect(registry.get('nonexistent')).toBeUndefined();
+  });
+
+  it('ensureRegistered() is idempotent — a second call does not re-register (no duplicate work)', () => {
+    const registry = load();
+    registry.ensureRegistered();
+    const first = registry.get('registration');
+    registry.ensureRegistered();
+    expect(registry.get('registration')).toBe(first);
+  });
+
+  it('registration renderer calls handleRegistrationInit with the resolved userId', async () => {
+    const registry = load();
+    registry.ensureRegistered();
+    const { handleRegistrationInit } = require('../../bot/shared/routes/registration-endpoint');
+
+    const renderer = registry.get('registration');
+    await renderer.buildInitialView({ userId: 'u1', flowToken: 'u1:registration:169' });
+
+    expect(handleRegistrationInit).toHaveBeenCalledWith('u1');
+  });
+
+  it('registration renderer\'s onFinish posts the welcome/portal message to the Slack user', async () => {
+    const registry = load();
+    registry.ensureRegistered();
+    const slackWebClient = require('../../bot/shared/services/messaging/slack-web-client');
+
+    const renderer = registry.get('registration');
+    const ctx = { userId: 'u1', flowToken: 'u1:registration:169', slackUserId: 'U0123ABC' };
+    await renderer.handleSubmission(ctx, 'PROFESSIONAL_INFO', {
+      organization_block: { organization: { selected_option: { value: 'fde' } } },
+      school_name_block: { school_name: { value: '' } },
+      grade_block: { grade: { selected_option: { value: 'grade_1' } } },
+      subjects_block: { subjects: { selected_options: [] } },
+    });
+
+    expect(slackWebClient.postMessage).toHaveBeenCalledWith('U0123ABC', expect.stringContaining('Welcome!'));
+  });
+
+  it('settings renderer\'s onFinish posts the confirmation message', async () => {
+    const registry = load();
+    registry.ensureRegistered();
+    const slackWebClient = require('../../bot/shared/services/messaging/slack-web-client');
+
+    const renderer = registry.get('settings');
+    const ctx = { userId: 'u1', flowToken: 'u1:settings:169', slackUserId: 'U0123ABC' };
+    await renderer.handleSubmission(ctx, 'SETTINGS_MAIN', {
+      language_block: { language: { selected_option: { value: 'en' } } },
+      framework_block: { observation_framework: { selected_option: { value: 'oecd' } } },
+    });
+
+    expect(slackWebClient.postMessage).toHaveBeenCalledWith('U0123ABC', 'Saved.');
+  });
+
+  it('buildFlowToken follows the existing "userId:kind:timestamp" convention', () => {
+    const registry = load();
+    const token = registry.buildFlowToken('u1', 'registration');
+    expect(token).toMatch(/^u1:registration:\d+$/);
+  });
+});

--- a/tests/routes/slack-flow-registry.test.js
+++ b/tests/routes/slack-flow-registry.test.js
@@ -21,6 +21,31 @@ jest.mock('../../bot/shared/routes/settings-endpoint', () => ({
     data: { languages: [], frameworks: [], current_language: 'en', current_framework: 'oecd' },
   })),
 }));
+jest.mock('../../bot/shared/routes/attendance-setup-endpoint', () => ({
+  handleSetupInit: jest.fn(async () => ({ screen: 'CLASS_INFO', data: {} })),
+  handleSetupDataExchange: jest.fn(async () => ({
+    screen: 'ADD_STUDENT',
+    data: { list_id: 'list-1', class_display: 'Grade 3 - A', heading: 'Add Student #1' },
+  })),
+  handleDoneAction: jest.fn(async () => ({ screen: 'SUCCESS', data: { success_message: 'Class ready with 3 students.' } })),
+}));
+jest.mock('../../bot/shared/routes/exam-confirm-endpoint', () => ({
+  handleExamConfirmInit: jest.fn(async () => ({
+    screen: 'CONFIRM_STUDENTS',
+    data: { heading: 'I found 2 students', students: [{ id: '0', title: '1. Zara' }] },
+  })),
+  handleExamConfirmDataExchange: jest.fn(async () => ({
+    screen: 'SUCCESS',
+    data: { extension_message_response: { params: { flow_token: 'session-1', confirmed_students: ['0'] } } },
+  })),
+  handleExamConfirmBack: jest.fn(async () => ({ screen: 'CONFIRM_STUDENTS', data: { students: [] } })),
+}));
+jest.mock('../../bot/shared/services/exam-checker/exam-session.service', () => ({
+  getById: jest.fn(async () => ({ id: 'session-1', user_id: 'u1', recipient_identifier: 'slack:U0123ABC' })),
+}));
+jest.mock('../../bot/shared/services/exam-checker/exam-checker.orchestrator', () => ({
+  ExamCheckerOrchestrator: { process: jest.fn(async () => ({})) },
+}));
 jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
 jest.mock('../../bot/shared/services/messaging/slack-web-client', () => ({
   postMessage: jest.fn().mockResolvedValue(undefined),
@@ -36,11 +61,13 @@ function load() {
 }
 
 describe('slack-flow-registry', () => {
-  it('ensureRegistered() registers both registration and settings renderers', () => {
+  it('ensureRegistered() registers registration, settings, attendance, and exam_confirm renderers', () => {
     const registry = load();
     registry.ensureRegistered();
     expect(registry.get('registration')).toBeTruthy();
     expect(registry.get('settings')).toBeTruthy();
+    expect(registry.get('attendance')).toBeTruthy();
+    expect(registry.get('exam_confirm')).toBeTruthy();
     expect(registry.get('nonexistent')).toBeUndefined();
   });
 
@@ -99,5 +126,103 @@ describe('slack-flow-registry', () => {
     const registry = load();
     const token = registry.buildFlowToken('u1', 'registration');
     expect(token).toMatch(/^u1:registration:\d+$/);
+  });
+
+  describe('attendance renderer', () => {
+    it('calls handleSetupInit with the resolved userId on buildInitialView', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const { handleSetupInit } = require('../../bot/shared/routes/attendance-setup-endpoint');
+
+      const renderer = registry.get('attendance');
+      await renderer.buildInitialView({ userId: 'u1', flowToken: 'u1:attendance:169' });
+
+      expect(handleSetupInit).toHaveBeenCalledWith('u1');
+    });
+
+    it('ADD_STUDENT submission carries {list_id, class_display} in the pushed view\'s private_metadata (metadataCarry)', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+
+      const renderer = registry.get('attendance');
+      const ctx = { userId: 'u1', flowToken: 'u1:attendance:169', slackUserId: 'U0123ABC' };
+      const result = await renderer.handleSubmission(ctx, 'CLASS_INFO', {
+        class_name_block: { class_name: { value: 'Grade 3' } },
+        section_block: { section: { value: 'A' } },
+        attendance_frequency_block: { attendance_frequency: { selected_option: { value: 'once' } } },
+      });
+
+      expect(result.response_action).toBe('push');
+      const metadata = JSON.parse(result.view.private_metadata);
+      expect(metadata.carry).toEqual({ list_id: 'list-1', class_display: 'Grade 3 - A' });
+    });
+
+    it('onFinish posts the success_message to the Slack user on the terminal screen', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const attendanceEndpoint = require('../../bot/shared/routes/attendance-setup-endpoint');
+      attendanceEndpoint.handleSetupDataExchange.mockResolvedValueOnce({
+        screen: 'SUCCESS', data: { success_message: 'Class ready with 3 students.' },
+      });
+      const slackWebClient = require('../../bot/shared/services/messaging/slack-web-client');
+
+      const renderer = registry.get('attendance');
+      const ctx = { userId: 'u1', flowToken: 'u1:attendance:169', slackUserId: 'U0123ABC' };
+      const result = await renderer.handleSubmission(ctx, 'ADD_STUDENT', {
+        first_name_block: { first_name: { value: 'Zara' } },
+        last_name_block: { last_name: { value: '' } },
+      });
+
+      expect(result).toEqual({ response_action: 'clear' });
+      expect(slackWebClient.postMessage).toHaveBeenCalledWith('U0123ABC', 'Class ready with 3 students.');
+    });
+  });
+
+  describe('exam_confirm renderer', () => {
+    it('calls handleExamConfirmInit with the session id passed as flowToken (not a minted token)', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const { handleExamConfirmInit } = require('../../bot/shared/routes/exam-confirm-endpoint');
+
+      const renderer = registry.get('exam_confirm');
+      await renderer.buildInitialView({ userId: null, flowToken: 'session-1' });
+
+      expect(handleExamConfirmInit).toHaveBeenCalledWith('session-1');
+    });
+
+    it('onFinish looks up the session by id and hands off to ExamCheckerOrchestrator.process with the confirmed students', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const ExamSessionService = require('../../bot/shared/services/exam-checker/exam-session.service');
+      const { ExamCheckerOrchestrator } = require('../../bot/shared/services/exam-checker/exam-checker.orchestrator');
+
+      const renderer = registry.get('exam_confirm');
+      const ctx = { userId: null, flowToken: 'session-1', slackUserId: 'U0123ABC' };
+      const result = await renderer.handleSubmission(ctx, 'CONFIRM_STUDENTS', {
+        confirmed_students_block: { confirmed_students: { selected_options: [{ value: '0' }] } },
+      });
+
+      expect(result).toEqual({ response_action: 'clear' });
+      expect(ExamSessionService.getById).toHaveBeenCalledWith('session-1');
+      expect(ExamCheckerOrchestrator.process).toHaveBeenCalledWith(
+        { type: 'flow', flowResponse: { confirmed_students: ['0'] } },
+        'u1',
+        'slack:U0123ABC',
+      );
+    });
+
+    it('onFinish is a no-op when the session no longer exists (expired/deleted)', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const ExamSessionService = require('../../bot/shared/services/exam-checker/exam-session.service');
+      ExamSessionService.getById.mockResolvedValueOnce(null);
+      const { ExamCheckerOrchestrator } = require('../../bot/shared/services/exam-checker/exam-checker.orchestrator');
+
+      const renderer = registry.get('exam_confirm');
+      const ctx = { userId: null, flowToken: 'session-gone', slackUserId: 'U0123ABC' };
+      await renderer.handleSubmission(ctx, 'CONFIRM_STUDENTS', {});
+
+      expect(ExamCheckerOrchestrator.process).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/routes/slack-interactions-routes.test.js
+++ b/tests/routes/slack-interactions-routes.test.js
@@ -22,6 +22,13 @@ function loadRouter() {
   jest.resetModules();
   process.env.SLACK_SIGNING_SECRET = SIGNING_SECRET;
   jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  // slack-interactions.routes.js requires slack-modal-interactions.handler.js,
+  // which requires bot-helpers.js -> the real config/supabase.js ->
+  // @supabase/supabase-js — a bot/-only dependency CI installs AFTER root
+  // `npm test` runs (see CLAUDE.md's "TDD" note). Mocking supabase here, same
+  // as every other suite that touches bot-helpers.js, keeps this test from
+  // needing that package installed at all.
+  jest.doMock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
   const dispatch = jest.fn().mockResolvedValue(undefined);
   const mountSlackRoutes = require('../../bot/shared/routes/slack-interactions.routes');
   const router = mountSlackRoutes(dispatch);

--- a/tests/routes/slack-interactions-routes.test.js
+++ b/tests/routes/slack-interactions-routes.test.js
@@ -220,4 +220,34 @@ describe('slack-interactions.routes — /interactions', () => {
     // never falls through to the ordinary chat interactivity dispatch.
     expect(dispatch).not.toHaveBeenCalled();
   });
+
+  it('routes a block_actions "country_bucket_select" click to the modal machinery instead of the ordinary chat handler', async () => {
+    // Regression coverage for the registration country-picker fix (Slack's
+    // static_select 100-option cap made registration fail every time) —
+    // confirms the route layer recognizes and dispatches this action_id at
+    // all; handleCountryBucketChange's own behavior is covered by
+    // slack-modal-interactions-handler.test.js.
+    const { router, dispatch } = loadRouter();
+    const payloadObj = {
+      type: 'block_actions',
+      user: { id: 'U0123ABC' },
+      view: { id: 'V0123VIEW', private_metadata: JSON.stringify({ kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'db-user-1:registration:169' }) },
+      actions: [{ action_id: 'country_bucket_select', selected_option: { value: 'europe' } }],
+    };
+    const rawBody = `payload=${encodeURIComponent(JSON.stringify(payloadObj))}`;
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': sign(timestamp, rawBody),
+      },
+      rawBody: Buffer.from(rawBody),
+      path: '/interactions',
+    };
+
+    const { calls } = await invokeRoute(router, 'post', '/interactions', req);
+    expect(calls.status).toEqual([200]);
+    expect(calls.send).toEqual(['']);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });

--- a/tests/routes/slack-interactions-routes.test.js
+++ b/tests/routes/slack-interactions-routes.test.js
@@ -193,4 +193,31 @@ describe('slack-interactions.routes — /interactions', () => {
     expect(calls.status).toEqual([401]);
     expect(dispatch).not.toHaveBeenCalled();
   });
+
+  it('routes a block_actions "attendance_finish" click to the modal machinery instead of the ordinary chat handler', async () => {
+    const { router, dispatch } = loadRouter();
+    const payloadObj = {
+      type: 'block_actions',
+      user: { id: 'U0123ABC' },
+      view: { id: 'V0123VIEW', private_metadata: JSON.stringify({ kind: 'attendance', screen: 'ADD_STUDENT', flowToken: 'db-user-1:attendance:169' }) },
+      actions: [{ action_id: 'attendance_finish' }],
+    };
+    const rawBody = `payload=${encodeURIComponent(JSON.stringify(payloadObj))}`;
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': sign(timestamp, rawBody),
+      },
+      rawBody: Buffer.from(rawBody),
+      path: '/interactions',
+    };
+
+    const { calls } = await invokeRoute(router, 'post', '/interactions', req);
+    // acked immediately, same as open_modal/back — the actual modal update is a separate API call.
+    expect(calls.status).toEqual([200]);
+    expect(calls.send).toEqual(['']);
+    // never falls through to the ordinary chat interactivity dispatch.
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });

--- a/tests/routes/slack-interactions-routes.test.js
+++ b/tests/routes/slack-interactions-routes.test.js
@@ -103,6 +103,48 @@ describe('slack-interactions.routes — /events', () => {
   });
 });
 
+describe('slack-interactions.routes — /commands', () => {
+  it('verifies the signature, parses the top-level form-encoded command body, and dispatches', async () => {
+    const { router, dispatch } = loadRouter();
+    const rawBody = 'command=%2Fquiz&text=fractions+for+grade+5&user_id=U0123ABC';
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': sign(timestamp, rawBody),
+      },
+      rawBody: Buffer.from(rawBody),
+      path: '/commands',
+    };
+
+    const { calls } = await invokeRoute(router, 'post', '/commands', req);
+    expect(calls.status).toEqual([200]);
+    expect(calls.send).toEqual(['']);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [dispatchReq] = dispatch.mock.calls[0];
+    expect(dispatchReq.body.entry[0].changes[0].value.messages[0]).toEqual(
+      expect.objectContaining({ from: 'slack:U0123ABC', type: 'text', text: { body: '/quiz fractions for grade 5' } })
+    );
+  });
+
+  it('rejects an incorrectly-signed slash command request with 401, never dispatching', async () => {
+    const { router, dispatch } = loadRouter();
+    const rawBody = 'command=%2Fmenu&text=&user_id=U0123ABC';
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': String(Math.floor(Date.now() / 1000)),
+        'x-slack-signature': 'v0=deadbeef',
+      },
+      rawBody: Buffer.from(rawBody),
+      path: '/commands',
+    };
+
+    const { calls } = await invokeRoute(router, 'post', '/commands', req);
+    expect(calls.status).toEqual([401]);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
 describe('slack-interactions.routes — /interactions', () => {
   it('verifies the signature, parses the form-encoded payload, and dispatches', async () => {
     const { router, dispatch } = loadRouter();

--- a/tests/routes/slack-interactions-routes.test.js
+++ b/tests/routes/slack-interactions-routes.test.js
@@ -1,0 +1,147 @@
+/**
+ * slack-interactions.routes.js — the route-layer wiring: signature
+ * verification runs BEFORE any dispatch, and the two content-type shapes
+ * (Events API JSON vs Interactivity form-encoded `payload`) are parsed
+ * correctly before handing off to the inbound adapter.
+ *
+ * Exercised as plain Express middleware functions (not over a real HTTP
+ * server) — mirrors this repo's existing route-test style for
+ * flow-endpoint.routes.js.
+ */
+
+const crypto = require('crypto');
+
+const SIGNING_SECRET = 'test-signing-secret';
+
+function sign(timestamp, rawBody) {
+  const base = `v0:${timestamp}:${rawBody}`;
+  return 'v0=' + crypto.createHmac('sha256', SIGNING_SECRET).update(base).digest('hex');
+}
+
+function loadRouter() {
+  jest.resetModules();
+  process.env.SLACK_SIGNING_SECRET = SIGNING_SECRET;
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  const dispatch = jest.fn().mockResolvedValue(undefined);
+  const mountSlackRoutes = require('../../bot/shared/routes/slack-interactions.routes');
+  const router = mountSlackRoutes(dispatch);
+  return { router, dispatch };
+}
+
+afterEach(() => {
+  delete process.env.SLACK_SIGNING_SECRET;
+  jest.resetModules();
+});
+
+/** Finds the layer handling `method`+`path` on an Express Router, and invokes its stack of handlers in order. */
+async function invokeRoute(router, method, urlPath, req) {
+  const layer = router.stack.find(
+    (l) => l.route && l.route.path === urlPath && l.route.methods[method]
+  );
+  if (!layer) throw new Error(`No route registered for ${method.toUpperCase()} ${urlPath}`);
+
+  const calls = { status: [], json: [], send: [] };
+  const res = {
+    status(code) { calls.status.push(code); return res; },
+    json(body) { calls.json.push(body); return res; },
+    send(body) { calls.send.push(body); return res; },
+  };
+
+  for (const handler of layer.route.stack) {
+    let nextCalled = false;
+    await new Promise((resolve, reject) => {
+      const next = () => { nextCalled = true; resolve(); };
+      Promise.resolve(handler.handle(req, res, next)).then(() => {
+        if (!nextCalled) resolve();
+      }).catch(reject);
+    });
+    if (!nextCalled) break; // a handler that didn't call next() ended the chain (e.g. sent a response)
+  }
+
+  return { res, calls };
+}
+
+describe('slack-interactions.routes — /events', () => {
+  it('verifies the signature and dispatches on a correctly-signed Events API request', async () => {
+    const { router, dispatch } = loadRouter();
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const rawBody = JSON.stringify({
+      type: 'event_callback',
+      event_id: 'Ev001',
+      event: { type: 'message', user: 'U0123ABC', text: 'hi', ts: '169.001' },
+    });
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': sign(timestamp, rawBody),
+      },
+      rawBody: Buffer.from(rawBody),
+      path: '/events',
+    };
+
+    const { calls } = await invokeRoute(router, 'post', '/events', req);
+    expect(calls.status).toContain(200);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an incorrectly-signed request with 401, never dispatching', async () => {
+    const { router, dispatch } = loadRouter();
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const rawBody = JSON.stringify({ type: 'event_callback', event_id: 'Ev002', event: {} });
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': 'v0=deadbeef',
+      },
+      rawBody: Buffer.from(rawBody),
+      path: '/events',
+    };
+
+    const { calls } = await invokeRoute(router, 'post', '/events', req);
+    expect(calls.status).toEqual([401]);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('slack-interactions.routes — /interactions', () => {
+  it('verifies the signature, parses the form-encoded payload, and dispatches', async () => {
+    const { router, dispatch } = loadRouter();
+    const payloadObj = {
+      type: 'block_actions',
+      user: { id: 'U0123ABC' },
+      container: { message_ts: '169.010' },
+      actions: [{ type: 'button', value: 'menu_video', text: { text: 'Video' } }],
+    };
+    const rawBody = `payload=${encodeURIComponent(JSON.stringify(payloadObj))}`;
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': sign(timestamp, rawBody),
+      },
+      rawBody: Buffer.from(rawBody),
+      path: '/interactions',
+    };
+
+    const { calls } = await invokeRoute(router, 'post', '/interactions', req);
+    expect(calls.status).toContain(200);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an incorrectly-signed interactivity request with 401', async () => {
+    const { router, dispatch } = loadRouter();
+    const rawBody = 'payload=%7B%7D';
+    const req = {
+      headers: {
+        'x-slack-request-timestamp': String(Math.floor(Date.now() / 1000)),
+        'x-slack-signature': 'v0=deadbeef',
+      },
+      rawBody: Buffer.from(rawBody),
+      path: '/interactions',
+    };
+
+    const { calls } = await invokeRoute(router, 'post', '/interactions', req);
+    expect(calls.status).toEqual([401]);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/routes/slack-interactions-routes.test.js
+++ b/tests/routes/slack-interactions-routes.test.js
@@ -28,7 +28,7 @@ function loadRouter() {
   // `npm test` runs (see CLAUDE.md's "TDD" note). Mocking supabase here, same
   // as every other suite that touches bot-helpers.js, keeps this test from
   // needing that package installed at all.
-  jest.doMock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }));
+  jest.doMock('../../bot/shared/config/supabase', () => ({ from: jest.fn() }), { virtual: true });
   const dispatch = jest.fn().mockResolvedValue(undefined);
   const mountSlackRoutes = require('../../bot/shared/routes/slack-interactions.routes');
   const router = mountSlackRoutes(dispatch);

--- a/tests/routes/slack-modal-interactions-handler.test.js
+++ b/tests/routes/slack-modal-interactions-handler.test.js
@@ -1,0 +1,141 @@
+/**
+ * slack-modal-interactions.handler.js — dispatches the three
+ * modal-specific Slack interaction shapes: opening the first modal,
+ * the Back button, and view_submission.
+ */
+
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/database/bot-helpers', () => ({
+  getOrCreateUserByChannel: jest.fn(async () => ({ id: 'db-user-1' })),
+}));
+
+function loadHandler({ renderer } = {}) {
+  jest.resetModules();
+  const flowRegistry = {
+    ensureRegistered: jest.fn(),
+    get: jest.fn(() => renderer),
+    buildFlowToken: jest.fn((userId, kind) => `${userId}:${kind}:169`),
+  };
+  jest.doMock('../../bot/shared/routes/slack-flow-registry', () => flowRegistry);
+
+  const slackWebClient = {
+    openView: jest.fn().mockResolvedValue(undefined),
+    updateView: jest.fn().mockResolvedValue(undefined),
+    postMessage: jest.fn().mockResolvedValue(undefined),
+  };
+  jest.doMock('../../bot/shared/services/messaging/slack-web-client', () => slackWebClient);
+
+  const handler = require('../../bot/shared/routes/slack-modal-interactions.handler');
+  const { getOrCreateUserByChannel } = require('../../bot/shared/database/bot-helpers');
+  return { handler, flowRegistry, slackWebClient, getOrCreateUserByChannel };
+}
+
+describe('isOpenModalAction / isBackAction', () => {
+  it('recognizes the open_modal: prefix and the _back suffix', () => {
+    const { handler } = loadHandler();
+    expect(handler.isOpenModalAction('open_modal:registration')).toBe(true);
+    expect(handler.isOpenModalAction('menu_lesson_plan')).toBe(false);
+    expect(handler.isBackAction('registration_back')).toBe(true);
+    expect(handler.isBackAction('registration')).toBe(false);
+  });
+});
+
+describe('handleOpenModal', () => {
+  it('returns false for a payload whose action is not open_modal:', async () => {
+    const { handler } = loadHandler();
+    const handled = await handler.handleOpenModal({ actions: [{ action_id: 'menu_lesson_plan' }] });
+    expect(handled).toBe(false);
+  });
+
+  it('resolves the DB user, mints a flow token, and opens the initial view via trigger_id', async () => {
+    const renderer = { buildInitialView: jest.fn().mockResolvedValue({ type: 'modal' }) };
+    const { handler, getOrCreateUserByChannel, slackWebClient, flowRegistry } = loadHandler({ renderer });
+
+    const payload = {
+      trigger_id: 'trigger-123',
+      user: { id: 'U0123ABC' },
+      actions: [{ action_id: 'open_modal:registration' }],
+    };
+    const handled = await handler.handleOpenModal(payload);
+
+    expect(handled).toBe(true);
+    expect(getOrCreateUserByChannel).toHaveBeenCalledWith('slack', 'U0123ABC');
+    expect(flowRegistry.buildFlowToken).toHaveBeenCalledWith('db-user-1', 'registration');
+    expect(renderer.buildInitialView).toHaveBeenCalledWith({
+      userId: 'db-user-1', slackUserId: 'U0123ABC', flowToken: 'db-user-1:registration:169',
+    });
+    expect(slackWebClient.openView).toHaveBeenCalledWith('trigger-123', { type: 'modal' });
+  });
+
+  it('does not throw when no renderer is registered for the kind — logs and returns true (handled, nothing to open)', async () => {
+    const { handler } = loadHandler({ renderer: undefined });
+    const handled = await handler.handleOpenModal({
+      trigger_id: 't', user: { id: 'U1' }, actions: [{ action_id: 'open_modal:unknown_kind' }],
+    });
+    expect(handled).toBe(true);
+  });
+});
+
+describe('handleBackButton', () => {
+  it('returns false for a payload whose action is not a *_back action', async () => {
+    const { handler } = loadHandler();
+    const handled = await handler.handleBackButton({ actions: [{ action_id: 'menu_lesson_plan' }] });
+    expect(handled).toBe(false);
+  });
+
+  it('calls the renderer\'s handleBack and updates the current view via view.id', async () => {
+    const renderer = { handleBack: jest.fn().mockResolvedValue({ type: 'modal', screen: 'PERSONAL_INFO' }) };
+    const { handler, slackWebClient } = loadHandler({ renderer });
+
+    const metadata = JSON.stringify({ kind: 'registration', screen: 'PROFESSIONAL_INFO', flowToken: 'db-user-1:registration:169' });
+    const payload = {
+      user: { id: 'U0123ABC' },
+      view: { id: 'V0123VIEW', private_metadata: metadata },
+      actions: [{ action_id: 'registration_back' }],
+    };
+    const handled = await handler.handleBackButton(payload);
+
+    expect(handled).toBe(true);
+    expect(renderer.handleBack).toHaveBeenCalledWith(
+      { userId: 'db-user-1', slackUserId: 'U0123ABC', flowToken: 'db-user-1:registration:169' },
+      'PROFESSIONAL_INFO'
+    );
+    expect(slackWebClient.updateView).toHaveBeenCalledWith('V0123VIEW', { type: 'modal', screen: 'PERSONAL_INFO' });
+  });
+});
+
+describe('handleViewSubmission', () => {
+  it('resolves kind/screen/flowToken from private_metadata and calls the renderer\'s handleSubmission', async () => {
+    const renderer = { handleSubmission: jest.fn().mockResolvedValue({ response_action: 'push', view: {} }) };
+    const { handler } = loadHandler({ renderer });
+
+    const metadata = JSON.stringify({ kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'db-user-1:registration:169' });
+    const payload = {
+      user: { id: 'U0123ABC' },
+      view: { private_metadata: metadata, state: { values: { some: 'values' } } },
+    };
+    const result = await handler.handleViewSubmission(payload);
+
+    expect(renderer.handleSubmission).toHaveBeenCalledWith(
+      { userId: 'db-user-1', slackUserId: 'U0123ABC', flowToken: 'db-user-1:registration:169' },
+      'PERSONAL_INFO',
+      { some: 'values' },
+    );
+    expect(result).toEqual({ response_action: 'push', view: {} });
+  });
+
+  it('returns null when no renderer is registered for the decoded kind', async () => {
+    const { handler } = loadHandler({ renderer: undefined });
+    const metadata = JSON.stringify({ kind: 'unknown', screen: 'X', flowToken: 't' });
+    const result = await handler.handleViewSubmission({ user: { id: 'U1' }, view: { private_metadata: metadata } });
+    expect(result).toBeNull();
+  });
+
+  it('returns a safe errors response_action if the renderer throws', async () => {
+    const renderer = { handleSubmission: jest.fn().mockRejectedValue(new Error('boom')) };
+    const { handler } = loadHandler({ renderer });
+    const metadata = JSON.stringify({ kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 't' });
+    const result = await handler.handleViewSubmission({ user: { id: 'U1' }, view: { private_metadata: metadata, state: { values: {} } } });
+    expect(result).toEqual({ response_action: 'errors', errors: {} });
+  });
+});

--- a/tests/routes/slack-modal-interactions-handler.test.js
+++ b/tests/routes/slack-modal-interactions-handler.test.js
@@ -30,13 +30,42 @@ function loadHandler({ renderer } = {}) {
   return { handler, flowRegistry, slackWebClient, getOrCreateUserByChannel };
 }
 
-describe('isOpenModalAction / isBackAction', () => {
+describe('isOpenModalAction / isBackAction / isAttendanceFinishAction', () => {
   it('recognizes the open_modal: prefix and the _back suffix', () => {
     const { handler } = loadHandler();
     expect(handler.isOpenModalAction('open_modal:registration')).toBe(true);
     expect(handler.isOpenModalAction('menu_lesson_plan')).toBe(false);
     expect(handler.isBackAction('registration_back')).toBe(true);
     expect(handler.isBackAction('registration')).toBe(false);
+  });
+
+  it('recognizes exactly the attendance_finish action_id, nothing else', () => {
+    const { handler } = loadHandler();
+    expect(handler.isAttendanceFinishAction('attendance_finish')).toBe(true);
+    expect(handler.isAttendanceFinishAction('open_modal:attendance')).toBe(false);
+    expect(handler.isAttendanceFinishAction('attendance_finish_extra')).toBe(false);
+  });
+});
+
+describe('parseOpenModalAction', () => {
+  it('splits a plain "open_modal:<kind>" action_id with no embedded session id', () => {
+    const { handler } = loadHandler();
+    expect(handler.parseOpenModalAction('open_modal:registration')).toEqual({ kind: 'registration', sessionId: null });
+    expect(handler.parseOpenModalAction('open_modal:attendance')).toEqual({ kind: 'attendance', sessionId: null });
+  });
+
+  it('splits "open_modal:exam_confirm:<sessionId>" on the FIRST colon after the prefix', () => {
+    const { handler } = loadHandler();
+    expect(handler.parseOpenModalAction('open_modal:exam_confirm:sess-123')).toEqual({
+      kind: 'exam_confirm', sessionId: 'sess-123',
+    });
+  });
+
+  it('keeps every colon after the first as part of the sessionId (a UUID-shaped id has none, but this must not truncate if one ever did)', () => {
+    const { handler } = loadHandler();
+    expect(handler.parseOpenModalAction('open_modal:exam_confirm:sess:with:colons')).toEqual({
+      kind: 'exam_confirm', sessionId: 'sess:with:colons',
+    });
   });
 });
 
@@ -73,6 +102,114 @@ describe('handleOpenModal', () => {
       trigger_id: 't', user: { id: 'U1' }, actions: [{ action_id: 'open_modal:unknown_kind' }],
     });
     expect(handled).toBe(true);
+  });
+
+  it('exam_confirm: uses the embedded sessionId directly as flowToken, never calling buildFlowToken or getOrCreateUserByChannel', async () => {
+    const renderer = { buildInitialView: jest.fn().mockResolvedValue({ type: 'modal' }) };
+    const { handler, getOrCreateUserByChannel, slackWebClient, flowRegistry } = loadHandler({ renderer });
+
+    const payload = {
+      trigger_id: 'trigger-456',
+      user: { id: 'U0123ABC' },
+      actions: [{ action_id: 'open_modal:exam_confirm:sess-789' }],
+    };
+    const handled = await handler.handleOpenModal(payload);
+
+    expect(handled).toBe(true);
+    expect(getOrCreateUserByChannel).not.toHaveBeenCalled();
+    expect(flowRegistry.buildFlowToken).not.toHaveBeenCalled();
+    expect(renderer.buildInitialView).toHaveBeenCalledWith({
+      userId: null, slackUserId: 'U0123ABC', flowToken: 'sess-789',
+    });
+    expect(slackWebClient.openView).toHaveBeenCalledWith('trigger-456', { type: 'modal' });
+  });
+
+  it('every other kind (attendance) still mints a fresh DB-user-keyed flowToken — the sessionId fix is additive, not a regression', async () => {
+    const renderer = { buildInitialView: jest.fn().mockResolvedValue({ type: 'modal' }) };
+    const { handler, getOrCreateUserByChannel, flowRegistry } = loadHandler({ renderer });
+
+    const payload = {
+      trigger_id: 'trigger-789',
+      user: { id: 'U0999XYZ' },
+      actions: [{ action_id: 'open_modal:attendance' }],
+    };
+    await handler.handleOpenModal(payload);
+
+    expect(getOrCreateUserByChannel).toHaveBeenCalledWith('slack', 'U0999XYZ');
+    expect(flowRegistry.buildFlowToken).toHaveBeenCalledWith('db-user-1', 'attendance');
+    expect(renderer.buildInitialView).toHaveBeenCalledWith({
+      userId: 'db-user-1', slackUserId: 'U0999XYZ', flowToken: 'db-user-1:attendance:169',
+    });
+  });
+});
+
+describe('handleAttendanceFinish', () => {
+  function mockAttendanceEndpoint(handleDoneAction) {
+    jest.doMock('../../bot/shared/routes/attendance-setup-endpoint', () => ({ handleDoneAction }));
+  }
+
+  it('returns false for a payload whose action is not attendance_finish', async () => {
+    const { handler } = loadHandler();
+    const handled = await handler.handleAttendanceFinish({ actions: [{ action_id: 'menu_lesson_plan' }] });
+    expect(handled).toBe(false);
+  });
+
+  it('recovers {list_id, class_display} from private_metadata\'s carry field and calls handleDoneAction directly', async () => {
+    const handleDoneAction = jest.fn().mockResolvedValue({ screen: 'SUCCESS', data: { success_message: 'Class ready with 2 students.' } });
+    mockAttendanceEndpoint(handleDoneAction);
+    const { handler, slackWebClient } = loadHandler();
+
+    const metadata = JSON.stringify({
+      kind: 'attendance', screen: 'ADD_STUDENT', flowToken: 'db-user-1:attendance:169',
+      carry: { list_id: 'list-1', class_display: 'Grade 3 - A' },
+    });
+    const payload = {
+      user: { id: 'U0123ABC' },
+      view: { id: 'V0123VIEW', private_metadata: metadata },
+      actions: [{ action_id: 'attendance_finish' }],
+    };
+    const handled = await handler.handleAttendanceFinish(payload);
+
+    expect(handled).toBe(true);
+    expect(handleDoneAction).toHaveBeenCalledWith('list-1', 'Grade 3 - A');
+    expect(slackWebClient.postMessage).toHaveBeenCalledWith('U0123ABC', 'Class ready with 2 students.');
+  });
+
+  it('reopens ADD_STUDENT with the error when handleDoneAction rejects (no students added yet)', async () => {
+    const handleDoneAction = jest.fn().mockResolvedValue({
+      screen: 'ADD_STUDENT',
+      data: { list_id: 'list-1', class_display: 'Grade 3 - A', heading: 'Add Student #1', error: { message: 'Please add at least one student.' } },
+    });
+    mockAttendanceEndpoint(handleDoneAction);
+    const { handler, slackWebClient } = loadHandler();
+
+    const metadata = JSON.stringify({
+      kind: 'attendance', screen: 'ADD_STUDENT', flowToken: 'db-user-1:attendance:169',
+      carry: { list_id: 'list-1', class_display: 'Grade 3 - A' },
+    });
+    const payload = {
+      user: { id: 'U0123ABC' },
+      view: { id: 'V0123VIEW', private_metadata: metadata },
+      actions: [{ action_id: 'attendance_finish' }],
+    };
+    const handled = await handler.handleAttendanceFinish(payload);
+
+    expect(handled).toBe(true);
+    expect(slackWebClient.postMessage).not.toHaveBeenCalled();
+    expect(slackWebClient.updateView).toHaveBeenCalledWith('V0123VIEW', expect.objectContaining({ title: expect.objectContaining({ text: 'Add Student #1' }) }));
+  });
+
+  it('does not throw if handleDoneAction itself throws', async () => {
+    mockAttendanceEndpoint(jest.fn().mockRejectedValue(new Error('boom')));
+    const { handler } = loadHandler();
+
+    const metadata = JSON.stringify({ kind: 'attendance', screen: 'ADD_STUDENT', flowToken: 't', carry: { list_id: 'list-1', class_display: 'X' } });
+    const payload = {
+      user: { id: 'U1' },
+      view: { id: 'V1', private_metadata: metadata },
+      actions: [{ action_id: 'attendance_finish' }],
+    };
+    await expect(handler.handleAttendanceFinish(payload)).resolves.toBe(true);
   });
 });
 
@@ -120,6 +257,7 @@ describe('handleViewSubmission', () => {
       { userId: 'db-user-1', slackUserId: 'U0123ABC', flowToken: 'db-user-1:registration:169' },
       'PERSONAL_INFO',
       { some: 'values' },
+      undefined,
     );
     expect(result).toEqual({ response_action: 'push', view: {} });
   });

--- a/tests/routes/slack-modal-interactions-handler.test.js
+++ b/tests/routes/slack-modal-interactions-handler.test.js
@@ -45,6 +45,13 @@ describe('isOpenModalAction / isBackAction / isAttendanceFinishAction', () => {
     expect(handler.isAttendanceFinishAction('open_modal:attendance')).toBe(false);
     expect(handler.isAttendanceFinishAction('attendance_finish_extra')).toBe(false);
   });
+
+  it('recognizes exactly the country_bucket_select action_id, nothing else', () => {
+    const { handler } = loadHandler();
+    expect(handler.isCountryBucketAction('country_bucket_select')).toBe(true);
+    expect(handler.isCountryBucketAction('country')).toBe(false);
+    expect(handler.isCountryBucketAction('registration_back')).toBe(false);
+  });
 });
 
 describe('parseOpenModalAction', () => {
@@ -210,6 +217,76 @@ describe('handleAttendanceFinish', () => {
       actions: [{ action_id: 'attendance_finish' }],
     };
     await expect(handler.handleAttendanceFinish(payload)).resolves.toBe(true);
+  });
+});
+
+describe('handleCountryBucketChange', () => {
+  // Regression coverage for a real, confirmed bug: registration's PERSONAL_INFO
+  // country field had a single static_select over all 164 countries, exceeding
+  // Slack's 100-option cap — registration failed 100% of the time. This
+  // handler is the live-update side of the fix (see slack-views/registration.view.js).
+
+  it('returns false for a payload whose action is not country_bucket_select', async () => {
+    const { handler } = loadHandler();
+    const handled = await handler.handleCountryBucketChange({ actions: [{ action_id: 'menu_lesson_plan' }] });
+    expect(handled).toBe(false);
+  });
+
+  it('is a no-op (but still handled) for any kind/screen other than registration/PERSONAL_INFO', async () => {
+    const { handler, slackWebClient } = loadHandler();
+    const metadata = JSON.stringify({ kind: 'attendance', screen: 'CLASS_INFO', flowToken: 't' });
+    const payload = {
+      user: { id: 'U1' },
+      view: { id: 'V1', private_metadata: metadata },
+      actions: [{ action_id: 'country_bucket_select', selected_option: { value: 'europe' } }],
+    };
+    const handled = await handler.handleCountryBucketChange(payload);
+    expect(handled).toBe(true);
+    expect(slackWebClient.updateView).not.toHaveBeenCalled();
+  });
+
+  it('live-updates the open modal with the country field filtered to the newly-picked bucket, preserving the typed full name', async () => {
+    const { handler, slackWebClient } = loadHandler();
+    const metadata = JSON.stringify({ kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'db-user-1:registration:169' });
+    const payload = {
+      user: { id: 'U0123ABC' },
+      view: {
+        id: 'V0123VIEW',
+        private_metadata: metadata,
+        state: { values: { full_name_block: { full_name: { value: 'Ayesha Khan' } } } },
+      },
+      actions: [{ action_id: 'country_bucket_select', selected_option: { value: 'europe' } }],
+    };
+    const handled = await handler.handleCountryBucketChange(payload);
+
+    expect(handled).toBe(true);
+    expect(slackWebClient.updateView).toHaveBeenCalledTimes(1);
+    const [viewId, view] = slackWebClient.updateView.mock.calls[0];
+    expect(viewId).toBe('V0123VIEW');
+    expect(view.private_metadata).toBe(metadata); // unchanged — flowToken/kind/screen still round-trip
+
+    const nameBlock = view.blocks.find((b) => b.block_id === 'full_name_block');
+    expect(nameBlock.element.initial_value).toBe('Ayesha Khan');
+
+    const bucketBlock = view.blocks.find((b) => b.block_id === 'country_bucket_block');
+    expect(bucketBlock.element.initial_option.value).toBe('europe');
+
+    const countryBlock = view.blocks.find((b) => b.block_id === 'country_block');
+    expect(countryBlock.element.options.length).toBeGreaterThan(0);
+    expect(countryBlock.element.options.length).toBeLessThanOrEqual(100);
+    expect(countryBlock.element.options.find((o) => o.value === 'DE')).toBeTruthy(); // Germany is in the europe bucket
+  });
+
+  it('does not throw when the live update itself fails', async () => {
+    const { handler, slackWebClient } = loadHandler();
+    slackWebClient.updateView.mockRejectedValueOnce(new Error('boom'));
+    const metadata = JSON.stringify({ kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 't' });
+    const payload = {
+      user: { id: 'U1' },
+      view: { id: 'V1', private_metadata: metadata, state: { values: {} } },
+      actions: [{ action_id: 'country_bucket_select', selected_option: { value: 'europe' } }],
+    };
+    await expect(handler.handleCountryBucketChange(payload)).resolves.toBe(true);
   });
 });
 

--- a/tests/routes/slack-routed-interactions-handler.test.js
+++ b/tests/routes/slack-routed-interactions-handler.test.js
@@ -1,0 +1,114 @@
+/**
+ * slack-interactions.routes.js's makeRoutedInteractionsHandler — the
+ * dispatch fork between view_submission, modal open/back block_actions,
+ * and ordinary chat block_actions. Exercised directly against the
+ * exported mount() function's internal handler (via a constructed router),
+ * with slack-modal-interactions.handler and the inbound adapter mocked so
+ * this test is pure dispatch-logic, not integration.
+ */
+
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/services/slack-signature.service', () => ({
+  isConfigured: jest.fn(() => true),
+  verify: jest.fn(() => true),
+}));
+
+function loadRoutedHandler() {
+  jest.resetModules();
+
+  const modalInteractions = {
+    isOpenModalAction: (id) => typeof id === 'string' && id.startsWith('open_modal:'),
+    isBackAction: (id) => typeof id === 'string' && id.endsWith('_back'),
+    handleOpenModal: jest.fn().mockResolvedValue(true),
+    handleBackButton: jest.fn().mockResolvedValue(true),
+    handleViewSubmission: jest.fn().mockResolvedValue({ response_action: 'clear' }),
+  };
+  jest.doMock('../../bot/shared/routes/slack-modal-interactions.handler', () => modalInteractions);
+
+  const chatHandler = jest.fn().mockImplementation(async (req, res) => res.status(200).send(''));
+  jest.doMock('../../bot/shared/services/messaging/inbound/slack-events.adapter', () => ({
+    makeEventsHandler: jest.fn(() => async (req, res) => res.status(200).send('')),
+    makeInteractionsHandler: jest.fn(() => chatHandler),
+  }));
+
+  const mount = require('../../bot/shared/routes/slack-interactions.routes');
+  const dispatch = jest.fn();
+  const router = mount(dispatch);
+  const interactionsLayer = router.stack.find((l) => l.route?.path === '/interactions');
+  // Last handler in the stack is the routed handler itself (after verifyAndParse).
+  const routedHandler = interactionsLayer.route.stack[interactionsLayer.route.stack.length - 1].handle;
+
+  return { routedHandler, modalInteractions, chatHandler };
+}
+
+function fakeRes() {
+  const calls = { status: [], json: [], send: [] };
+  const res = {
+    status(code) { calls.status.push(code); return res; },
+    json(body) { calls.json.push(body); return res; },
+    send(body) { calls.send.push(body); return res; },
+  };
+  res._calls = calls;
+  return res;
+}
+
+describe('makeRoutedInteractionsHandler dispatch', () => {
+  it('routes view_submission to handleViewSubmission and returns its response_action as JSON', async () => {
+    const { routedHandler, modalInteractions } = loadRoutedHandler();
+    const req = { body: { payload: JSON.stringify({ type: 'view_submission' }) } };
+    const res = fakeRes();
+
+    await routedHandler(req, res);
+
+    expect(modalInteractions.handleViewSubmission).toHaveBeenCalledTimes(1);
+    expect(res._calls.status).toEqual([200]);
+    expect(res._calls.json).toEqual([{ response_action: 'clear' }]);
+  });
+
+  it('routes an open_modal: block_actions to handleOpenModal, acking 200 immediately', async () => {
+    const { routedHandler, modalInteractions, chatHandler } = loadRoutedHandler();
+    const req = { body: { payload: JSON.stringify({ type: 'block_actions', actions: [{ action_id: 'open_modal:registration' }] }) } };
+    const res = fakeRes();
+
+    await routedHandler(req, res);
+
+    expect(modalInteractions.handleOpenModal).toHaveBeenCalledTimes(1);
+    expect(chatHandler).not.toHaveBeenCalled();
+    expect(res._calls.status).toEqual([200]);
+  });
+
+  it('routes a *_back block_actions to handleBackButton', async () => {
+    const { routedHandler, modalInteractions, chatHandler } = loadRoutedHandler();
+    const req = { body: { payload: JSON.stringify({ type: 'block_actions', actions: [{ action_id: 'registration_back' }] }) } };
+    const res = fakeRes();
+
+    await routedHandler(req, res);
+
+    expect(modalInteractions.handleBackButton).toHaveBeenCalledTimes(1);
+    expect(chatHandler).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the ordinary chat handler for a ordinary block_actions click', async () => {
+    const { routedHandler, modalInteractions, chatHandler } = loadRoutedHandler();
+    const req = { body: { payload: JSON.stringify({ type: 'block_actions', actions: [{ action_id: 'menu_lesson_plan' }] }) } };
+    const res = fakeRes();
+
+    await routedHandler(req, res);
+
+    expect(modalInteractions.handleOpenModal).not.toHaveBeenCalled();
+    expect(modalInteractions.handleBackButton).not.toHaveBeenCalled();
+    expect(chatHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('responds 400 for unparseable payload JSON, touching neither path', async () => {
+    const { routedHandler, modalInteractions, chatHandler } = loadRoutedHandler();
+    const req = { body: { payload: '{not json' } };
+    const res = fakeRes();
+
+    await routedHandler(req, res);
+
+    expect(res._calls.status).toEqual([400]);
+    expect(modalInteractions.handleOpenModal).not.toHaveBeenCalled();
+    expect(chatHandler).not.toHaveBeenCalled();
+  });
+});

--- a/tests/routes/slack-routed-interactions-handler.test.js
+++ b/tests/routes/slack-routed-interactions-handler.test.js
@@ -20,9 +20,11 @@ function loadRoutedHandler() {
     isOpenModalAction: (id) => typeof id === 'string' && id.startsWith('open_modal:'),
     isBackAction: (id) => typeof id === 'string' && id.endsWith('_back'),
     isAttendanceFinishAction: (id) => id === 'attendance_finish',
+    isCountryBucketAction: (id) => id === 'country_bucket_select',
     handleOpenModal: jest.fn().mockResolvedValue(true),
     handleBackButton: jest.fn().mockResolvedValue(true),
     handleAttendanceFinish: jest.fn().mockResolvedValue(true),
+    handleCountryBucketChange: jest.fn().mockResolvedValue(true),
     handleViewSubmission: jest.fn().mockResolvedValue({ response_action: 'clear' }),
   };
   jest.doMock('../../bot/shared/routes/slack-modal-interactions.handler', () => modalInteractions);
@@ -101,6 +103,21 @@ describe('makeRoutedInteractionsHandler dispatch', () => {
     expect(modalInteractions.handleAttendanceFinish).toHaveBeenCalledTimes(1);
     expect(modalInteractions.handleOpenModal).not.toHaveBeenCalled();
     expect(modalInteractions.handleBackButton).not.toHaveBeenCalled();
+    expect(chatHandler).not.toHaveBeenCalled();
+    expect(res._calls.status).toEqual([200]);
+  });
+
+  it('routes a country_bucket_select block_actions to handleCountryBucketChange, acking 200 immediately', async () => {
+    const { routedHandler, modalInteractions, chatHandler } = loadRoutedHandler();
+    const req = { body: { payload: JSON.stringify({ type: 'block_actions', actions: [{ action_id: 'country_bucket_select', selected_option: { value: 'europe' } }] }) } };
+    const res = fakeRes();
+
+    await routedHandler(req, res);
+
+    expect(modalInteractions.handleCountryBucketChange).toHaveBeenCalledTimes(1);
+    expect(modalInteractions.handleOpenModal).not.toHaveBeenCalled();
+    expect(modalInteractions.handleBackButton).not.toHaveBeenCalled();
+    expect(modalInteractions.handleAttendanceFinish).not.toHaveBeenCalled();
     expect(chatHandler).not.toHaveBeenCalled();
     expect(res._calls.status).toEqual([200]);
   });

--- a/tests/routes/slack-routed-interactions-handler.test.js
+++ b/tests/routes/slack-routed-interactions-handler.test.js
@@ -29,6 +29,7 @@ function loadRoutedHandler() {
   jest.doMock('../../bot/shared/services/messaging/inbound/slack-events.adapter', () => ({
     makeEventsHandler: jest.fn(() => async (req, res) => res.status(200).send('')),
     makeInteractionsHandler: jest.fn(() => chatHandler),
+    makeSlashCommandHandler: jest.fn(() => async (req, res) => res.status(200).send('')),
   }));
 
   const mount = require('../../bot/shared/routes/slack-interactions.routes');

--- a/tests/routes/slack-routed-interactions-handler.test.js
+++ b/tests/routes/slack-routed-interactions-handler.test.js
@@ -19,8 +19,10 @@ function loadRoutedHandler() {
   const modalInteractions = {
     isOpenModalAction: (id) => typeof id === 'string' && id.startsWith('open_modal:'),
     isBackAction: (id) => typeof id === 'string' && id.endsWith('_back'),
+    isAttendanceFinishAction: (id) => id === 'attendance_finish',
     handleOpenModal: jest.fn().mockResolvedValue(true),
     handleBackButton: jest.fn().mockResolvedValue(true),
+    handleAttendanceFinish: jest.fn().mockResolvedValue(true),
     handleViewSubmission: jest.fn().mockResolvedValue({ response_action: 'clear' }),
   };
   jest.doMock('../../bot/shared/routes/slack-modal-interactions.handler', () => modalInteractions);
@@ -87,6 +89,20 @@ describe('makeRoutedInteractionsHandler dispatch', () => {
 
     expect(modalInteractions.handleBackButton).toHaveBeenCalledTimes(1);
     expect(chatHandler).not.toHaveBeenCalled();
+  });
+
+  it('routes an attendance_finish block_actions to handleAttendanceFinish, acking 200 immediately', async () => {
+    const { routedHandler, modalInteractions, chatHandler } = loadRoutedHandler();
+    const req = { body: { payload: JSON.stringify({ type: 'block_actions', actions: [{ action_id: 'attendance_finish' }] }) } };
+    const res = fakeRes();
+
+    await routedHandler(req, res);
+
+    expect(modalInteractions.handleAttendanceFinish).toHaveBeenCalledTimes(1);
+    expect(modalInteractions.handleOpenModal).not.toHaveBeenCalled();
+    expect(modalInteractions.handleBackButton).not.toHaveBeenCalled();
+    expect(chatHandler).not.toHaveBeenCalled();
+    expect(res._calls.status).toEqual([200]);
   });
 
   it('falls through to the ordinary chat handler for a ordinary block_actions click', async () => {

--- a/tests/routes/slack-views-attendance-exam-confirm.test.js
+++ b/tests/routes/slack-views-attendance-exam-confirm.test.js
@@ -1,0 +1,183 @@
+/**
+ * slack-views/attendance.view.js and exam-confirm.view.js — the concrete
+ * screen <-> Block Kit mapping for the two retrofitted Slack Flow-equivalents.
+ * Mirrors tests/routes/slack-views.test.js's conventions (registration/settings).
+ */
+
+const attendanceView = require('../../bot/shared/routes/slack-views/attendance.view');
+const examConfirmView = require('../../bot/shared/routes/slack-views/exam-confirm.view');
+
+const METADATA = JSON.stringify({ kind: 'attendance', screen: 'CLASS_INFO', flowToken: 'u1:attendance:169' });
+
+describe('attendance.view — screenToView', () => {
+  it('CLASS_INFO renders class_name/section (text) and attendance_frequency (once/twice select)', () => {
+    const view = attendanceView.screenToView('CLASS_INFO', {}, { metadata: METADATA });
+    expect(view.private_metadata).toBe(METADATA);
+    const blockIds = view.blocks.map((b) => b.block_id);
+    expect(blockIds).toEqual(['class_name_block', 'section_block', 'attendance_frequency_block']);
+
+    const freqBlock = view.blocks.find((b) => b.block_id === 'attendance_frequency_block');
+    expect(freqBlock.element.type).toBe('static_select');
+    expect(freqBlock.element.options).toEqual([
+      { text: { type: 'plain_text', text: 'Once per day' }, value: 'once' },
+      { text: { type: 'plain_text', text: 'Twice (morning & afternoon)' }, value: 'twice' },
+    ]);
+  });
+
+  it('ADD_STUDENT renders first_name/last_name text inputs plus a non-modal-submit "I\'m Done" button', () => {
+    const view = attendanceView.screenToView('ADD_STUDENT', {
+      heading: 'Add Student #2',
+      class_info: 'Class: Grade 3 - A | Students: 1',
+      students_list: 'Added: 1. Zara Abdul',
+    }, { metadata: METADATA });
+
+    expect(view.title.text).toBe('Add Student #2');
+    expect(view.submit.text).toBe('Add & Continue');
+
+    const blockIds = view.blocks.map((b) => b.block_id);
+    expect(blockIds).toEqual([
+      'class_info_block', 'students_list_block', 'first_name_block', 'last_name_block', 'attendance_finish_block',
+    ]);
+
+    const finishBlock = view.blocks.find((b) => b.block_id === 'attendance_finish_block');
+    expect(finishBlock.type).toBe('actions');
+    expect(finishBlock.elements[0]).toEqual(expect.objectContaining({
+      type: 'button', action_id: 'attendance_finish', text: { type: 'plain_text', text: "I'm Done" },
+    }));
+  });
+
+  it('ADD_STUDENT omits the class_info/students_list section blocks when absent (first student, fresh class)', () => {
+    const view = attendanceView.screenToView('ADD_STUDENT', { heading: 'Add Student #1' }, { metadata: METADATA });
+    const blockIds = view.blocks.map((b) => b.block_id);
+    expect(blockIds).toEqual(['first_name_block', 'last_name_block', 'attendance_finish_block']);
+  });
+
+  it('throws for an unmapped screen', () => {
+    expect(() => attendanceView.screenToView('NOT_A_SCREEN', {}, { metadata: METADATA })).toThrow(/no view mapping/);
+  });
+});
+
+describe('attendance.view — viewToScreenData', () => {
+  it('extracts class_name/section/attendance_frequency from CLASS_INFO state values', () => {
+    const stateValues = {
+      class_name_block: { class_name: { value: 'Grade 3' } },
+      section_block: { section: { value: 'A' } },
+      attendance_frequency_block: { attendance_frequency: { selected_option: { value: 'once' } } },
+    };
+    expect(attendanceView.viewToScreenData('CLASS_INFO', stateValues)).toEqual({
+      class_name: 'Grade 3', section: 'A', attendance_frequency: 'once',
+    });
+  });
+
+  it('ADD_STUDENT sets _action="add" and threads _list_id/_class_display from the carried param', () => {
+    const stateValues = {
+      first_name_block: { first_name: { value: 'Zara' } },
+      last_name_block: { last_name: { value: 'Abdul' } },
+    };
+    const result = attendanceView.viewToScreenData('ADD_STUDENT', stateValues, { list_id: 'list-1', class_display: 'Grade 3 - A' });
+    expect(result).toEqual({
+      first_name: 'Zara', last_name: 'Abdul', _action: 'add', _list_id: 'list-1', _class_display: 'Grade 3 - A',
+    });
+  });
+
+  it('ADD_STUDENT tolerates a missing carried param (defaults to {})', () => {
+    const result = attendanceView.viewToScreenData('ADD_STUDENT', {
+      first_name_block: { first_name: { value: 'Zara' } },
+    });
+    expect(result._list_id).toBeUndefined();
+    expect(result._class_display).toBeUndefined();
+    expect(result._action).toBe('add');
+  });
+
+  it('returns {} for an unrecognized screen', () => {
+    expect(attendanceView.viewToScreenData('UNKNOWN', {})).toEqual({});
+  });
+});
+
+describe('attendance.view — metadataCarry', () => {
+  it('picks {list_id, class_display} out of ADD_STUDENT response data', () => {
+    const carry = attendanceView.metadataCarry('ADD_STUDENT', { list_id: 'list-1', class_display: 'Grade 3 - A', student_count: 2 });
+    expect(carry).toEqual({ list_id: 'list-1', class_display: 'Grade 3 - A' });
+  });
+
+  it('returns undefined for CLASS_INFO — nothing to carry yet', () => {
+    expect(attendanceView.metadataCarry('CLASS_INFO', {})).toBeUndefined();
+  });
+});
+
+describe('attendance.view — FIRST_INPUT_BLOCK_ID', () => {
+  it('names a real block_id for every screen the endpoint can return', () => {
+    for (const screen of ['CLASS_INFO', 'ADD_STUDENT']) {
+      expect(attendanceView.FIRST_INPUT_BLOCK_ID[screen]).toBeTruthy();
+    }
+  });
+});
+
+describe('exam-confirm.view — screenToView', () => {
+  const students = [
+    { id: '0', title: '1. Zara Abdul' },
+    { id: '1', title: '2. Ahmed Khan' },
+  ];
+
+  it('CONFIRM_STUDENTS renders every student as a checkboxes option, all pre-checked', () => {
+    const view = examConfirmView.screenToView('CONFIRM_STUDENTS', {
+      heading: 'I found 2 students', subheading: "Uncheck anyone who isn't real", students,
+    }, { metadata: 'meta' });
+
+    expect(view.type).toBe('modal');
+    expect(view.submit.text).toBe('Confirm & Grade');
+
+    const block = view.blocks.find((b) => b.block_id === 'confirmed_students_block');
+    expect(block.element.type).toBe('checkboxes');
+    expect(block.element.options).toEqual([
+      { text: { type: 'plain_text', text: '1. Zara Abdul' }, value: '0' },
+      { text: { type: 'plain_text', text: '2. Ahmed Khan' }, value: '1' },
+    ]);
+    // every option defaults to checked, matching Meta's CheckboxGroup default
+    expect(block.element.initial_options).toEqual(block.element.options);
+  });
+
+  it('handles an empty roster without throwing (zero checkboxes options)', () => {
+    const view = examConfirmView.screenToView('CONFIRM_STUDENTS', { students: [] }, { metadata: 'meta' });
+    const block = view.blocks.find((b) => b.block_id === 'confirmed_students_block');
+    expect(block.element.options).toEqual([]);
+  });
+
+  it('does not chunk a roster of 40 students — Slack checkboxes has no 25-option cap unlike Discord', () => {
+    const bigRoster = Array.from({ length: 40 }, (_, i) => ({ id: String(i), title: `Student ${i}` }));
+    const view = examConfirmView.screenToView('CONFIRM_STUDENTS', { students: bigRoster }, { metadata: 'meta' });
+    const block = view.blocks.find((b) => b.block_id === 'confirmed_students_block');
+    expect(block.element.options).toHaveLength(40);
+    // exactly one block for the roster (no split across multiple blocks/screens)
+    expect(view.blocks.filter((b) => b.block_id === 'confirmed_students_block')).toHaveLength(1);
+  });
+
+  it('throws for an unmapped screen', () => {
+    expect(() => examConfirmView.screenToView('NOT_A_SCREEN', {}, { metadata: 'meta' })).toThrow(/no view mapping/);
+  });
+});
+
+describe('exam-confirm.view — viewToScreenData', () => {
+  it('extracts confirmed_students as an array of selected option values', () => {
+    const stateValues = {
+      confirmed_students_block: {
+        confirmed_students: { selected_options: [{ value: '0' }, { value: '1' }] },
+      },
+    };
+    expect(examConfirmView.viewToScreenData('CONFIRM_STUDENTS', stateValues)).toEqual({ confirmed_students: ['0', '1'] });
+  });
+
+  it('defaults to an empty array when nothing is selected', () => {
+    expect(examConfirmView.viewToScreenData('CONFIRM_STUDENTS', {})).toEqual({ confirmed_students: [] });
+  });
+
+  it('returns {} for an unrecognized screen', () => {
+    expect(examConfirmView.viewToScreenData('UNKNOWN', {})).toEqual({});
+  });
+});
+
+describe('exam-confirm.view — FIRST_INPUT_BLOCK_ID', () => {
+  it('names the checkboxes block for CONFIRM_STUDENTS', () => {
+    expect(examConfirmView.FIRST_INPUT_BLOCK_ID.CONFIRM_STUDENTS).toBe('confirmed_students_block');
+  });
+});

--- a/tests/routes/slack-views.test.js
+++ b/tests/routes/slack-views.test.js
@@ -1,0 +1,120 @@
+/**
+ * slack-views/registration.view.js and settings.view.js — the concrete
+ * screen <-> Block Kit mapping. Pins the exact block_id/action_id shapes
+ * viewToScreenData reads back, since a mismatch here would silently drop a
+ * field on submission with no error at all.
+ */
+
+const registrationView = require('../../bot/shared/routes/slack-views/registration.view');
+const settingsView = require('../../bot/shared/routes/slack-views/settings.view');
+
+const METADATA = JSON.stringify({ kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'u1:registration:169' });
+
+describe('registration.view — screenToView', () => {
+  it('PERSONAL_INFO renders full_name (text) and country (select) inputs', () => {
+    const view = registrationView.screenToView('PERSONAL_INFO', { countries: [{ id: 'PK', title: 'Pakistan' }] }, { metadata: METADATA });
+    expect(view.private_metadata).toBe(METADATA);
+    const blockIds = view.blocks.map((b) => b.block_id);
+    expect(blockIds).toEqual(['full_name_block', 'country_block']);
+    const countryBlock = view.blocks.find((b) => b.block_id === 'country_block');
+    expect(countryBlock.element.type).toBe('static_select');
+    expect(countryBlock.element.options).toEqual([{ text: { type: 'plain_text', text: 'Pakistan' }, value: 'PK' }]);
+  });
+
+  it('PROFESSIONAL_INFO renders a multi_static_select for subjects and includes a Back button', () => {
+    const view = registrationView.screenToView('PROFESSIONAL_INFO', {
+      organizations: [{ id: 'fde', title: 'FDE' }],
+      grades: [{ id: 'grade_1', title: 'Grade 1' }],
+      subjects: [{ id: 'maths', title: 'Maths' }, { id: 'english', title: 'English' }],
+    }, { metadata: METADATA });
+
+    const subjectsBlock = view.blocks.find((b) => b.block_id === 'subjects_block');
+    expect(subjectsBlock.element.type).toBe('multi_static_select');
+    expect(subjectsBlock.element.options).toHaveLength(2);
+
+    const backBlock = view.blocks.find((b) => b.block_id === 'back_block');
+    expect(backBlock.elements[0].action_id).toBe('registration_back');
+  });
+
+  it('throws for an unmapped screen — a silent fallback would render a blank modal', () => {
+    expect(() => registrationView.screenToView('NOT_A_SCREEN', {}, { metadata: METADATA })).toThrow(/no view mapping/);
+  });
+});
+
+describe('registration.view — viewToScreenData', () => {
+  it('extracts full_name/country from PERSONAL_INFO state values', () => {
+    const stateValues = {
+      full_name_block: { full_name: { value: 'Ayesha Khan' } },
+      country_block: { country: { selected_option: { value: 'PK' } } },
+    };
+    expect(registrationView.viewToScreenData('PERSONAL_INFO', stateValues)).toEqual({
+      full_name: 'Ayesha Khan', country: 'PK',
+    });
+  });
+
+  it('extracts subjects as an array of values from PROFESSIONAL_INFO state values', () => {
+    const stateValues = {
+      organization_block: { organization: { selected_option: { value: 'fde' } } },
+      school_name_block: { school_name: { value: '' } },
+      grade_block: { grade: { selected_option: { value: 'grade_1' } } },
+      subjects_block: { subjects: { selected_options: [{ value: 'maths' }, { value: 'english' }] } },
+    };
+    expect(registrationView.viewToScreenData('PROFESSIONAL_INFO', stateValues)).toEqual({
+      organization: 'fde', school_name: '', grade: 'grade_1', subjects: ['maths', 'english'],
+    });
+  });
+
+  it('returns {} for an unrecognized screen rather than throwing', () => {
+    expect(registrationView.viewToScreenData('UNKNOWN', {})).toEqual({});
+  });
+});
+
+describe('registration.view — FIRST_INPUT_BLOCK_ID', () => {
+  it('names a real block_id for every screen the endpoint can return', () => {
+    for (const screen of ['PERSONAL_INFO', 'REGION_INFO', 'PROFESSIONAL_INFO', 'ORG_DETAILS']) {
+      expect(registrationView.FIRST_INPUT_BLOCK_ID[screen]).toBeTruthy();
+    }
+  });
+});
+
+describe('settings.view — screenToView', () => {
+  it('pre-selects the current language and framework via initial_option', () => {
+    const view = settingsView.screenToView('SETTINGS_MAIN', {
+      languages: [{ id: 'en', title: 'English' }, { id: 'ur', title: 'Urdu' }],
+      frameworks: [{ id: 'oecd', title: 'OECD' }],
+      current_language: 'ur',
+      current_framework: 'oecd',
+      info_text: 'Default for Punjab: OECD.',
+    }, { metadata: 'meta' });
+
+    const langBlock = view.blocks.find((b) => b.block_id === 'language_block');
+    expect(langBlock.element.initial_option).toEqual({ text: { type: 'plain_text', text: 'Urdu' }, value: 'ur' });
+
+    const fwBlock = view.blocks.find((b) => b.block_id === 'framework_block');
+    expect(fwBlock.element.initial_option).toEqual({ text: { type: 'plain_text', text: 'OECD' }, value: 'oecd' });
+    expect(fwBlock.hint.text).toBe('Default for Punjab: OECD.');
+  });
+
+  it('omits initial_option entirely when the current value is not in the dropdown', () => {
+    const view = settingsView.screenToView('SETTINGS_MAIN', {
+      languages: [{ id: 'en', title: 'English' }],
+      frameworks: [{ id: 'oecd', title: 'OECD' }],
+      current_language: 'fr', // not in the dropdown
+      current_framework: 'oecd',
+    }, { metadata: 'meta' });
+
+    const langBlock = view.blocks.find((b) => b.block_id === 'language_block');
+    expect(langBlock.element.initial_option).toBeUndefined();
+  });
+});
+
+describe('settings.view — viewToScreenData', () => {
+  it('extracts language and observation_framework, defaulting when absent', () => {
+    expect(settingsView.viewToScreenData('SETTINGS_MAIN', {
+      language_block: { language: { selected_option: { value: 'ur' } } },
+      framework_block: { observation_framework: { selected_option: { value: 'hots' } } },
+    })).toEqual({ language: 'ur', observation_framework: 'hots' });
+
+    expect(settingsView.viewToScreenData('SETTINGS_MAIN', {})).toEqual({ language: 'en', observation_framework: 'oecd' });
+  });
+});

--- a/tests/routes/slack-views.test.js
+++ b/tests/routes/slack-views.test.js
@@ -11,14 +11,77 @@ const settingsView = require('../../bot/shared/routes/slack-views/settings.view'
 const METADATA = JSON.stringify({ kind: 'registration', screen: 'PERSONAL_INFO', flowToken: 'u1:registration:169' });
 
 describe('registration.view — screenToView', () => {
-  it('PERSONAL_INFO renders full_name (text) and country (select) inputs', () => {
+  it('PERSONAL_INFO renders full_name (text), a region-bucket picker, and a country picker filtered to the default bucket', () => {
+    // Regression test for a real, confirmed bug: a single static_select with
+    // all 164 countries exceeds Slack's 100-option cap, so registration on
+    // Slack failed every single time the modal tried to open ("no more than
+    // 100 items allowed"). Fixed with a region-bucket-then-country picker,
+    // mirroring Discord's own country picker (both driven by
+    // discord-country-regions.js's channel-agnostic buildBuckets()).
     const view = registrationView.screenToView('PERSONAL_INFO', { countries: [{ id: 'PK', title: 'Pakistan' }] }, { metadata: METADATA });
     expect(view.private_metadata).toBe(METADATA);
     const blockIds = view.blocks.map((b) => b.block_id);
-    expect(blockIds).toEqual(['full_name_block', 'country_block']);
+    expect(blockIds).toEqual(['full_name_block', 'country_bucket_block', 'country_block']);
+
+    const bucketBlock = view.blocks.find((b) => b.block_id === 'country_bucket_block');
+    expect(bucketBlock.element.type).toBe('static_select');
+    expect(bucketBlock.element.action_id).toBe(registrationView.COUNTRY_BUCKET_ACTION_ID);
+    expect(bucketBlock.element.initial_option).toBeUndefined(); // never pre-selected on first render
+    // Confirmed live, not a guess: an `input` block's element is inert (no
+    // block_actions event fires on interaction) unless the BLOCK itself sets
+    // dispatch_action: true — without this, Slack updates its own displayed
+    // value locally but the country field's live-refresh never happens at
+    // all. Caught by manually testing the fix against a real Slack workspace
+    // after the unit tests already passed with a mocked live-update — the
+    // exact kind of bug this comment exists to prevent from regressing.
+    expect(bucketBlock.dispatch_action).toBe(true);
+
+    // With this minimal 1-country test fixture, only Pakistan survives
+    // buildBuckets()'s filter against the real COUNTRY_REGION_BUCKETS
+    // membership — and Pakistan's bucket (south_asia) is the first one
+    // defined, so it's exactly what an unselected-bucket render defaults to.
     const countryBlock = view.blocks.find((b) => b.block_id === 'country_block');
     expect(countryBlock.element.type).toBe('static_select');
     expect(countryBlock.element.options).toEqual([{ text: { type: 'plain_text', text: 'Pakistan' }, value: 'PK' }]);
+  });
+
+  it('PERSONAL_INFO filters the country picker to whichever bucket ctx.selectedCountryBucket names, and preserves the already-typed full name', () => {
+    const view = registrationView.screenToView('PERSONAL_INFO', {
+      countries: [
+        { id: 'PK', title: 'Pakistan' },
+        { id: 'GB', title: 'United Kingdom' },
+        { id: 'DE', title: 'Germany' },
+      ],
+    }, { metadata: METADATA, selectedCountryBucket: 'europe', fullNameValue: 'Ayesha Khan' });
+
+    const bucketBlock = view.blocks.find((b) => b.block_id === 'country_bucket_block');
+    expect(bucketBlock.element.initial_option).toEqual({ text: { type: 'plain_text', text: 'Europe' }, value: 'europe' });
+
+    const countryBlock = view.blocks.find((b) => b.block_id === 'country_block');
+    expect(countryBlock.element.options).toEqual(expect.arrayContaining([
+      { text: { type: 'plain_text', text: 'United Kingdom' }, value: 'GB' },
+      { text: { type: 'plain_text', text: 'Germany' }, value: 'DE' },
+    ]));
+    expect(countryBlock.element.options.find((o) => o.value === 'PK')).toBeUndefined(); // Pakistan is south_asia, not europe
+
+    const nameBlock = view.blocks.find((b) => b.block_id === 'full_name_block');
+    expect(nameBlock.element.initial_value).toBe('Ayesha Khan');
+  });
+
+  it('PERSONAL_INFO never renders more than 100 country options for the REAL 164-country dropdown, in every bucket', () => {
+    // eslint-disable-next-line global-require -- test-only, avoids a module-level import the file doesn't otherwise need
+    const { COUNTRIES_DROPDOWN } = require('../../bot/shared/config/registration-data');
+    // eslint-disable-next-line global-require
+    const { COUNTRY_REGION_BUCKETS } = require('../../bot/shared/config/discord-country-regions');
+
+    for (const bucket of COUNTRY_REGION_BUCKETS) {
+      const view = registrationView.screenToView('PERSONAL_INFO', { countries: COUNTRIES_DROPDOWN }, {
+        metadata: METADATA, selectedCountryBucket: bucket.id,
+      });
+      const countryBlock = view.blocks.find((b) => b.block_id === 'country_block');
+      expect(countryBlock.element.options.length).toBeLessThanOrEqual(100);
+      expect(countryBlock.element.options.length).toBeGreaterThan(0);
+    }
   });
 
   it('PROFESSIONAL_INFO renders a multi_static_select for subjects and includes a Back button', () => {

--- a/tests/scripts/discord-register-commands.test.js
+++ b/tests/scripts/discord-register-commands.test.js
@@ -1,0 +1,123 @@
+/**
+ * discord-register-commands.js — the one-time REST call registering the 9
+ * slash commands (unlike Slack, which has no such registration script — its
+ * commands are entered by hand, one at a time, in the app config UI).
+ * discord.js's REST client is mocked entirely; this suite never makes a
+ * real network call.
+ */
+
+const { SLACK_SLASH_COMMANDS } = require('../../bot/scripts/setup/fields');
+
+// discord.js is a bot-only dependency (installed under bot/node_modules,
+// not the repo root) — mocked virtual: true so this suite runs identically
+// whether or not it happens to be resolvable, matching this session's own
+// established CI lesson (root `npm test` runs BEFORE `bot/ npm ci`).
+function mockDiscordRest() {
+  const put = jest.fn().mockResolvedValue([]);
+  class FakeREST {
+    setToken() { return this; }
+    put(...args) { return put(...args); }
+  }
+  const Routes = {
+    applicationCommands: jest.fn((id) => `/applications/${id}/commands`),
+    applicationGuildCommands: jest.fn((id, guildId) => `/applications/${id}/guilds/${guildId}/commands`),
+  };
+  class FakeSlashCommandBuilder {
+    setName(name) { this.name = name; return this; }
+    setDescription(description) { this.description = description; return this; }
+    toJSON() { return { name: this.name, description: this.description, options: [], type: 1 }; }
+  }
+  jest.doMock('discord.js', () => ({ REST: FakeREST, Routes, SlashCommandBuilder: FakeSlashCommandBuilder }), { virtual: true });
+  return { put, Routes };
+}
+
+function load() {
+  jest.resetModules();
+  const rest = mockDiscordRest();
+  const mod = require('../../bot/scripts/setup/discord-register-commands');
+  return { mod, ...rest };
+}
+
+describe('bareCommandNames', () => {
+  it('strips the leading "/" off every command in SLACK_SLASH_COMMANDS — the SAME list, not a second hardcoded copy', () => {
+    const { mod } = load();
+    const bare = mod.bareCommandNames();
+    expect(bare).toEqual(SLACK_SLASH_COMMANDS.map((c) => c.slice(1)));
+    expect(bare).toHaveLength(SLACK_SLASH_COMMANDS.length);
+  });
+
+  it('never drifts from SLACK_SLASH_COMMANDS — adding/removing a command there is the only way to change this list', () => {
+    const { mod } = load();
+    expect(mod.bareCommandNames().map((c) => `/${c}`)).toEqual(SLACK_SLASH_COMMANDS);
+  });
+});
+
+describe('buildCommandDefinitions', () => {
+  it('builds one {name, description} entry per command, all Discord-legal (lowercase, no spaces)', () => {
+    const { mod } = load();
+    const defs = mod.buildCommandDefinitions();
+    expect(defs).toHaveLength(SLACK_SLASH_COMMANDS.length);
+    for (const def of defs) {
+      expect(def.name).toMatch(/^[a-z0-9_-]+$/);
+      expect(typeof def.description).toBe('string');
+      expect(def.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every command has a real, specific description — not a generic fallback', () => {
+    const { mod } = load();
+    const defs = mod.buildCommandDefinitions();
+    for (const def of defs) {
+      expect(mod.COMMAND_DESCRIPTIONS[def.name]).toBe(def.description);
+    }
+  });
+});
+
+describe('registerDiscordCommands', () => {
+  it('throws without a bot token', async () => {
+    const { mod } = load();
+    await expect(mod.registerDiscordCommands({ applicationId: 'app1' })).rejects.toThrow(/DISCORD_BOT_TOKEN/);
+  });
+
+  it('throws without an application id', async () => {
+    const { mod } = load();
+    await expect(mod.registerDiscordCommands({ token: 'tok1' })).rejects.toThrow(/DISCORD_APPLICATION_ID/);
+  });
+
+  it('registers globally when no guildId is given', async () => {
+    const { mod, put, Routes } = load();
+    const result = await mod.registerDiscordCommands({ token: 'tok1', applicationId: 'app1' });
+
+    expect(Routes.applicationCommands).toHaveBeenCalledWith('app1');
+    expect(Routes.applicationGuildCommands).not.toHaveBeenCalled();
+    expect(put).toHaveBeenCalledWith('/applications/app1/commands', { body: expect.any(Array) });
+    expect(result.guildScoped).toBe(false);
+    expect(result.registered).toBe(SLACK_SLASH_COMMANDS.length);
+    expect(result.commands).toEqual(mod.bareCommandNames());
+  });
+
+  it('registers guild-scoped (instant propagation) when a guildId is given', async () => {
+    const { mod, put, Routes } = load();
+    const result = await mod.registerDiscordCommands({ token: 'tok1', applicationId: 'app1', guildId: 'guild1' });
+
+    expect(Routes.applicationGuildCommands).toHaveBeenCalledWith('app1', 'guild1');
+    expect(put).toHaveBeenCalledWith('/applications/app1/guilds/guild1/commands', { body: expect.any(Array) });
+    expect(result.guildScoped).toBe(true);
+  });
+
+  it('reads the token/applicationId/guildId from env vars when not passed explicitly', async () => {
+    const { mod, Routes } = load();
+    process.env.DISCORD_BOT_TOKEN = 'env-token';
+    process.env.DISCORD_APPLICATION_ID = 'env-app';
+    process.env.DISCORD_TEST_GUILD_ID = 'env-guild';
+
+    try {
+      await mod.registerDiscordCommands();
+      expect(Routes.applicationGuildCommands).toHaveBeenCalledWith('env-app', 'env-guild');
+    } finally {
+      delete process.env.DISCORD_BOT_TOKEN;
+      delete process.env.DISCORD_APPLICATION_ID;
+      delete process.env.DISCORD_TEST_GUILD_ID;
+    }
+  });
+});

--- a/tests/services/video/video-assembly-delivery.test.js
+++ b/tests/services/video/video-assembly-delivery.test.js
@@ -1,0 +1,120 @@
+/**
+ * video-assembly.service.js#assembleAndDeliver — the video-delivery fix
+ * covered here: prefer sendVideoFromUrl(from, finalVideoUrl, ...) whenever
+ * the R2 upload succeeded (finalVideoUrl truthy), avoiding a wasted
+ * raw-buffer upload and sidestepping every channel's own per-upload size
+ * limits (e.g. Discord's ~8MB safe ceiling on a bot DM channel) — falling
+ * back to the raw-buffer sendVideo(...) only when R2 upload failed after all
+ * retries. This is a real bug found while designing Discord's video
+ * delivery: the fix benefits every channel, not just Discord.
+ *
+ * The FFmpeg/filesystem pipeline (syncAudioVideo/concatenateVideos/
+ * concatenateAudio/mergeVideoAudio/generatePDF, all execSync-driven) is
+ * mocked wholesale via jest.spyOn on the class's own static methods — this
+ * test targets ONLY the delivery-branch logic the fix touches, not the video
+ * assembly pipeline itself (which has no dedicated test suite and is out of
+ * scope for this change).
+ */
+
+// pdfkit is a bot-only dependency (bot/package.json, not the repo root) —
+// video-assembly.service.js requires it at module load time regardless of
+// whether generatePDF() is ever called, so this must be mocked even though
+// this suite never touches PDF generation. Matches the CI-ordering lesson
+// already established for other bot-only deps (see jest.config.js's
+// moduleNameMapper for @ffmpeg-installer/ffmpeg etc.) — root `npm test` runs
+// BEFORE `bot/ npm ci`, so an unmocked require here passes locally (if
+// bot/node_modules happens to be installed) but fails in real CI.
+jest.mock('pdfkit', () => class FakePDFDocument {}, { virtual: true });
+
+jest.mock('../../../bot/shared/config/supabase', () => ({
+  from: jest.fn(() => ({
+    update: jest.fn(() => ({ eq: jest.fn().mockResolvedValue({ data: null, error: null }) })),
+  })),
+}));
+
+jest.mock('../../../bot/shared/storage/r2', () => ({
+  uploadVideoAsset: jest.fn(),
+}));
+
+jest.mock('../../../bot/shared/services/whatsapp.service', () => ({
+  sendVideo: jest.fn().mockResolvedValue(true),
+  sendVideoFromUrl: jest.fn().mockResolvedValue(true),
+  sendMessage: jest.fn().mockResolvedValue(true),
+  sendDocument: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../../../bot/shared/utils/language-cache', () => ({ getUserLanguage: jest.fn().mockResolvedValue('en') }));
+jest.mock('../../../bot/shared/config/branding', () => ({ portalUrl: jest.fn(() => null) }));
+jest.mock('../../../bot/shared/services/video/video-session.service', () => ({
+  getProgressMessages: jest.fn(() => ({ complete: 'Your video is ready!' })),
+}));
+jest.mock('../../../bot/shared/services/video/video-watermark.service', () => ({
+  addWatermark: jest.fn().mockResolvedValue({ success: true, path: '/tmp/final.mp4', skipped: true }),
+}));
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  copyFileSync: jest.fn(),
+  readFileSync: jest.fn(() => Buffer.from('fake-video-bytes')),
+  existsSync: jest.fn(() => true),
+  rmSync: jest.fn(),
+  mkdirSync: jest.fn(),
+}));
+
+const VideoAssemblyService = require('../../../bot/shared/services/video/video-assembly.service');
+const WhatsAppService = require('../../../bot/shared/services/whatsapp.service');
+const { uploadVideoAsset } = require('../../../bot/shared/storage/r2');
+
+const BASE_OPTIONS = {
+  from: '923001234567',
+  userId: 'u1',
+  language: 'en',
+  videoPaths: ['/tmp/v1.mp4'],
+  audioPaths: ['/tmp/a1.mp3'],
+  slideUrls: ['https://example.com/slide1.png'],
+};
+
+function stubFfmpegPipeline() {
+  jest.spyOn(VideoAssemblyService, 'syncAudioVideo').mockResolvedValue(['/tmp/adjusted1.mp4']);
+  jest.spyOn(VideoAssemblyService, 'concatenateVideos').mockResolvedValue(undefined);
+  jest.spyOn(VideoAssemblyService, 'concatenateAudio').mockResolvedValue(undefined);
+  jest.spyOn(VideoAssemblyService, 'mergeVideoAudio').mockResolvedValue(undefined);
+}
+
+afterEach(() => jest.clearAllMocks());
+
+describe('assembleAndDeliver — video delivery branch', () => {
+  it('prefers sendVideoFromUrl with the R2 url when upload succeeds — never touches the raw buffer', async () => {
+    stubFfmpegPipeline();
+    uploadVideoAsset.mockResolvedValue('https://videorequests.r2.cloudflarestorage.com/final.mp4');
+
+    await VideoAssemblyService.assembleAndDeliver('req-1', BASE_OPTIONS);
+
+    expect(WhatsAppService.sendVideoFromUrl).toHaveBeenCalledWith(
+      '923001234567', 'https://videorequests.r2.cloudflarestorage.com/final.mp4', 'Your video is ready!',
+    );
+    expect(WhatsAppService.sendVideo).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the raw-buffer sendVideo when R2 upload fails after all retries', async () => {
+    stubFfmpegPipeline();
+    uploadVideoAsset.mockRejectedValue(new Error('R2 unreachable'));
+    jest.useFakeTimers();
+
+    const deliveryPromise = VideoAssemblyService.assembleAndDeliver('req-2', BASE_OPTIONS);
+    // 3 retries with a 2000ms*attempt backoff between them — flush each wait
+    // without actually sleeping in real time.
+    await jest.advanceTimersByTimeAsync(2000);
+    await jest.advanceTimersByTimeAsync(4000);
+    await deliveryPromise;
+
+    jest.useRealTimers();
+
+    expect(WhatsAppService.sendVideo).toHaveBeenCalledTimes(1);
+    const [to, buffer, , caption] = WhatsAppService.sendVideo.mock.calls[0];
+    expect(to).toBe('923001234567');
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(caption).toBe('Your video is ready!');
+    expect(WhatsAppService.sendVideoFromUrl).not.toHaveBeenCalled();
+  });
+});

--- a/tests/setup/doctor.test.js
+++ b/tests/setup/doctor.test.js
@@ -318,6 +318,45 @@ describe('the real Slack probe — a token that authenticates is not the same as
   });
 });
 
+describe('the real Discord probe — lighter than Slack\'s, no per-scope breakdown', () => {
+  // Discord has no clean single-call equivalent to Slack's x-oauth-scopes
+  // response header, so this probe only confirms the bot token authenticates
+  // (and, as a bonus, that the application id it returns matches
+  // DISCORD_APPLICATION_ID) — deliberately not a per-permission check.
+  const { defaultProbes } = require('../../bot/scripts/setup/doctor');
+  const ENV = { DISCORD_BOT_TOKEN: 'test-bot-token', DISCORD_APPLICATION_ID: 'app-123' };
+
+  let realFetch;
+  beforeEach(() => { realFetch = global.fetch; });
+  afterEach(() => { global.fetch = realFetch; });
+
+  it('passes when the token authenticates and the application id matches', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ id: 'app-123', name: 'Rumi' }) });
+    const result = await defaultProbes.discord(ENV);
+    expect(result.ok).toBe(true);
+    expect(result.detail).toMatch(/Rumi/);
+  });
+
+  it('fails on a non-2xx HTTP response (e.g. an invalid/revoked token)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await defaultProbes.discord(ENV);
+    expect(result).toEqual({ ok: false, detail: 'HTTP 401' });
+  });
+
+  it('fails when the returned application id does not match DISCORD_APPLICATION_ID', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ id: 'a-different-app', name: 'Someone Else\'s App' }) });
+    const result = await defaultProbes.discord(ENV);
+    expect(result.ok).toBe(false);
+    expect(result.detail).toMatch(/does not match/);
+  });
+
+  it('passes even without DISCORD_APPLICATION_ID set — the id check only runs when there is something to compare against', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ id: 'app-123', name: 'Rumi' }) });
+    const result = await defaultProbes.discord({ DISCORD_BOT_TOKEN: 'test-bot-token' });
+    expect(result.ok).toBe(true);
+  });
+});
+
 describe('the real OpenRouter probe — a valid key is not the same as a usable one', () => {
   // Live finding: doctor reported "✅ OpenRouter (LLM) — HTTP 200" and "All
   // required services are configured and reachable" on an account with zero

--- a/tests/setup/doctor.test.js
+++ b/tests/setup/doctor.test.js
@@ -256,6 +256,68 @@ describe('flow registration state (analyzeFlows + doctor reporting)', () => {
   });
 });
 
+describe('the real Slack probe — a token that authenticates is not the same as one with every scope Rumi needs', () => {
+  // Live finding: `auth.test` succeeding says nothing about which OAuth scopes
+  // the token actually carries — Slack reports those in the `x-oauth-scopes`
+  // response HEADER, not the JSON body. Without checking it, a token missing
+  // e.g. files:read looked "connected" here and then failed hours later, mid
+  // conversation, with an opaque "missing_scope" naming neither which scope
+  // nor how to fix it.
+  const { defaultProbes } = require('../../bot/scripts/setup/doctor');
+  const ENV = { SLACK_BOT_TOKEN: 'xoxb-test-token' };
+
+  function authTestResponse({ ok = true, scopes = '', status = 200, body = {} } = {}) {
+    return {
+      ok: status < 300,
+      status,
+      headers: { get: (name) => (name === 'x-oauth-scopes' ? scopes : null) },
+      json: async () => ({ ok, team: 'My Workspace', ...body }),
+    };
+  }
+
+  const ALL_SCOPES = 'chat:write,im:write,reactions:write,files:read,files:write';
+
+  let realFetch;
+  beforeEach(() => { realFetch = global.fetch; });
+  afterEach(() => { global.fetch = realFetch; });
+
+  it('passes a token with every required scope present', async () => {
+    global.fetch = jest.fn().mockResolvedValue(authTestResponse({ scopes: ALL_SCOPES }));
+    const result = await defaultProbes.slack(ENV);
+    expect(result.ok).toBe(true);
+    expect(result.detail).toMatch(/My Workspace/);
+  });
+
+  it('fails and names EVERY missing scope, not just the first', async () => {
+    global.fetch = jest.fn().mockResolvedValue(authTestResponse({ scopes: 'chat:write,im:write,reactions:write' }));
+    const result = await defaultProbes.slack(ENV);
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('files:read');
+    expect(result.detail).toContain('files:write');
+    expect(result.detail).not.toContain('chat:write'); // present — must not be reported as missing
+  });
+
+  it('fails a token Slack itself rejects (auth.test ok:false), naming the error Slack gave', async () => {
+    global.fetch = jest.fn().mockResolvedValue(authTestResponse({ ok: false, body: { error: 'invalid_auth' } }));
+    const result = await defaultProbes.slack(ENV);
+    expect(result.ok).toBe(false);
+    expect(result.detail).toMatch(/invalid_auth/);
+  });
+
+  it('fails on a non-2xx HTTP response without even reading scopes', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+    const result = await defaultProbes.slack(ENV);
+    expect(result).toEqual({ ok: false, detail: 'HTTP 500' });
+  });
+
+  it('treats an absent x-oauth-scopes header as zero scopes granted, not as "everything present"', async () => {
+    global.fetch = jest.fn().mockResolvedValue(authTestResponse({ scopes: '' }));
+    const result = await defaultProbes.slack(ENV);
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('chat:write');
+  });
+});
+
 describe('the real OpenRouter probe — a valid key is not the same as a usable one', () => {
   // Live finding: doctor reported "✅ OpenRouter (LLM) — HTTP 200" and "All
   // required services are configured and reachable" on an account with zero

--- a/tests/setup/env-file.test.js
+++ b/tests/setup/env-file.test.js
@@ -88,6 +88,49 @@ describe('writeEnvVars', () => {
     expect(readEnvFile(p).CHANNEL_DRIVER).toBe('PATCHED');
   });
 
+  it('uncomments and patches a commented-out placeholder IN PLACE, rather than appending a second live copy at the end', () => {
+    // Real bug this fixes: a user (or a fresh .env.template) commented out
+    // `# SLACK_SIGNING_SECRET=...` in its intended spot, right after the
+    // WhatsApp block. Running the wizard's Slack step patched the value by
+    // APPENDING SLACK_SIGNING_SECRET=<real value> at the very end of the
+    // file instead — leaving the original commented placeholder sitting
+    // above, stale and confusing, while the real, active line lived
+    // hundreds of lines away in the Optional section.
+    const p = tempEnvPath();
+    fs.writeFileSync(p, '# keep me\n# SLACK_SIGNING_SECRET=CHANGEME\nOTHER=untouched\n');
+
+    writeEnvVars(p, { SLACK_SIGNING_SECRET: 'real-secret' });
+
+    const lines = fs.readFileSync(p, 'utf-8').split('\n');
+    expect(lines[0]).toBe('# keep me');
+    expect(lines[1]).toBe('SLACK_SIGNING_SECRET=real-secret'); // uncommented, in place
+    expect(lines[2]).toBe('OTHER=untouched');
+    expect(lines.filter((l) => l.includes('SLACK_SIGNING_SECRET'))).toHaveLength(1); // no duplicate at the end
+  });
+
+  it('prefers an ACTIVE line over a commented-out one when both exist for the same key', () => {
+    const p = tempEnvPath();
+    fs.writeFileSync(p, '# FOO=commented-stale\nFOO=CHANGEME\n');
+
+    writeEnvVars(p, { FOO: 'real-value' });
+
+    const lines = fs.readFileSync(p, 'utf-8').trim().split('\n');
+    expect(lines).toEqual(['# FOO=commented-stale', 'FOO=real-value']);
+  });
+
+  it('does not mistake an ordinary prose comment for a commented-out key', () => {
+    const p = tempEnvPath();
+    fs.writeFileSync(p, '# note: this only applies if CHANNEL_DRIVER=meta\nFOO=bar\n');
+
+    writeEnvVars(p, { CHANNEL_DRIVER: 'meta' });
+
+    const lines = fs.readFileSync(p, 'utf-8').trim().split('\n');
+    // The prose comment is untouched; CHANNEL_DRIVER is appended fresh, since
+    // there was no real commented-out placeholder for it to uncomment.
+    expect(lines[0]).toBe('# note: this only applies if CHANNEL_DRIVER=meta');
+    expect(lines).toContain('CHANNEL_DRIVER=meta');
+  });
+
   it('normalizes CRLF line endings to LF on write (no mixed-EOL file)', () => {
     const p = tempEnvPath();
     fs.writeFileSync(p, 'FOO=bar\r\nBAZ=CHANGEME\r\n');

--- a/tests/setup/interactive-setup.test.js
+++ b/tests/setup/interactive-setup.test.js
@@ -403,7 +403,15 @@ describe('stepMessagingChannels', () => {
     expect(io.asked.ask).toHaveLength(0);
   });
 
-  it('prints the full checklist (scopes, event, all 3 Request URLs, every slash command) before asking for credentials', async () => {
+  it('prints the full checklist (scopes, event, all 3 Request URLs, every ADDABLE slash command) before asking for credentials', async () => {
+    // /status is deliberately excluded from what this step tells the user to
+    // add — confirmed live: Slack rejects it outright as a reserved word, no
+    // matter what. Telling a user to add it here would send them straight
+    // into that wall. The feature stays reachable on Slack via the
+    // natural-language alternative text-message.handler.js added for this
+    // (see its own /status branch's comment) — this step must say so instead
+    // of silently omitting it, which is why the second assertion checks for
+    // an explicit note, not just the command's absence.
     const { stepMessagingChannels } = loadWizard({ probes: slackPass });
     const { SLACK_BOT_SCOPES, SLACK_SLASH_COMMANDS } = require('../../bot/scripts/setup/fields');
     const io = fakeIo({
@@ -414,7 +422,10 @@ describe('stepMessagingChannels', () => {
     await stepMessagingChannels(io, {}, () => {});
 
     for (const scope of SLACK_BOT_SCOPES) expect(log.text).toContain(scope);
-    for (const cmd of SLACK_SLASH_COMMANDS) expect(log.text).toContain(cmd);
+    for (const cmd of SLACK_SLASH_COMMANDS.filter((c) => c !== '/status')) expect(log.text).toContain(cmd);
+    // /status itself is still mentioned, but only inside the explanatory
+    // note below — never as a numbered row the user is told to go add.
+    expect(log.text).toMatch(/status.*reserve|reserve.*status/is);
     expect(log.text).toContain('https://my-tunnel.ngrok-free.dev/api/slack/events');
     expect(log.text).toContain('https://my-tunnel.ngrok-free.dev/api/slack/interactions');
     expect(log.text).toContain('https://my-tunnel.ngrok-free.dev/api/slack/commands');

--- a/tests/setup/interactive-setup.test.js
+++ b/tests/setup/interactive-setup.test.js
@@ -383,36 +383,157 @@ describe('optional extras', () => {
     expect(saved.AZURE_SPEECH_KEY).toBeUndefined();
   });
 
-  it('masks EVERY key of a multi-secret extra, not just the first — Slack needs both hidden', async () => {
-    // Azure's second key (a region string) isn't actually sensitive, which is
-    // why this went unnoticed until Slack's second key (a real bot token)
-    // needed masking too. Answering every OPTIONAL_EXTRAS question in order
-    // and inspecting what was actually asked with {secret: true} is the real
-    // behavioral contract — not just a static check of the field definition.
-    const { stepExtras } = loadWizard();
+  it('no longer lists Slack — it has its own step, not a single "Key" prompt (a whole channel with app-side config needs more than one field)', () => {
     const { OPTIONAL_EXTRAS } = require('../../bot/scripts/setup/fields');
-    const totalKeys = OPTIONAL_EXTRAS.reduce((n, e) => n + e.keys.length, 0);
-    const io = fakeIo({ select: ['add'], ask: new Array(totalKeys).fill('answer') });
+    expect(OPTIONAL_EXTRAS.some((e) => e.keys.includes('SLACK_BOT_TOKEN'))).toBe(false);
+  });
+});
 
-    await stepExtras(io, {}, () => {});
+describe('stepMessagingChannels', () => {
+  const slackPass = { slack: async () => ({ ok: true, detail: 'connected as My Workspace, all required scopes present' }) };
 
-    const slackExtra = OPTIONAL_EXTRAS.find((e) => e.keys.includes('SLACK_BOT_TOKEN'));
-    expect(Array.isArray(slackExtra.secret)).toBe(true);
+  it('defaults to declining Slack — WhatsApp alone is a complete setup', async () => {
+    const { stepMessagingChannels } = loadWizard();
+    const io = fakeIo({ confirm: [false] });
 
-    // Match each recorded question back to the Slack extra's own key order —
-    // io.asked.ask is a flat, in-order log of every "Key"-labelled prompt
-    // across all extras, so slice out the two entries belonging to Slack.
-    let cursor = 0;
-    const questionsByExtra = OPTIONAL_EXTRAS.map((extra) => {
-      const slice = io.asked.ask.slice(cursor, cursor + extra.keys.length);
-      cursor += extra.keys.length;
-      return { extra, slice };
+    const result = await stepMessagingChannels(io, {}, () => {});
+
+    expect(io.asked.confirm[0]).toMatch(/also connect slack/i);
+    expect(result).toEqual({ slack: false });
+    expect(io.asked.ask).toHaveLength(0);
+  });
+
+  it('prints the full checklist (scopes, event, all 3 Request URLs, every slash command) before asking for credentials', async () => {
+    const { stepMessagingChannels } = loadWizard({ probes: slackPass });
+    const { SLACK_BOT_SCOPES, SLACK_SLASH_COMMANDS } = require('../../bot/scripts/setup/fields');
+    const io = fakeIo({
+      confirm: [true],
+      ask: ['https://my-tunnel.ngrok-free.dev', 'signing-secret', 'xoxb-bot-token'],
     });
-    const { slice: slackQuestions } = questionsByExtra.find(({ extra }) => extra === slackExtra);
 
-    expect(slackQuestions).toHaveLength(2);
-    expect(slackQuestions[0].secret).toBe(true); // SLACK_SIGNING_SECRET
-    expect(slackQuestions[1].secret).toBe(true); // SLACK_BOT_TOKEN — the bug this fixes
+    await stepMessagingChannels(io, {}, () => {});
+
+    for (const scope of SLACK_BOT_SCOPES) expect(log.text).toContain(scope);
+    for (const cmd of SLACK_SLASH_COMMANDS) expect(log.text).toContain(cmd);
+    expect(log.text).toContain('https://my-tunnel.ngrok-free.dev/api/slack/events');
+    expect(log.text).toContain('https://my-tunnel.ngrok-free.dev/api/slack/interactions');
+    expect(log.text).toContain('https://my-tunnel.ngrok-free.dev/api/slack/commands');
+    expect(log.text).toContain('message.im');
+    expect(log.text).toMatch(/Socket Mode OFF/i);
+  });
+
+  it('walks the app config as 6 separate screens, one Press Enter between each, not one wall of text', async () => {
+    const { stepMessagingChannels } = loadWizard({ probes: slackPass });
+    const io = fakeIo({
+      confirm: [true],
+      ask: ['https://my-tunnel.ngrok-free.dev', 'signing-secret', 'xoxb-bot-token'],
+    });
+
+    await stepMessagingChannels(io, {}, () => {});
+
+    // 6 app-config screens (create app, scopes, events, interactivity, slash
+    // commands, install) — the credential prompts afterward are `ask`, not
+    // `pressEnter`, so this count is exactly the config walkthrough's length.
+    expect(io.asked.pressEnter).toBe(6);
+  });
+
+  it('presents the checklist in Slack\'s own sidebar order: create app -> scopes -> events -> interactivity -> slash commands -> install', async () => {
+    const { stepMessagingChannels } = loadWizard({ probes: slackPass });
+    const io = fakeIo({
+      confirm: [true],
+      ask: ['https://my-tunnel.ngrok-free.dev', 'signing-secret', 'xoxb-bot-token'],
+    });
+
+    await stepMessagingChannels(io, {}, () => {});
+
+    const order = ['Create the app', 'Bot Token Scopes', 'Event Subscriptions', 'Interactivity & Shortcuts', 'Slash Commands', 'Install the app']
+      .map((label) => log.text.indexOf(label));
+    expect(order.every((i) => i !== -1)).toBe(true);
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+  });
+
+  it('masks both Slack credentials — the signing secret AND the bot token', async () => {
+    const { stepMessagingChannels } = loadWizard({ probes: slackPass });
+    const io = fakeIo({
+      confirm: [true],
+      ask: ['https://my-tunnel.ngrok-free.dev', 'signing-secret', 'xoxb-bot-token'],
+    });
+
+    await stepMessagingChannels(io, {}, () => {});
+
+    // ask[0] is the base-URL prompt; the two Slack credential prompts follow.
+    expect(io.asked.ask[1].secret).toBe(true); // Signing Secret
+    expect(io.asked.ask[2].secret).toBe(true); // Bot User OAuth Token
+  });
+
+  it('saves both credentials once the live scope check passes', async () => {
+    const { stepMessagingChannels } = loadWizard({ probes: slackPass });
+    const saved = {};
+    const io = fakeIo({
+      confirm: [true],
+      ask: ['https://my-tunnel.ngrok-free.dev', 'a-signing-secret', 'xoxb-a-bot-token'],
+    });
+
+    const result = await stepMessagingChannels(io, {}, (vars) => Object.assign(saved, vars));
+
+    expect(saved.SLACK_SIGNING_SECRET).toBe('a-signing-secret');
+    expect(saved.SLACK_BOT_TOKEN).toBe('xoxb-a-bot-token');
+    expect(result).toEqual({ slack: true });
+  });
+
+  it('reports exactly which scopes are missing rather than a generic failure, and lets the user retry', async () => {
+    const scopeCheck = jest.fn()
+      .mockResolvedValueOnce({ ok: false, detail: 'token works, but is missing scopes: files:read, files:write' })
+      .mockResolvedValueOnce({ ok: true, detail: 'connected as My Workspace, all required scopes present' });
+    const { stepMessagingChannels } = loadWizard({ probes: { slack: scopeCheck } });
+    const io = fakeIo({
+      confirm: [true, true], // connect Slack, then "try again" after the failure
+      ask: [
+        'https://my-tunnel.ngrok-free.dev',
+        'signing-secret', 'xoxb-bot-token-1', // first attempt — missing scopes
+        'signing-secret', 'xoxb-bot-token-2', // retry — succeeds
+      ],
+    });
+
+    const result = await stepMessagingChannels(io, {}, () => {});
+
+    expect(scopeCheck).toHaveBeenCalledTimes(2);
+    expect(log.text).toContain('missing scopes: files:read, files:write');
+    expect(result).toEqual({ slack: true });
+  });
+
+  it('gives up cleanly if the user declines to retry after a failed check', async () => {
+    const { stepMessagingChannels } = loadWizard({ probes: { slack: async () => ({ ok: false, detail: 'HTTP 401' }) } });
+    const io = fakeIo({
+      confirm: [true, false], // connect Slack, then decline the retry
+      ask: ['https://my-tunnel.ngrok-free.dev', 'signing-secret', 'xoxb-bot-token'],
+    });
+
+    const result = await stepMessagingChannels(io, {}, () => {});
+    expect(result).toEqual({ slack: false });
+  });
+
+  it('rejects a non-https base URL — Slack refuses anything else', async () => {
+    const { stepMessagingChannels } = loadWizard({ probes: slackPass });
+    const io = fakeIo({
+      confirm: [true],
+      ask: ['http://not-secure.example.com', 'signing-secret', 'xoxb-bot-token'],
+    });
+
+    await stepMessagingChannels(io, {}, () => {});
+
+    expect(io.validationFailures.some((f) => /https:\/\//.test(f.reason))).toBe(true);
+  });
+
+  it('skips straight through when Slack is already configured and still working', async () => {
+    const { stepMessagingChannels } = loadWizard({ probes: slackPass });
+    const env = { SLACK_SIGNING_SECRET: 'already-set', SLACK_BOT_TOKEN: 'xoxb-already-set' };
+    const io = fakeIo();
+
+    const result = await stepMessagingChannels(io, env, () => {});
+
+    expect(result).toEqual({ slack: true });
+    expect(io.asked.confirm).toHaveLength(0); // never even asked "also connect Slack?"
   });
 });
 

--- a/tests/setup/interactive-setup.test.js
+++ b/tests/setup/interactive-setup.test.js
@@ -399,7 +399,7 @@ describe('stepMessagingChannels', () => {
     const result = await stepMessagingChannels(io, {}, () => {});
 
     expect(io.asked.confirm[0]).toMatch(/also connect slack/i);
-    expect(result).toEqual({ slack: false });
+    expect(result).toEqual({ slack: false, discord: false });
     expect(io.asked.ask).toHaveLength(0);
   });
 
@@ -478,7 +478,7 @@ describe('stepMessagingChannels', () => {
 
     expect(saved.SLACK_SIGNING_SECRET).toBe('a-signing-secret');
     expect(saved.SLACK_BOT_TOKEN).toBe('xoxb-a-bot-token');
-    expect(result).toEqual({ slack: true });
+    expect(result).toEqual({ slack: true, discord: false });
   });
 
   it('reports exactly which scopes are missing rather than a generic failure, and lets the user retry', async () => {
@@ -499,7 +499,7 @@ describe('stepMessagingChannels', () => {
 
     expect(scopeCheck).toHaveBeenCalledTimes(2);
     expect(log.text).toContain('missing scopes: files:read, files:write');
-    expect(result).toEqual({ slack: true });
+    expect(result).toEqual({ slack: true, discord: false });
   });
 
   it('gives up cleanly if the user declines to retry after a failed check', async () => {
@@ -510,7 +510,7 @@ describe('stepMessagingChannels', () => {
     });
 
     const result = await stepMessagingChannels(io, {}, () => {});
-    expect(result).toEqual({ slack: false });
+    expect(result).toEqual({ slack: false, discord: false });
   });
 
   it('rejects a non-https base URL — Slack refuses anything else', async () => {
@@ -532,8 +532,102 @@ describe('stepMessagingChannels', () => {
 
     const result = await stepMessagingChannels(io, env, () => {});
 
-    expect(result).toEqual({ slack: true });
-    expect(io.asked.confirm).toHaveLength(0); // never even asked "also connect Slack?"
+    expect(result).toEqual({ slack: true, discord: false });
+    // Never asked "also connect Slack?" (Slack's own live check short-circuited
+    // that) — the one confirm() call that DOES happen is Discord's own
+    // "Also connect Discord?" question, asked unconditionally afterward.
+    expect(io.asked.confirm).toEqual(['Also connect Discord?']);
+  });
+});
+
+describe('stepDiscordChannel', () => {
+  const discordPass = { discord: async () => ({ ok: true, detail: 'connected as My App' }) };
+
+  function loadWizardWithDiscordCommands(registerImpl) {
+    jest.doMock('../../bot/scripts/setup/discord-register-commands', () => ({
+      registerDiscordCommands: registerImpl || jest.fn().mockResolvedValue({ registered: 9, guildScoped: false, commands: [] }),
+    }));
+    return loadWizard({ probes: discordPass });
+  }
+
+  it('defaults to declining Discord — WhatsApp alone is a complete setup', async () => {
+    const { stepDiscordChannel } = loadWizardWithDiscordCommands();
+    const io = fakeIo({ confirm: [false] });
+
+    const result = await stepDiscordChannel(io, {}, () => {});
+
+    expect(io.asked.confirm[0]).toMatch(/also connect discord/i);
+    expect(result).toEqual({ discord: false });
+    expect(io.asked.ask).toHaveLength(0);
+  });
+
+  it('walks the app config as 5 separate screens, one Press Enter between each', async () => {
+    const { stepDiscordChannel } = loadWizardWithDiscordCommands();
+    const io = fakeIo({ confirm: [true], ask: ['bot-token', 'app-id'] });
+
+    await stepDiscordChannel(io, {}, () => {});
+
+    expect(io.asked.pressEnter).toBe(5);
+  });
+
+  it('saves both credentials, registers slash commands, and reports success once the live check passes', async () => {
+    const registerImpl = jest.fn().mockResolvedValue({ registered: 9, guildScoped: false, commands: ['portal'] });
+    const { stepDiscordChannel } = loadWizardWithDiscordCommands(registerImpl);
+    const saved = {};
+    const io = fakeIo({ confirm: [true], ask: ['a-bot-token', 'an-app-id'] });
+
+    const result = await stepDiscordChannel(io, {}, (vars) => Object.assign(saved, vars));
+
+    expect(saved.DISCORD_BOT_TOKEN).toBe('a-bot-token');
+    expect(saved.DISCORD_APPLICATION_ID).toBe('an-app-id');
+    expect(registerImpl).toHaveBeenCalledWith({ token: 'a-bot-token', applicationId: 'an-app-id', guildId: undefined });
+    expect(result).toEqual({ discord: true });
+  });
+
+  it('masks the bot token but not the application id', async () => {
+    const { stepDiscordChannel } = loadWizardWithDiscordCommands();
+    const io = fakeIo({ confirm: [true], ask: ['a-bot-token', 'an-app-id'] });
+
+    await stepDiscordChannel(io, {}, () => {});
+
+    expect(io.asked.ask[0].secret).toBe(true); // Bot Token
+    expect(io.asked.ask[1].secret).toBeFalsy(); // Application ID
+  });
+
+  it('still reports success even if slash-command registration itself fails — that is retriable separately', async () => {
+    const registerImpl = jest.fn().mockRejectedValue(new Error('network error'));
+    const { stepDiscordChannel } = loadWizardWithDiscordCommands(registerImpl);
+    const io = fakeIo({ confirm: [true], ask: ['a-bot-token', 'an-app-id'] });
+
+    const result = await stepDiscordChannel(io, {}, () => {});
+
+    expect(result).toEqual({ discord: true });
+  });
+
+  it('gives up cleanly if the user declines to retry after a failed check', async () => {
+    const { stepDiscordChannel } = loadWizardWithDiscordCommands();
+    jest.resetModules();
+    jest.doMock('../../bot/scripts/setup/discord-register-commands', () => ({ registerDiscordCommands: jest.fn() }));
+    jest.doMock('../../bot/scripts/setup/doctor', () => ({
+      defaultProbes: { discord: async () => ({ ok: false, detail: 'HTTP 401' }) },
+      runDoctor: jest.fn(),
+    }));
+    const wizard = require(WIZARD);
+    const io = fakeIo({ confirm: [true, false], ask: ['bad-token', 'an-app-id'] });
+
+    const result = await wizard.stepDiscordChannel(io, {}, () => {});
+    expect(result).toEqual({ discord: false });
+  });
+
+  it('skips straight through when Discord is already configured and still working', async () => {
+    const { stepDiscordChannel } = loadWizardWithDiscordCommands();
+    const env = { DISCORD_BOT_TOKEN: 'already-set', DISCORD_APPLICATION_ID: 'already-set' };
+    const io = fakeIo();
+
+    const result = await stepDiscordChannel(io, env, () => {});
+
+    expect(result).toEqual({ discord: true });
+    expect(io.asked.confirm).toHaveLength(0); // never even asked "also connect Discord?"
   });
 });
 

--- a/tests/setup/interactive-setup.test.js
+++ b/tests/setup/interactive-setup.test.js
@@ -382,6 +382,38 @@ describe('optional extras', () => {
     expect(saved.SONIOX_API_KEY).toBe('soniox-key');
     expect(saved.AZURE_SPEECH_KEY).toBeUndefined();
   });
+
+  it('masks EVERY key of a multi-secret extra, not just the first — Slack needs both hidden', async () => {
+    // Azure's second key (a region string) isn't actually sensitive, which is
+    // why this went unnoticed until Slack's second key (a real bot token)
+    // needed masking too. Answering every OPTIONAL_EXTRAS question in order
+    // and inspecting what was actually asked with {secret: true} is the real
+    // behavioral contract — not just a static check of the field definition.
+    const { stepExtras } = loadWizard();
+    const { OPTIONAL_EXTRAS } = require('../../bot/scripts/setup/fields');
+    const totalKeys = OPTIONAL_EXTRAS.reduce((n, e) => n + e.keys.length, 0);
+    const io = fakeIo({ select: ['add'], ask: new Array(totalKeys).fill('answer') });
+
+    await stepExtras(io, {}, () => {});
+
+    const slackExtra = OPTIONAL_EXTRAS.find((e) => e.keys.includes('SLACK_BOT_TOKEN'));
+    expect(Array.isArray(slackExtra.secret)).toBe(true);
+
+    // Match each recorded question back to the Slack extra's own key order —
+    // io.asked.ask is a flat, in-order log of every "Key"-labelled prompt
+    // across all extras, so slice out the two entries belonging to Slack.
+    let cursor = 0;
+    const questionsByExtra = OPTIONAL_EXTRAS.map((extra) => {
+      const slice = io.asked.ask.slice(cursor, cursor + extra.keys.length);
+      cursor += extra.keys.length;
+      return { extra, slice };
+    });
+    const { slice: slackQuestions } = questionsByExtra.find(({ extra }) => extra === slackExtra);
+
+    expect(slackQuestions).toHaveLength(2);
+    expect(slackQuestions[0].secret).toBe(true); // SLACK_SIGNING_SECRET
+    expect(slackQuestions[1].secret).toBe(true); // SLACK_BOT_TOKEN — the bug this fixes
+  });
 });
 
 describe('the template is a set of suggestions, not answers', () => {

--- a/tests/setup/source-hygiene.test.js
+++ b/tests/setup/source-hygiene.test.js
@@ -17,6 +17,22 @@ const { execFileSync } = require('child_process');
 
 const ROOT = path.resolve(__dirname, '../..');
 
+// Other test suites legitimately create and remove real directories under
+// the repo root while these tree-walkers run concurrently in a different
+// Jest worker (e.g. tests/setup/graduate.test.js's repo-anchored
+// .rumi-test-state fixture) — a directory listed at readdirSync time can be
+// gone by the time a walker recurses into it. That's not a real hygiene
+// violation, just a benign race; treat a vanished directory as empty rather
+// than letting ENOENT fail an unrelated test. Confirmed live in CI.
+function safeReaddirSync(d) {
+  try {
+    return fs.readdirSync(d, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT' || error.code === 'ENOTDIR') return [];
+    throw error;
+  }
+}
+
 // Internal ticket namespaces. Includes the dashboard's own `plt-*` / `etv-*` bead
 // prefixes (they leaked through `Bead:` comment headers + SQL migration headers because
 // the original guard only knew bd-/BUG-/PROJ-/FEAT-/TASK- and never scanned .sql).
@@ -46,7 +62,7 @@ function collectAgentDocs() {
     if (fs.existsSync(p)) docs.push(p);
   }
   const walk = (d) => {
-    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+    for (const e of safeReaddirSync(d)) {
       const p = path.join(d, e.name);
       if (e.isDirectory()) {
         if (['node_modules', '.git', 'dist', 'build', 'coverage'].includes(e.name)) continue;
@@ -61,7 +77,7 @@ function collectAgentDocs() {
   const claudeDir = path.join(ROOT, '.claude');
   if (fs.existsSync(claudeDir)) {
     const walkMd = (d) => {
-      for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      for (const e of safeReaddirSync(d)) {
         const p = path.join(d, e.name);
         if (e.isDirectory()) { if (e.name !== 'node_modules') walkMd(p); }
         else if (e.name.endsWith('.md')) docs.push(p);
@@ -76,7 +92,7 @@ function collectAgentDocs() {
 function collectAllMarkdown() {
   const out = [];
   const walk = (d) => {
-    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+    for (const e of safeReaddirSync(d)) {
       const p = path.join(d, e.name);
       if (e.isDirectory()) {
         if (['node_modules', '.git', 'dist', 'build', 'coverage'].includes(e.name)) continue;
@@ -96,7 +112,7 @@ function collect(dir, exts) {
   const abs = path.join(ROOT, dir);
   if (!fs.existsSync(abs)) return out;
   const walk = (d) => {
-    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+    for (const e of safeReaddirSync(d)) {
       const p = path.join(d, e.name);
       if (e.isDirectory()) {
         if (['node_modules', '.git', 'dist', 'build', 'coverage', 'tests', '__tests__'].includes(e.name)) continue;

--- a/tests/video/sqs-worker-stale-video-recovery.test.js
+++ b/tests/video/sqs-worker-stale-video-recovery.test.js
@@ -1,0 +1,103 @@
+/**
+ * sqs-worker.js#recoverStaleVideoRequests — a video job stuck in
+ * 'processing' past the stale threshold must be re-queued WITHOUT dropping
+ * its originating channel identifier (`from`), and the max-retries apology
+ * must deliver to session.recipient_identifier, never a users.phone_number
+ * re-derivation (WhatsApp-only, would misdeliver a Slack-originated request).
+ *
+ * This was a real bug: the re-queue rebuilt the job payload from scratch and
+ * silently dropped `from`, so a video job that survived a restart could
+ * never deliver its completion message at all.
+ */
+
+function makeSupabase({ staleRequests }) {
+  function builder(resolveValue) {
+    const b = {
+      select: () => b,
+      eq: () => b,
+      lt: () => b,
+      update: () => ({ eq: () => Promise.resolve({ data: null, error: null }) }),
+      then: (resolve) => resolve(resolveValue),
+    };
+    return b;
+  }
+  return {
+    from(table) {
+      if (table === 'video_requests') return builder({ data: staleRequests, error: null });
+      throw new Error(`Unexpected table in test: ${table}`);
+    },
+  };
+}
+
+function load({ staleRequests = [] } = {}) {
+  jest.resetModules();
+  jest.doMock('../../bot/shared/config/supabase', () => makeSupabase({ staleRequests }));
+  jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+  jest.doMock('../../bot/shared/utils/structured-logger', () => ({
+    runWithCorrelation: (id, fn) => fn(),
+    generateCorrelationId: () => 'corr-1',
+  }));
+  const whatsapp = { sendMessage: jest.fn().mockResolvedValue(true) };
+  jest.doMock('../../bot/shared/services/whatsapp.service', () => whatsapp);
+  const sqsQueue = {
+    queueVideoJob: jest.fn().mockResolvedValue('msg-id'),
+    queueJob: jest.fn().mockResolvedValue('msg-id'),
+  };
+  jest.doMock('../../bot/shared/services/queue', () => sqsQueue);
+  jest.doMock('../../bot/shared/services/coaching-orchestrator.service', () => ({}));
+  jest.doMock('../../bot/workers/lesson-plan-extraction.worker', () => ({}));
+  jest.doMock('../../bot/workers/lesson-plan-generation.worker', () => ({}));
+  jest.doMock('../../bot/workers/video-generation.worker', () => ({}));
+  jest.doMock('../../bot/workers/exam-grading.worker', () => ({}));
+
+  const worker = require('../../bot/workers/sqs-worker');
+  return { worker, whatsapp, sqsQueue };
+}
+
+afterEach(() => jest.resetModules());
+
+describe('recoverStaleVideoRequests — recipient_identifier preservation', () => {
+  it('re-queues a stale video job WITH `from` preserved from recipient_identifier, not dropped', async () => {
+    const staleRequest = {
+      id: 'video-1', user_id: 'user-1', topic: 'fractions', language: 'en',
+      customization: null, style: 'infographic', retry_count: 0, session_id: 'sess-1',
+      recipient_identifier: 'slack:U0123ABC',
+    };
+    const { worker, sqsQueue } = load({ staleRequests: [staleRequest] });
+
+    await worker.recoverStaleVideoRequests();
+
+    expect(sqsQueue.queueVideoJob).toHaveBeenCalledWith(
+      'video-1',
+      'video_generation',
+      expect.objectContaining({ from: 'slack:U0123ABC', videoRequestId: 'video-1' })
+    );
+  });
+
+  it('sends the max-retries apology to recipient_identifier, never a users.phone_number re-derivation', async () => {
+    const staleRequest = {
+      id: 'video-2', user_id: 'user-2', topic: 'algebra', language: 'en',
+      customization: null, style: 'infographic', retry_count: 3, session_id: 'sess-2',
+      recipient_identifier: 'slack:U0999XYZ',
+    };
+    const { worker, whatsapp, sqsQueue } = load({ staleRequests: [staleRequest] });
+
+    await worker.recoverStaleVideoRequests();
+
+    expect(whatsapp.sendMessage).toHaveBeenCalledWith('slack:U0999XYZ', expect.stringContaining('algebra'));
+    expect(sqsQueue.queueVideoJob).not.toHaveBeenCalled(); // exceeded retries — marked failed, not re-queued
+  });
+
+  it('does not send an apology when recipient_identifier is missing (never guesses a channel)', async () => {
+    const staleRequest = {
+      id: 'video-3', user_id: 'user-3', topic: 'geometry', language: 'en',
+      customization: null, style: 'infographic', retry_count: 3, session_id: 'sess-3',
+      recipient_identifier: null,
+    };
+    const { worker, whatsapp } = load({ staleRequests: [staleRequest] });
+
+    await worker.recoverStaleVideoRequests();
+
+    expect(whatsapp.sendMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds Slack **and** Discord as fully working messaging channels that run **concurrently** with WhatsApp — a teacher can be reached on any combination of the three, at the same time, on the same account.

- **Concurrent-driver architecture**: `messaging/index.js` is a router that dispatches by identifier prefix (`slack:...`, `discord:...`, or a bare phone number), so ~500 existing WhatsApp call sites needed zero changes.
- **Multi-homed identity**: a `user_channels` table lets one person be recognized across channels, while session/conversation state stays strictly per-channel (a conversation on one channel never interferes with the same person's conversation on another).
- **Full Slack driver**: text, reactions, images/audio/documents (both directions, inbound via `file_share` events), real Block Kit interactive buttons/menus (no text-degradation), native Block Kit modals for registration/settings, and Slash Commands via a new `/api/slack/commands` route.
- **Full Discord driver**: a persistent Gateway connection (like the Baileys sandbox driver, not a webhook like Slack) delivering plain messages, slash commands, and button/select interactions all over one socket. Text, reactions, media, typing indicators, real native buttons/select menus, and size-gated video delivery (prefers a durable URL over a raw upload above Discord's practical DM upload ceiling).
- **Discord's modal-workaround system**: Discord modals can only contain text inputs — no dropdowns — unlike Slack's Block Kit modals. Built a renderer that collects enum fields via ordinary chat messages carrying real select menus *before* opening a modal for whatever free-text fields remain, including a 2-step picker for the 164-country registration list (Discord caps a select menu at 25 options) and a Redis-backed state hand-off for multi-screen flows.
- **Every feature working on both channels**: registration, settings, attendance/class-setup (including the add-student loop), exam-checker's student-confirmation step, and reading assessment (the last of these extracted into a real, reusable endpoint file for the first time — previously it only existed as inline logic in the WhatsApp NFM handler).
- **Guided setup for both**: `rumi setup` walks through each app's configuration one section at a time, then live-verifies the credentials actually work (Slack: confirms the token carries every required scope via `auth.test`, naming exactly what's missing if not; Discord: confirms the bot token authenticates and its application id matches).
- **Slash-command registration**: Slack's commands are added one at a time in its app-config UI (walked through by the wizard); Discord's are registered in one REST call via a new script (`npm run discord:register-commands`), reusing the same command list so the two can never drift apart. One exception: `/status` is a Slack-reserved word (Slack refuses to register it, full stop) — the Slack wizard step skips it and explains why; the feature stays reachable on Slack via a natural-language alternative ("my status" / "show status" / "what's running").
- **Origin-channel-only delivery**: background jobs (coaching, exam grading, video generation, quizzes) deliver back to the exact channel identifier that made the request — never fan out to a person's other linked channels.

## Also fixed along the way

Real, pre-existing bugs found and fixed during this work (verified against `main` before fixing, none specific to either new channel unless noted):

**Found via a full live end-to-end pass against a real Slack workspace** (every feature with a Slack renderer, one by one — see Testing below):
- **Registration was completely broken on Slack, 100% of the time.** The 164-country field was a single `static_select`, but Slack caps that element at 100 options — every `/register` attempt failed immediately with an API error the moment the modal tried to open. Fixed with the same region-bucket-then-country picker Discord's registration already uses. A second bug surfaced mid-fix: Slack's `input` blocks are inert on interaction unless the block sets `dispatch_action: true` — without it the live region→country refresh silently never happened, even though Slack's own UI looked like it worked.
- **exam-checker was completely non-functional on Slack, from its very first step.** `sendInteractiveMessage()` only handled Meta's list-shaped payloads; exam-checker's prompts are all button-shaped, so they were silently dropped with no error anywhere. Fixed by branching on payload shape.
- **`/status` was unreachable on Slack by any method.** Slack rejects it as a reserved slash-command name, and separately, Slack's own client intercepts anything typed starting with `/` before the bot ever sees it — so there was no registered-command path and no plain-text path either. Fixed with a natural-language trigger.

**Found earlier in the same work:**
- Natural-language quiz requests ("create a quiz on X") were silently misrouted into lesson-plan generation on **every** channel — a working, unit-tested quiz-intent detector existed but was never wired into the text handler.
- A hardcoded Urdu error message in the voice handler ignored the user's actual language preference.
- Baileys' graceful shutdown could hang forever (and keep printing QR codes) when the process was interrupted while unpaired.
- AI-generated videos were uploaded raw to WhatsApp/Slack even when a durable cloud URL was already available one line earlier in the same function — wasting a large upload every time; now the URL is preferred whenever it exists.
- A module-import bug (missing destructuring) that would have made the exam-checker's grading call silently `undefined` in production the first time anyone completed exam confirmation on either new channel.
- A `/register` fallback bug: a brand-new Slack/Discord user with zero prior feature usage fell through to a WhatsApp-flavored "try a feature first" guide message instead of ever reaching the actual registration form — that gate only makes sense for WhatsApp's plain-text fallback.
- A Discord UX bug found via live testing: settings' dropdowns pre-selected the current value, but Discord's client sends no interaction at all when you re-pick an already-selected option, silently stalling the flow until timeout; fixed by surfacing the current value in the placeholder text instead, and by adding an explicit message when a flow does genuinely time out (previously silent).
- Two schema idempotency bugs (found while bootstrapping a fresh database) and a stale, unfrozen-time test bug.
- attendance/class-setup and exam-checker's student-confirmation step had no Slack renderer at all before this PR (a pre-existing gap, not introduced here) — built for both channels as part of this same PR rather than left for later.

## Testing

- Full suite green: 203/203 test suites, 2487/2487 tests — verified twice, once with a normal install and once simulating exactly what CI does (a missing bot-only dependency at the point the root suite runs), which caught and fixed a real CI-safety gap (`discord.js` wasn't resolvable at the repo root).
- **A full live end-to-end pass against a real Slack workspace**, feature by feature: plain text chat, reactions, `/menu`, `/settings` (full modal flow), `/register` (full modal flow, including the fixed country picker), image upload with real vision analysis, quiz generation (both natural-language and the confirmation buttons), attendance/class-setup (the full Add-Another/Done loop, ending in a real created class), a voice message through the complete transcribe → respond → speak pipeline (Soniox → ElevenLabs), and exam-checker's and reading-assessment's/video's expected graceful degradation where credentials aren't configured. This pass is what surfaced and got the 3 bugs above fixed and re-verified live.
- Manually tested live against a real Discord server too: plain text conversation, voice message transcription + reply, images, all slash commands, the settings flow, and the registration flow (including Discord's 2-step country/region pickers and multi-select subjects field).
- Confirmed origin-channel delivery and session isolation live: messaging the bot on WhatsApp, Slack, and Discord in the same session produced independent conversations with no cross-talk, and each account's identity resolved to a separate, correctly-scoped user row.

## What's NOT in this PR

- Live end-to-end testing of the exam-checker's full OCR pipeline and coaching/lesson-plan generation against real credentials — this environment has no Mistral/Chandra/Gamma keys configured. The interactive-message layer these features depend on (the part that was actually broken) is now fixed and verified; the OCR/generation logic itself is equally gated on WhatsApp without those keys, so this is a credentials gap, not a channel-specific one.
- A Slack renderer for reading assessment — the new endpoint file's contract is renderer-agnostic, so this is a pure additive follow-up, not a redesign, whenever it's needed.
