### PR TITLE
Slack/Discord attendance tap-to-mark + related fixes

### DIFF
--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -1533,6 +1533,21 @@ async function handleTextMessage(message, from, messageBody, user = null) {
 
         let result;
 
+        // A fresh attendance trigger ("attendance", "حاضری", ...) sent while
+        // already mid-flow means the teacher wants to start over, not answer
+        // whatever state-specific prompt is pending — without this, a stuck
+        // or half-abandoned session (e.g. a channel that silently dropped a
+        // step) has no way back in except explicitly typing "cancel" first,
+        // and instead gets misread as an answer to that prompt (e.g.
+        // AWAITING_VERIFICATION's yes/edit/cancel check). Excluded from
+        // PROCESSING, which already has its own wait/timeout handling and
+        // shouldn't be interrupted mid-generation by this.
+        const attendanceRetrigger = AttendanceDetectorService.detectAttendanceIntent(messageBody);
+        if (sessionState.state !== AttendanceConversationService.STATES.PROCESSING && attendanceRetrigger.detected) {
+          logToFile('📋 Attendance trigger received mid-session, restarting', { userId: user.id, previousState: sessionState.state });
+          await AttendanceConversationService.clearSessionState(user.id);
+          result = await AttendanceConversationService.startAttendanceSession(user.id);
+        } else {
         // Route based on current state
         switch (sessionState.state) {
           case AttendanceConversationService.STATES.AWAITING_CLASS_SELECTION:
@@ -1610,6 +1625,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
               action: 'ERROR',
               message: 'Something went wrong with attendance. Say "attendance" to start again.'
             };
+        }
         }
 
         typingController.stop();

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -1648,6 +1648,11 @@ async function handleTextMessage(message, from, messageBody, user = null) {
               body: result.message,
               buttons: [{ id: 'open_modal:attendance_mark', title: 'Mark Attendance' }],
             });
+          } else if (driverForIdentifier(from) === 'discord') {
+            await WhatsAppService.sendInteractiveButtons(from, {
+              body: result.message,
+              buttons: [{ id: 'discord_start_flow:attendance_mark', title: 'Mark Attendance' }],
+            });
           } else if (ATTENDANCE_MARKING_FLOW_ID) {
             const sessionState = await AttendanceConversationService.getSessionState(user.id);
             const today = new Date().toISOString().split('T')[0];

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -1653,7 +1653,7 @@ async function handleTextMessage(message, from, messageBody, user = null) {
               body: result.message,
               buttons: [{ id: 'discord_start_flow:attendance_mark', title: 'Mark Attendance' }],
             });
-          } else if (ATTENDANCE_MARKING_FLOW_ID) {
+          } else {
             const sessionState = await AttendanceConversationService.getSessionState(user.id);
             const today = new Date().toISOString().split('T')[0];
             // Flow token format: userId:classId:date:sessionType:className - all data for response handling
@@ -1664,8 +1664,17 @@ async function handleTextMessage(message, from, messageBody, user = null) {
             // Dynamic header with class + section (e.g., "5A Attendance")
             const displayName = section ? `${className}${section}` : className;
 
-            await WhatsAppService.sendFlow(from, {
+            // Baileys has no real Flow support at all — sendFlow() degrades
+            // to the 'attendance-mark' text-flow definition
+            // (text-flow-definitions.js) via flowKind, exactly like
+            // class-setup's own sendFlow() call above already does. Meta
+            // simply ignores flowKind and uses flowId for the real Flow.
+            // Called unconditionally (not gated behind ATTENDANCE_MARKING_FLOW_ID)
+            // so Baileys gets tap-to-mark even with no Meta Flow registered —
+            // the boolean return value decides whether to fall back.
+            const markingSent = await WhatsAppService.sendFlow(from, {
               flowId: ATTENDANCE_MARKING_FLOW_ID,
+              flowKind: 'attendance-mark',
               header: `📋 ${displayName} Attendance`,
               body: result.message,
               buttonText: 'Mark Attendance',
@@ -1673,17 +1682,19 @@ async function handleTextMessage(message, from, messageBody, user = null) {
               // The endpoint determines first screen via INIT response
               flowToken: flowToken
             });
-            logToFile('📋 Sent attendance marking flow', {
-              userId: user.id,
-              flowId: ATTENDANCE_MARKING_FLOW_ID,
-              classId: sessionState?.selectedListId,
-              studentCount: result.students?.length,
-              className: className
-            });
-          } else {
-            // Fallback if flow not configured
-            await WhatsAppService.sendMessage(from, 'The marking form is not configured. Please use voice marking instead.\n\nSay something like: "Everyone is here except Ali and Sara"');
-            logToFile('⚠️ ATTENDANCE_MARKING_FLOW_ID not configured', { userId: user.id });
+
+            if (markingSent) {
+              logToFile('📋 Sent attendance marking flow', {
+                userId: user.id,
+                flowId: ATTENDANCE_MARKING_FLOW_ID,
+                classId: sessionState?.selectedListId,
+                studentCount: result.students?.length,
+                className: className
+              });
+            } else {
+              await WhatsAppService.sendMessage(from, 'The marking form is not configured. Please use voice marking instead.\n\nSay something like: "Everyone is here except Ali and Sara"');
+              logToFile('⚠️ Attendance marking flow unavailable on this channel', { userId: user.id });
+            }
           }
         } else if (result.action === 'GENERATE_ATTENDANCE') {
           // Send initial "generating" message

--- a/bot/shared/handlers/text-message.handler.js
+++ b/bot/shared/handlers/text-message.handler.js
@@ -1620,8 +1620,19 @@ async function handleTextMessage(message, from, messageBody, user = null) {
         } else if (result.action === 'AWAIT_VOICE_INPUT' || result.action === 'PROMPT_VOICE') {
           await WhatsAppService.sendMessage(from, result.message);
         } else if (result.action === 'SEND_MARKING_FLOW') {
-          // Send the WhatsApp Flow for marking attendance (encryption endpoint implemented)
-          if (ATTENDANCE_MARKING_FLOW_ID) {
+          // Slack has a real Flow-equivalent (attendance_mark's checkbox
+          // modal — see slack-flow-registry.js), not sendFlow()'s Meta/
+          // Baileys-shaped {flowId, flowToken} contract. Same
+          // driverForIdentifier() branch shape as the addClassDetection
+          // block below and /settings above. The roster this modal needs
+          // is already sitting in the Redis session handleMarkingMethodSelection
+          // just saved — the modal's own INIT reads it back by userId.
+          if (driverForIdentifier(from) === 'slack') {
+            await WhatsAppService.sendInteractiveButtons(from, {
+              body: result.message,
+              buttons: [{ id: 'open_modal:attendance_mark', title: 'Mark Attendance' }],
+            });
+          } else if (ATTENDANCE_MARKING_FLOW_ID) {
             const sessionState = await AttendanceConversationService.getSessionState(user.id);
             const today = new Date().toISOString().split('T')[0];
             // Flow token format: userId:classId:date:sessionType:className - all data for response handling

--- a/bot/shared/routes/attendance-marking-endpoint.js
+++ b/bot/shared/routes/attendance-marking-endpoint.js
@@ -1,0 +1,93 @@
+/**
+ * Attendance Marking Endpoint Handler
+ *
+ * The Slack/Discord modal-workaround counterpart to the WhatsApp attendance
+ * marking Flow (docs/flows/attendance-marking-flow.json's CheckboxGroup).
+ * Reuses the roster attendance-conversation.service.js's
+ * handleMarkingMethodSelection('tap' branch) already loaded into Redis —
+ * this endpoint only reads that session by userId, it never re-queries
+ * the class roster itself.
+ *
+ * Flow:
+ * 1. INIT → MARK_ABSENT screen (roster from the existing Redis session)
+ * 2. MARK_ABSENT submit → build records, SUCCESS screen
+ *
+ * Created: 2026-08-25
+ */
+
+const AttendanceConversationService = require('../services/attendance-conversation.service');
+const AttendanceFlowHandler = require('../handlers/attendance-flow.handler');
+const AttendanceGeneratorService = require('../services/attendance-generator.service');
+const { logToFile } = require('../utils/logger');
+
+/**
+ * Handle INIT action - provide the MARK_ABSENT screen from the existing
+ * attendance-conversation session (already loaded when the teacher picked
+ * "Tap to Mark").
+ * @param {string} userId - User ID
+ * @returns {Object} - Response with the roster, or an error if no session
+ */
+async function handleMarkingInit(userId) {
+  const sessionState = await AttendanceConversationService.getSessionState(userId);
+  const students = sessionState?.students || [];
+
+  if (!sessionState || students.length === 0) {
+    logToFile('⚠️ Marking flow INIT with no active session', { userId });
+    return { data: { error: { message: 'No attendance session found. Say "attendance" to start again.' } } };
+  }
+
+  return {
+    screen: 'MARK_ABSENT',
+    data: {
+      students: students.map((s) => ({ id: s.id, title: s.student_name })),
+      class_display: AttendanceConversationService.formatClassDisplayName(sessionState.selectedClass),
+    },
+  };
+}
+
+/**
+ * Handle MARK_ABSENT submission - builds attendance records from the
+ * checked (absent) student ids, everyone else is present.
+ * @param {string} userId - User ID
+ * @param {string} screen - Current screen ID
+ * @param {Object} screenData - { absent_student_ids: string[] }
+ * @returns {Object} - SUCCESS screen with records/stats for onFinish delivery
+ */
+async function handleMarkingExchange(userId, screen, screenData) {
+  if (screen !== 'MARK_ABSENT') {
+    return { data: { error: { message: 'Unknown screen' } } };
+  }
+
+  const sessionState = await AttendanceConversationService.getSessionState(userId);
+  if (!sessionState || !sessionState.students) {
+    return { data: { error: { message: 'Session expired. Say "attendance" to start again.' } } };
+  }
+
+  const absentIds = screenData.absent_student_ids || [];
+  const records = AttendanceFlowHandler.buildAttendanceRecords(sessionState.students, absentIds);
+  const stats = AttendanceGeneratorService.calculateSummaryStats(records);
+  const classDisplay = AttendanceConversationService.formatClassDisplayName(sessionState.selectedClass);
+
+  logToFile('📋 Slack tap-to-mark submitted', {
+    userId,
+    listId: sessionState.selectedListId,
+    total: stats.total,
+    present: stats.present,
+    absent: stats.absent
+  });
+
+  return {
+    screen: 'SUCCESS',
+    data: {
+      success_message: AttendanceFlowHandler.generateConfirmationMessage(classDisplay, stats),
+      selectedClass: sessionState.selectedClass,
+      selectedListId: sessionState.selectedListId,
+      records,
+      stats,
+      sessionDate: sessionState.selectedDate,
+      sessionType: sessionState.sessionType
+    }
+  };
+}
+
+module.exports = { handleMarkingInit, handleMarkingExchange };

--- a/bot/shared/routes/discord-flow-registry.js
+++ b/bot/shared/routes/discord-flow-registry.js
@@ -97,6 +97,53 @@ function registerAll() {
     },
   }));
 
+  // attendance_mark reuses the SAME endpoint Slack registers
+  // (attendance-marking-endpoint.js is channel-agnostic — it only reads the
+  // roster already sitting in AttendanceConversationService's Redis session,
+  // keyed by userId, never anything Slack- or Discord-shaped). MARK_ABSENT
+  // is a one-shot all-enum screen (zero textFields, see
+  // discord-views/attendance-marking.view.js) so it never opens a Modal and
+  // needs no loopScreens/onScreenLoop — straight to exchange() -> SUCCESS.
+  const attendanceMarking = require('./attendance-marking-endpoint');
+  const attendanceMarkingView = require('./discord-views/attendance-marking.view');
+  register('attendance_mark', buildEndpointModal({
+    kind: 'attendance_mark',
+    init: (ctx) => attendanceMarking.handleMarkingInit(ctx.userId),
+    exchange: (ctx, screen, screenData) => attendanceMarking.handleMarkingExchange(ctx.userId, screen, screenData),
+    screenToSteps: attendanceMarkingView.screenToSteps,
+    mergeScreenData: attendanceMarkingView.mergeScreenData,
+    onFinish: async (response, ctx) => {
+      const { success_message: success, selectedClass, selectedListId, records, stats, sessionDate, sessionType } = response.data || {};
+      const recipientIdentifier = `discord:${ctx.discordUserId}`;
+      if (success) await discordChannel.sendMessage(recipientIdentifier, success);
+
+      const AttendanceDeliveryService = require('../services/attendance-delivery.service');
+      const AttendanceConversationService = require('../services/attendance-conversation.service');
+
+      try {
+        const deliveryResult = await AttendanceDeliveryService.processAndDeliver(ctx.userId, recipientIdentifier, {
+          selectedClass,
+          selectedListId,
+          records,
+          markingMethod: 'tap',
+          summary: {
+            present: stats?.present,
+            absent: stats?.absent,
+            attendancePercentage: parseFloat(stats?.attendanceRate) || 0,
+          },
+          sessionDate,
+          sessionType,
+        });
+
+        if (!deliveryResult.success && !deliveryResult.isDuplicate) {
+          await discordChannel.sendMessage(recipientIdentifier, `Sorry, there was an error generating your attendance file: ${deliveryResult.error}`);
+        }
+      } finally {
+        await AttendanceConversationService.clearSessionState(ctx.userId);
+      }
+    },
+  }));
+
   // exam_confirm is the one kind whose flowToken IS the exam session's own
   // session.id (set by the orchestrator at sendFlow-time), never a
   // buildFlowToken() "userId:kind:timestamp" token — the endpoint keys

--- a/bot/shared/routes/discord-views/attendance-marking.view.js
+++ b/bot/shared/routes/discord-views/attendance-marking.view.js
@@ -1,0 +1,81 @@
+/**
+ * Discord screen mapping for the tap-to-mark attendance Flow-equivalent —
+ * the counterpart to slack-views/attendance-marking.view.js, shaped for
+ * discord-modal-flow.js's screenToSteps()/mergeScreenData() contract.
+ *
+ * MARK_ABSENT is one (or more, chunked) multi-select StringSelectMenu
+ * field(s) over attendance-marking-endpoint.js's dynamically-sized
+ * `data.students` array — the same chunking need as discord-views/
+ * exam-confirm.view.js's CONFIRM_STUDENTS: real class sizes (20-40 students)
+ * routinely exceed Discord's 25-option StringSelectMenu cap.
+ *
+ * Convention matches docs/flows/attendance-marking-flow.json's CheckboxGroup
+ * and slack-views/attendance-marking.view.js: selecting a student marks them
+ * ABSENT; everyone else is present. Unlike exam-confirm's all-pre-selected
+ * "confirmed" semantics, nothing is pre-selected here (default: everyone
+ * present) — a selected box means the opposite thing on this screen.
+ *
+ * No text-fields modal at all for this screen — it's one (or two+) selects,
+ * nothing else, so it never opens a Discord Modal (see discord-modal-flow.js's
+ * runScreen(): a screen with zero textFields acks directly and calls
+ * exchange(), skipping showModal() entirely).
+ */
+
+const { StringSelectMenuBuilder } = require('discord.js');
+
+const CHUNK_SIZE = 25;
+
+function toOption(row) {
+  return { label: String(row.title).slice(0, 100), value: String(row.id).slice(0, 100) };
+}
+
+function chunkStudents(students) {
+  const chunks = [];
+  for (let i = 0; i < students.length; i += CHUNK_SIZE) {
+    chunks.push(students.slice(i, i + CHUNK_SIZE));
+  }
+  return chunks;
+}
+
+function buildChunkMenu(chunk, fieldName, placeholder) {
+  return new StringSelectMenuBuilder()
+    .setCustomId(fieldName)
+    .setPlaceholder(placeholder)
+    .setMinValues(0)
+    .setMaxValues(chunk.length)
+    .addOptions(chunk.map(toOption));
+}
+
+function screenToSteps(screen, data) {
+  if (screen === 'MARK_ABSENT') {
+    const students = data?.students || [];
+    const chunks = chunkStudents(students);
+    const classDisplay = data?.class_display || 'this class';
+
+    const steps = chunks.map((chunk, i) => ({
+      fieldName: `absent_students_chunk_${i}`,
+      promptText: chunks.length > 1
+        ? `Check who's ABSENT in ${classDisplay} (${i + 1}/${chunks.length}). Everyone else will be marked present:`
+        : `Check who's ABSENT in ${classDisplay}. Everyone else will be marked present:`,
+      buildMenu: () => buildChunkMenu(chunk, `absent_students_chunk_${i}`, `Students ${i + 1}-${i + chunk.length} of ${students.length}`),
+      multi: true,
+    }));
+
+    return { steps, textFields: [], title: 'Mark Attendance' };
+  }
+
+  throw new Error(`discord-views/attendance-marking: no screen mapping for "${screen}"`);
+}
+
+function mergeScreenData(screen, enumAnswers) {
+  if (screen === 'MARK_ABSENT') {
+    const absentStudentIds = Object.keys(enumAnswers)
+      .filter((key) => key.startsWith('absent_students_chunk_'))
+      .sort()
+      .flatMap((key) => enumAnswers[key] || []);
+    return { absent_student_ids: absentStudentIds };
+  }
+  return {};
+}
+
+module.exports = { screenToSteps, mergeScreenData, chunkStudents, toOption, CHUNK_SIZE };

--- a/bot/shared/routes/slack-flow-registry.js
+++ b/bot/shared/routes/slack-flow-registry.js
@@ -108,6 +108,62 @@ function registerAll() {
   // exam_confirm onFinish verbatim), looking the session back up by id to
   // recover the userId/from ExamCheckerOrchestrator.process() needs (ctx only
   // carries the session id as flowToken).
+  // attendance_mark's flowToken is a normal buildFlowToken() mint (unlike
+  // exam_confirm's session-id exception below) — the roster it needs comes
+  // from AttendanceConversationService's Redis session (keyed by userId,
+  // already populated by handleMarkingMethodSelection's 'tap' branch), not
+  // from anything carried in the flowToken itself.
+  //
+  // onFinish drives the real side effects on the terminal SUCCESS screen:
+  // DMs the confirmation, then hands off to AttendanceDeliveryService for
+  // Excel generation/upload/delivery + DB persistence, exactly like the
+  // WhatsApp Flow path (flow-response.handler.js's ATTENDANCE_MARKING_FLOW_ID
+  // branch) does after AttendanceFlowHandler.handleMarkingFlowSubmission.
+  // Session state is always cleared afterward, success or failure, matching
+  // text-message.handler.js's GENERATE_ATTENDANCE branch (never leave the
+  // conversation stuck in PROCESSING).
+  const attendanceMarking = require('./attendance-marking-endpoint');
+  const attendanceMarkingView = require('./slack-views/attendance-marking.view');
+  register('attendance_mark', buildEndpointModal({
+    kind: 'attendance_mark',
+    init: (ctx) => attendanceMarking.handleMarkingInit(ctx.userId),
+    exchange: (ctx, screen, screenData) => attendanceMarking.handleMarkingExchange(ctx.userId, screen, screenData),
+    screenToView: attendanceMarkingView.screenToView,
+    viewToScreenData: attendanceMarkingView.viewToScreenData,
+    firstInputBlockId: attendanceMarkingView.FIRST_INPUT_BLOCK_ID,
+    onFinish: async (response, ctx) => {
+      const { success_message: success, selectedClass, selectedListId, records, stats, sessionDate, sessionType } = response.data || {};
+      if (success) await slackWebClient.postMessage(ctx.slackUserId, success);
+
+      const AttendanceDeliveryService = require('../services/attendance-delivery.service');
+      const AttendanceConversationService = require('../services/attendance-conversation.service');
+      const { prefixFor } = require('../services/messaging/channel-registry');
+      const recipientIdentifier = `${prefixFor('slack')}:${ctx.slackUserId}`;
+
+      try {
+        const deliveryResult = await AttendanceDeliveryService.processAndDeliver(ctx.userId, recipientIdentifier, {
+          selectedClass,
+          selectedListId,
+          records,
+          markingMethod: 'tap',
+          summary: {
+            present: stats?.present,
+            absent: stats?.absent,
+            attendancePercentage: parseFloat(stats?.attendanceRate) || 0,
+          },
+          sessionDate,
+          sessionType,
+        });
+
+        if (!deliveryResult.success && !deliveryResult.isDuplicate) {
+          await slackWebClient.postMessage(ctx.slackUserId, `Sorry, there was an error generating your attendance file: ${deliveryResult.error}`);
+        }
+      } finally {
+        await AttendanceConversationService.clearSessionState(ctx.userId);
+      }
+    },
+  }));
+
   const examConfirm = require('./exam-confirm-endpoint');
   const examConfirmView = require('./slack-views/exam-confirm.view');
   register('exam_confirm', buildEndpointModal({

--- a/bot/shared/routes/slack-modal-interactions.handler.js
+++ b/bot/shared/routes/slack-modal-interactions.handler.js
@@ -163,6 +163,13 @@ async function handleAttendanceFinish(payload) {
     const response = await attendance.handleDoneAction(carry?.list_id, carry?.class_display);
     if (response?.data?.success_message) {
       await slackWebClient.postMessage(ctx.slackUserId, response.data.success_message);
+      // Also reflect completion in the modal itself — leaving it on the
+      // stale ADD_STUDENT form made a real success DM look like nothing
+      // happened (the teacher had to separately notice the DM).
+      const attendanceView = require('./slack-views/attendance.view');
+      const metadata = JSON.stringify({ kind: 'attendance', screen: 'SUCCESS', flowToken });
+      const view = attendanceView.screenToView('SUCCESS', response.data, { ...ctx, metadata });
+      await slackWebClient.updateView(payload.view.id, view);
     } else if (response?.data?.error && response.screen) {
       // Still needs at least one student — reopen ADD_STUDENT with the error,
       // via the SAME screenToView() the ordinary submission path uses (its

--- a/bot/shared/routes/slack-modal-interactions.handler.js
+++ b/bot/shared/routes/slack-modal-interactions.handler.js
@@ -127,7 +127,9 @@ async function handleOpenModal(payload) {
 
   try {
     const view = await renderer.buildInitialView(ctx);
-    await slackWebClient.openView(payload.trigger_id, view);
+    // null means buildInitialView already handled an init() error itself
+    // (DMed the teacher — see slack-modal-flow.js) — nothing left to open.
+    if (view) await slackWebClient.openView(payload.trigger_id, view);
   } catch (error) {
     logToFile('❌ Slack modal: failed to open initial view', { kind, error: error.message, stack: error.stack });
   }

--- a/bot/shared/routes/slack-views/attendance-marking.view.js
+++ b/bot/shared/routes/slack-views/attendance-marking.view.js
@@ -1,0 +1,88 @@
+/**
+ * Block Kit screen mapping for the tap-to-mark attendance Flow-equivalent —
+ * shaped for Slack's slack-modal-flow.js screenToView()/viewToScreenData()
+ * contract, modeled directly on slack-views/exam-confirm.view.js's
+ * `checkboxes` pattern.
+ *
+ * MARK_ABSENT renders the dynamically-sized roster (attendance-marking-
+ * endpoint.js's `data.students`, an array of {id, title}) as a single Block
+ * Kit `checkboxes` element. Like exam-confirm's roster, Slack's `checkboxes`
+ * element has no documented hard option cap (unlike Discord's 25-option
+ * StringSelectMenu, which needs chunking) — one block holds the whole class.
+ *
+ * Convention matches docs/flows/attendance-marking-flow.json's CheckboxGroup:
+ * checking a box marks that student ABSENT. Nothing is pre-checked (the
+ * default — everyone present), unlike exam-confirm's all-pre-checked
+ * "confirmed" semantics, since the two screens mean opposite things by a
+ * checked box.
+ */
+
+function toOption(row) {
+  // Block Kit option text is capped at 75 chars; the endpoint's rows are {id, title}.
+  return { text: { type: 'plain_text', text: String(row.title).slice(0, 75) }, value: String(row.id) };
+}
+
+function screenToView(screen, data, ctx) {
+  const metadata = ctx.metadata;
+
+  if (screen === 'MARK_ABSENT') {
+    const students = data?.students || [];
+    const options = students.map(toOption);
+
+    return {
+      type: 'modal',
+      callback_id: 'attendance_mark',
+      private_metadata: metadata,
+      title: { type: 'plain_text', text: (data?.class_display || 'Attendance').slice(0, 24) },
+      submit: { type: 'plain_text', text: 'Mark Attendance' },
+      blocks: [
+        {
+          type: 'section', block_id: 'instructions_block',
+          text: { type: 'plain_text', text: 'Check the students who are ABSENT. Everyone else will be marked present.' },
+        },
+        {
+          // optional: true — submitting with nobody checked (everyone
+          // present) is a valid, common case, not a validation failure.
+          type: 'input', block_id: 'absent_students_block', optional: true,
+          label: { type: 'plain_text', text: 'Absent students' },
+          element: {
+            type: 'checkboxes',
+            action_id: 'absent_students',
+            options,
+          },
+        },
+      ],
+    };
+  }
+
+  if (screen === 'SUCCESS') {
+    // Terminal confirmation shown in-modal; onFinish (slack-flow-registry.js)
+    // also DMs the same success_message and drives the actual Excel
+    // generation/delivery — this view is just the visual close-out.
+    return {
+      type: 'modal',
+      callback_id: 'attendance_mark',
+      private_metadata: metadata,
+      title: { type: 'plain_text', text: 'Attendance recorded' },
+      blocks: [
+        { type: 'section', block_id: 'success_block', text: { type: 'plain_text', text: data?.success_message || 'Attendance recorded!' } },
+      ],
+    };
+  }
+
+  throw new Error(`slack-views/attendance-marking: no view mapping for screen "${screen}"`);
+}
+
+function viewToScreenData(screen, stateValues) {
+  const get = (blockId, actionId) => stateValues?.[blockId]?.[actionId];
+
+  if (screen === 'MARK_ABSENT') {
+    const selected = get('absent_students_block', 'absent_students')?.selected_options || [];
+    return { absent_student_ids: selected.map((o) => o.value) };
+  }
+  return {};
+}
+
+const FIRST_INPUT_BLOCK_ID = { MARK_ABSENT: 'absent_students_block' };
+
+module.exports = { screenToView, viewToScreenData, FIRST_INPUT_BLOCK_ID, toOption };

--- a/bot/shared/routes/slack-views/attendance.view.js
+++ b/bot/shared/routes/slack-views/attendance.view.js
@@ -78,6 +78,12 @@ function screenToView(screen, data, ctx) {
       blocks: [
         ...(data?.class_info ? [{ type: 'section', block_id: 'class_info_block', text: { type: 'plain_text', text: data.class_info } }] : []),
         ...(data?.students_list ? [{ type: 'section', block_id: 'students_list_block', text: { type: 'plain_text', text: data.students_list } }] : []),
+        // handleDoneAction rejects "I'm Done" with 0 students by re-returning
+        // this same ADD_STUDENT screen with a `data.error`. Without this block
+        // the reopened modal was pixel-identical to before, so the rejection
+        // was invisible — see slack-modal-interactions.handler.js's
+        // handleAttendanceFinish for the other half of this fix.
+        ...(data?.error ? [{ type: 'section', block_id: 'add_student_error_block', text: { type: 'plain_text', text: `⚠️ ${data.error.message}` } }] : []),
         {
           type: 'input', block_id: 'first_name_block',
           label: { type: 'plain_text', text: 'Student first name' },
@@ -92,6 +98,24 @@ function screenToView(screen, data, ctx) {
           type: 'actions', block_id: 'attendance_finish_block',
           elements: [{ type: 'button', action_id: 'attendance_finish', style: 'primary', text: { type: 'plain_text', text: "I'm Done" } }],
         },
+      ],
+    };
+  }
+
+  if (screen === 'SUCCESS') {
+    // Terminal confirmation, shown via views.update after handleDoneAction
+    // succeeds — replaces the stale ADD_STUDENT form so the modal itself
+    // reflects completion rather than relying solely on the separate DM
+    // (see slack-modal-interactions.handler.js's handleAttendanceFinish).
+    // No `submit` — this is a dead-end screen, closeable via the modal's
+    // native X only.
+    return {
+      type: 'modal',
+      callback_id: 'attendance',
+      private_metadata: metadata,
+      title: { type: 'plain_text', text: 'All set!' },
+      blocks: [
+        { type: 'section', block_id: 'success_block', text: { type: 'plain_text', text: data?.success_message || 'Class created.' } },
       ],
     };
   }

--- a/bot/shared/services/attendance-conversation.service.js
+++ b/bot/shared/services/attendance-conversation.service.js
@@ -731,6 +731,20 @@ class AttendanceConversationService {
           };
         }
 
+        // An empty array is truthy — `!students` above does NOT catch a real
+        // class with zero students added yet (e.g. one where setup was
+        // abandoned right after CLASS_INFO, before any ADD_STUDENT step).
+        // Without this, a session gets saved with students: [], and the
+        // channel-specific marking screen later has to guess why its roster
+        // is empty — surfacing as a confusing "no session found" instead of
+        // the real, actionable reason.
+        if (students.length === 0) {
+          return {
+            action: 'ERROR',
+            message: `${this.formatClassDisplayName(sessionState.selectedClass)} has no students yet. Say "add class" to add students before marking attendance.`
+          };
+        }
+
         await this.saveSessionState(userId, {
           ...sessionState,
           state: STATES.AWAITING_VERIFICATION, // Will receive flow response
@@ -780,6 +794,15 @@ class AttendanceConversationService {
         return {
           action: 'ERROR',
           message: 'Sorry, could not load students. Please try again.'
+        };
+      }
+
+      // Same empty-array gap as the tap branch above — `!students` doesn't
+      // catch a real class with zero students added yet.
+      if (students.length === 0) {
+        return {
+          action: 'ERROR',
+          message: `${this.formatClassDisplayName(sessionState.selectedClass)} has no students yet. Say "add class" to add students before marking attendance.`
         };
       }
 

--- a/bot/shared/services/messaging/discord-modal-flow.js
+++ b/bot/shared/services/messaging/discord-modal-flow.js
@@ -400,6 +400,21 @@ function buildEndpointModal(config) {
      */
     async startFlow(ctx, triggerInteraction) {
       const response = await init(ctx);
+      if (response?.data?.error) {
+        // init() can legitimately fail for a kind whose first screen depends
+        // on state a prior async step must have already populated (e.g.
+        // attendance_mark's roster, sitting in a Redis session a different
+        // flow wrote) — unlike every other kind's init(), which always
+        // unconditionally returns a screen. Without this check, runScreen()
+        // crashes on screenToSteps(undefined, ...) BEFORE ever acking
+        // triggerInteraction, which is exactly what "the application didn't
+        // respond in time" looks like — confirmed live, not a guess.
+        logToFile('⚠️ Discord modal-flow: init() returned an error with no screen to render', { kind, error: response.data.error.message });
+        await triggerInteraction.deferUpdate();
+        const discordChannel = require('./discord-channel.service');
+        await discordChannel.sendMessage(`discord:${ctx.discordUserId}`, response.data.error.message);
+        return 'finished';
+      }
       return this.runScreen(ctx, triggerInteraction, response.screen, response.data);
     },
 

--- a/bot/shared/services/messaging/slack-modal-flow.js
+++ b/bot/shared/services/messaging/slack-modal-flow.js
@@ -81,6 +81,20 @@ function buildEndpointModal(config) {
     /** Called when a shortcut/button opens the FIRST modal. Returns a Slack `views.open` `view` argument. */
     async buildInitialView(ctx) {
       const response = await init(ctx);
+      if (response?.data?.error) {
+        // init() can legitimately fail for a kind whose first screen depends
+        // on state a prior async step must have already populated (e.g.
+        // attendance_mark's roster, sitting in a Redis session a different
+        // flow wrote) — unlike every other kind's init(), which always
+        // unconditionally returns a screen. Without this check, this would
+        // call screenToView(undefined, ...) and throw — there's no view to
+        // open anyway (Slack's trigger_id is single-use), so DM the error
+        // instead and return null for the caller (handleOpenModal) to skip.
+        logToFile('⚠️ Slack modal-flow: init() returned an error with no screen to render', { kind, error: response.data.error.message });
+        const slackWebClient = require('./slack-web-client');
+        await slackWebClient.postMessage(ctx.slackUserId, response.data.error.message);
+        return null;
+      }
       const carry = metadataCarry ? metadataCarry(response.screen, response.data) : undefined;
       const metadata = encodeMetadata(kind, response.screen, ctx.flowToken, carry);
       return screenToView(response.screen, response.data, { ...ctx, metadata });

--- a/bot/shared/services/messaging/text-flow-definitions.js
+++ b/bot/shared/services/messaging/text-flow-definitions.js
@@ -281,7 +281,97 @@ function classSetupFlow() {
   };
 }
 
-const BUILDERS = [studentVideosFlow, settingsFlow, readingAssessmentFlow, classSetupFlow];
+// ── attendance-mark: tap-to-mark absentees, degraded to one free-text reply ──
+//
+// The Meta Flow for this (docs/flows/attendance-marking-flow.json) is a
+// CheckboxGroup over the roster — there's no text equivalent for a real
+// checkbox list, so this collects the same information as one free-text
+// reply instead: the roster is listed by number in the prompt, and the
+// teacher replies with the numbers of absent students (or "none").
+// Synthesises the exact { absent_students, flow_token, class_name,
+// date_display, session_type } response_json shape flow-type-detector.js /
+// AttendanceFlowHandler already expect from a real Flow submission, so
+// whatsapp-bot.js's existing attendance_marking dispatch
+// (FlowResponseHandler.handleAttendanceMarkingFlow) runs completely
+// unchanged — no new server-side attendance logic needed here at all.
+//
+// The roster itself isn't collected from the teacher — it's already sitting
+// in AttendanceConversationService's Redis session (populated by
+// handleMarkingMethodSelection's 'tap' branch), read here by userId exactly
+// like the Slack/Discord tap-to-mark screens do.
+function parseAbsentAttendanceReply(reply, students) {
+  const trimmed = String(reply || '').trim().toLowerCase();
+  const noneKeywords = ['none', 'no one', 'nobody', 'everyone present', 'everyone is here', 'all present'];
+  if (!trimmed || noneKeywords.includes(trimmed)) return [];
+
+  const numbers = trimmed.match(/\d+/g) || [];
+  const ids = [];
+  for (const numStr of numbers) {
+    const index = parseInt(numStr, 10) - 1;
+    if (students[index]) ids.push(students[index].id);
+  }
+  return ids;
+}
+
+function attendanceMarkingFlow() {
+  return {
+    kind: 'attendance-mark',
+    steps: [
+      {
+        id: 'absent_students',
+        freeText: true,
+        prompt: async (answers, context) => {
+          const userId = context?._ctx?.userId;
+          // eslint-disable-next-line global-require -- pulls in redis; load on use
+          const AttendanceConversationService = require('../attendance-conversation.service');
+          const sessionState = await AttendanceConversationService.getSessionState(userId);
+          const students = sessionState?.students || [];
+          const classDisplay = sessionState?.selectedClass
+            ? AttendanceConversationService.formatClassDisplayName(sessionState.selectedClass)
+            : 'your class';
+
+          if (students.length === 0) {
+            return { header: '📋 Mark Attendance', body: `${classDisplay} has no students yet. Say "add class" to add students before marking attendance.` };
+          }
+
+          const roster = students.map((s, i) => `${i + 1}. ${s.student_name}`).join('\n');
+          return {
+            header: '📋 Mark Attendance',
+            body: `${roster}\n\nWho's absent in ${classDisplay} today?\n\nReply with the numbers, separated by commas (e.g. "2, 5"), or "none" if everyone is present.`,
+          };
+        },
+      },
+    ],
+    async onComplete(phone, answers, context) {
+      const userId = context?._ctx?.userId;
+      // eslint-disable-next-line global-require -- see above
+      const AttendanceConversationService = require('../attendance-conversation.service');
+      const sessionState = await AttendanceConversationService.getSessionState(userId);
+      const students = sessionState?.students || [];
+
+      if (!sessionState || students.length === 0) {
+        return { text: 'No attendance session found. Say "attendance" to start again.' };
+      }
+
+      const absentIds = parseAbsentAttendanceReply(answers.absent_students?.title, students);
+      const today = sessionState.selectedDate || new Date().toISOString().split('T')[0];
+      const sessionType = sessionState.sessionType || 'full_day';
+      const className = sessionState.selectedClass?.class_name || 'Class';
+      const flowToken = `${userId}:${sessionState.selectedListId}:${today}:${sessionType}:${encodeURIComponent(className)}`;
+
+      const responseJson = {
+        flow_token: flowToken,
+        absent_students: absentIds,
+        class_name: className,
+        date_display: today,
+        session_type: sessionType,
+      };
+      return { metaMessage: toNfmReply('attendance_marking', responseJson) };
+    },
+  };
+}
+
+const BUILDERS = [studentVideosFlow, settingsFlow, readingAssessmentFlow, classSetupFlow, attendanceMarkingFlow];
 
 /**
  * Registers every text flow. Idempotent (register() overwrites by kind), and
@@ -331,6 +421,7 @@ module.exports = {
   ensureRegistered,
   _resetForTests,
   toNfmReply,
+  parseAbsentAttendanceReply,
   ATTENDANCE_FREQUENCIES,
   READING_LANGUAGES,
   READING_MODES,

--- a/bot/tests/services/attendance-conversation.test.js
+++ b/bot/tests/services/attendance-conversation.test.js
@@ -246,6 +246,23 @@ describe('AttendanceConversationService', () => {
 
       expect(result.action).toBe('AWAIT_VOICE_INPUT');
     });
+
+    // Regression: confirmed live — a real class can exist with zero students
+    // (e.g. setup abandoned right after CLASS_INFO, before ADD_STUDENT). An
+    // empty array is truthy, so the pre-existing `!students` check let this
+    // through, saving a session with students: [] and leaving the
+    // channel-specific marking screen to fail later with a confusing
+    // "no session found" instead of the real, actionable reason.
+    it('should reject tap-to-mark with a clear message when the class has zero students', async () => {
+      mockStudentListService.getStudentsByList.mockResolvedValue({ data: [], error: null });
+
+      const result = await AttendanceConversationService.handleMarkingMethodSelection('user-123', 'tap');
+
+      expect(result.action).toBe('ERROR');
+      expect(result.message).toContain('Grade 4 - A');
+      expect(result.message).toContain('no students yet');
+      expect(mockRedis.set).not.toHaveBeenCalled(); // never saves a dead-end empty-roster session
+    });
   });
 
   describe('formatClassDisplayName', () => {
@@ -349,6 +366,23 @@ describe('AttendanceConversationService', () => {
 
       expect(result.action).toBe('GENERATE_ATTENDANCE');
       expect(result.records.every(r => r.status === 'present')).toBe(true);
+    });
+
+    it('should reject "everyone present" with a clear message when the class has zero students', async () => {
+      const sessionState = {
+        state: 'AWAITING_MARKING_METHOD',
+        userId: 'user-123',
+        selectedListId: 'list-1',
+        selectedClass: { id: 'list-1', class_name: 'Grade 4', section: 'A' }
+      };
+      mockRedis.get.mockResolvedValue(JSON.stringify(sessionState));
+      mockStudentListService.getStudentsByList.mockResolvedValue({ data: [], error: null });
+
+      const result = await AttendanceConversationService.handleEveryonePresent('user-123');
+
+      expect(result.action).toBe('ERROR');
+      expect(result.message).toContain('no students yet');
+      expect(mockRedis.set).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/__mocks__/exceljs.js
+++ b/tests/__mocks__/exceljs.js
@@ -1,0 +1,59 @@
+/**
+ * exceljs mock for the OSS root test suite.
+ *
+ * exceljs is a runtime dependency in bot/node_modules but not the root, and
+ * CI runs the ROOT suite before `cd bot && npm ci` — so any test that
+ * reaches bot/shared/services/attendance-generator.service.js (Excel
+ * register generation) needs this or the suite fails in CI for reasons
+ * unrelated to the test itself.
+ *
+ * Only the surface attendance-generator.service.js actually touches: a
+ * Workbook whose addWorksheet() returns a worksheet with addRow()/
+ * mergeCells()/getColumn(), each producing row/cell/column stand-ins that
+ * tolerate arbitrary property writes (font/alignment/fill/border/numFmt —
+ * cosmetic styling this suite never asserts on) and a real eachCell()
+ * iteration, plus xlsx.writeBuffer().
+ */
+
+function createCell() {
+  return {}; // plain object — arbitrary property writes (font/fill/...) just land on it
+}
+
+function createRow(values) {
+  const cells = (values || []).map(() => createCell());
+  return {
+    getCell: jest.fn((i) => cells[i - 1] || createCell()),
+    eachCell: jest.fn((callback) => cells.forEach((cell, i) => callback(cell, i + 1))),
+  };
+}
+
+function createColumn() {
+  return {};
+}
+
+function createWorksheet() {
+  const columns = [];
+  return {
+    columns: [],
+    addRow: jest.fn((values) => createRow(values)),
+    mergeCells: jest.fn(),
+    getColumn: jest.fn((i) => {
+      columns[i - 1] = columns[i - 1] || createColumn();
+      return columns[i - 1];
+    }),
+  };
+}
+
+class Workbook {
+  constructor() {
+    this.creator = undefined;
+    this.created = undefined;
+    this.xlsx = { writeBuffer: jest.fn(async () => Buffer.from('')) };
+  }
+
+  addWorksheet() {
+    return createWorksheet();
+  }
+}
+
+module.exports = { Workbook };

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -35,6 +35,10 @@ module.exports = {
     '^fluent-ffmpeg$': '<rootDir>/tests/__mocks__/fluent-ffmpeg.js',
     '^@ffmpeg-installer/ffmpeg$': '<rootDir>/tests/__mocks__/ffmpeg-installer.js',
     '^@ffprobe-installer/ffprobe$': '<rootDir>/tests/__mocks__/ffmpeg-installer.js',
+    // exceljs: bot-only dep pulled in transitively by attendance-generator.service.js
+    // (via attendance-flow.handler.js) — anything reaching it needs this mapped
+    // for the root-suite-first CI pass, same rationale as ffmpeg/canvas above.
+    '^exceljs$': '<rootDir>/tests/__mocks__/exceljs.js',
   },
   setupFiles: ['<rootDir>/tests/setup.js'],
   testEnvironment: 'node',

--- a/tests/messaging/discord-modal-flow.test.js
+++ b/tests/messaging/discord-modal-flow.test.js
@@ -45,13 +45,20 @@ function mockDiscordBuilders() {
   }), { virtual: true });
 }
 
+function mockDiscordChannel() {
+  const discordChannel = { sendMessage: jest.fn().mockResolvedValue(true) };
+  jest.doMock('../../bot/shared/services/messaging/discord-channel.service', () => discordChannel);
+  return discordChannel;
+}
+
 function loadModule() {
   jest.resetModules();
   jest.doMock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
   const redis = mockRedis();
   mockDiscordBuilders();
+  const discordChannel = mockDiscordChannel();
   const mod = require('../../bot/shared/services/messaging/discord-modal-flow');
-  return { mod, redis };
+  return { mod, redis, discordChannel };
 }
 
 afterEach(() => jest.resetModules());
@@ -234,6 +241,28 @@ describe('buildEndpointModal', () => {
   it('throws if required config is missing', () => {
     const { mod } = loadModule();
     expect(() => mod.buildEndpointModal({})).toThrow(/needs \{ kind, init, exchange/);
+  });
+
+  // Regression: an endpoint whose init() depends on state a prior async step
+  // must have already populated (attendance_mark's Redis roster is the real
+  // example) can legitimately return {data: {error}} with no screen. Without
+  // this check, startFlow called runScreen(ctx, trigger, undefined, ...),
+  // which called screenToSteps(undefined, ...) and threw BEFORE ever acking
+  // the triggering interaction — confirmed live: Discord showed "the
+  // application didn't respond in time" on every attempt.
+  it('startFlow acks the trigger and sends the error message when init() returns an error with no screen, without ever calling runScreen', async () => {
+    const { mod, discordChannel } = loadModule();
+    const init = jest.fn().mockResolvedValue({ data: { error: { message: 'No attendance session found. Say "attendance" to start again.' } } });
+    const screenToSteps = jest.fn();
+    const renderer = mod.buildEndpointModal({ kind: 'attendance_mark', init, exchange: jest.fn(), screenToSteps, mergeScreenData: jest.fn() });
+    const trigger = fakeTriggerInteraction();
+
+    const result = await renderer.startFlow({ userId: 'u1', discordUserId: 'U1', flowToken: 'u1:attendance_mark:1' }, trigger);
+
+    expect(result).toBe('finished');
+    expect(trigger.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(screenToSteps).not.toHaveBeenCalled();
+    expect(discordChannel.sendMessage).toHaveBeenCalledWith('discord:U1', 'No attendance session found. Say "attendance" to start again.');
   });
 
   it('startFlow -> runScreen opens a modal directly for a screen with no enum fields at all', async () => {

--- a/tests/messaging/slack-modal-flow.test.js
+++ b/tests/messaging/slack-modal-flow.test.js
@@ -6,6 +6,9 @@
  */
 
 jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+jest.mock('../../bot/shared/services/messaging/slack-web-client', () => ({
+  postMessage: jest.fn().mockResolvedValue(undefined),
+}));
 
 const { buildEndpointModal, encodeMetadata, decodeMetadata } = require('../../bot/shared/services/messaging/slack-modal-flow');
 
@@ -54,6 +57,28 @@ describe('buildEndpointModal', () => {
     expect(endpoint.init).toHaveBeenCalledWith({ userId: 'u1', flowToken: 'u1:fake:169' });
     expect(view.screen).toBe('STEP_ONE');
     expect(decodeMetadata(view.private_metadata)).toEqual({ kind: 'fake', screen: 'STEP_ONE', flowToken: 'u1:fake:169' });
+  });
+
+  // Regression: an endpoint whose init() depends on state a prior async step
+  // must have already populated (attendance_mark's Redis roster is the real
+  // example) can legitimately return {data: {error}} with no screen. Without
+  // this check, buildInitialView called screenToView(undefined, ...) and
+  // threw — confirmed live on Discord's equivalent (startFlow), which is
+  // worse there since it crashes BEFORE acking the triggering interaction
+  // ("the application didn't respond in time"). Slack's failure mode is
+  // milder (no crash, just silently never opens a modal) but still broken.
+  it('buildInitialView DMs the error and returns null (nothing to open) when init() returns an error with no screen', async () => {
+    const endpoint = fakeEndpoint();
+    endpoint.init.mockResolvedValue({ data: { error: { message: 'No attendance session found. Say "attendance" to start again.' } } });
+    const renderer = buildEndpointModal({
+      kind: 'fake', ...endpoint, screenToView: fakeScreenToView, viewToScreenData: fakeViewToScreenData,
+    });
+    const slackWebClient = require('../../bot/shared/services/messaging/slack-web-client');
+
+    const view = await renderer.buildInitialView({ userId: 'u1', flowToken: 'u1:fake:169', slackUserId: 'U0123ABC' });
+
+    expect(view).toBeNull();
+    expect(slackWebClient.postMessage).toHaveBeenCalledWith('U0123ABC', 'No attendance session found. Say "attendance" to start again.');
   });
 
   it('handleSubmission on a non-terminal screen returns response_action: push with the next screen view', async () => {

--- a/tests/messaging/text-flow-definitions.test.js
+++ b/tests/messaging/text-flow-definitions.test.js
@@ -59,9 +59,9 @@ async function run(textFlow, kind, replies, ctx = CTX) {
 }
 
 describe('registration', () => {
-  it('registers the three flows a sandbox needs, and is idempotent', () => {
+  it('registers the five flows a sandbox needs, and is idempotent', () => {
     const { definitions, textFlow } = load();
-    for (const kind of ['student-videos', 'settings', 'reading-assessment']) {
+    for (const kind of ['student-videos', 'settings', 'reading-assessment', 'class-setup', 'attendance-mark']) {
       expect(textFlow.getDefinition(kind)).toBeTruthy();
     }
     definitions.ensureRegistered(); // second call must not throw or duplicate
@@ -214,5 +214,150 @@ describe('endpoint-backed definitions are wired to the real endpoints', () => {
       'user-7', 'SETTINGS_MAIN', { language: 'en', observation_framework: 'oecd' }, 'user-7:settings:1'
     );
     expect(outcome.text).toContain('Saved.');
+  });
+});
+
+describe('attendance-mark: WhatsApp Baileys tap-to-mark, degraded to one free-text reply', () => {
+  const ATTENDANCE_CTX = { _ctx: { userId: 'user-7', flowToken: 'user-7:attendance-mark:1', phone: PHONE } };
+
+  // Both AttendanceConversationService's session AND text-flow.js's OWN
+  // step-tracking state persist through this SAME mocked Redis client — a
+  // blanket mockResolvedValue would make text-flow.js read back the
+  // attendance session object as if it were its own {kind, stepIndex,
+  // answers} state, breaking multi-step advancement entirely. Route by key
+  // instead: the attendance session key returns the fixture, everything
+  // else (text-flow.js's own key) goes through a real in-memory store.
+  function mockSession(session) {
+    const redis = require('../../bot/shared/services/cache/railway-redis.service');
+    const sessionKey = 'attendance:session:user-7';
+    const store = new Map();
+    redis.get.mockImplementation(async (key) => {
+      if (key === sessionKey) return session ? JSON.stringify(session) : null;
+      return store.has(key) ? store.get(key) : null;
+    });
+    redis.set.mockImplementation(async (key, value) => { store.set(key, value); return true; });
+    redis.delete.mockImplementation(async (key) => { store.delete(key); return true; });
+  }
+
+  const SESSION = {
+    selectedClass: { class_name: 'Grade 3', section: 'A' },
+    selectedListId: 'list-1',
+    selectedDate: '2026-08-25',
+    sessionType: 'morning',
+    students: [
+      { id: 's1', student_name: 'Zara Abdul' },
+      { id: 's2', student_name: 'Ahmed Khan' },
+      { id: 's3', student_name: 'Fatima Noor' },
+    ],
+  };
+
+  it('lists the roster by number and asks who is absent', async () => {
+    mockSession(SESSION);
+    const { textFlow } = load();
+
+    const first = await textFlow.start(PHONE, 'attendance-mark', {}, ATTENDANCE_CTX);
+    expect(first.kind).toBe('text');
+    expect(first.prompt.body).toContain('1. Zara Abdul');
+    expect(first.prompt.body).toContain('2. Ahmed Khan');
+    expect(first.prompt.body).toContain('3. Fatima Noor');
+  });
+
+  it('shows a "no students yet" prompt instead of an empty roster', async () => {
+    mockSession({ ...SESSION, students: [] });
+    const { textFlow } = load();
+
+    const first = await textFlow.start(PHONE, 'attendance-mark', {}, ATTENDANCE_CTX);
+    expect(first.prompt.body).toMatch(/no students yet/i);
+  });
+
+  it('produces an nfm_reply that flow-type-detector routes to attendance_marking', async () => {
+    mockSession(SESSION);
+    const { textFlow } = load();
+    const definition = textFlow.getDefinition('attendance-mark');
+
+    const done = await run(textFlow, 'attendance-mark', ['2, 3'], ATTENDANCE_CTX);
+    expect(done.status).toBe('complete');
+
+    const { metaMessage } = await definition.onComplete(PHONE, done.answers, done.context);
+    const responseJson = JSON.parse(metaMessage.interactive.nfm_reply.response_json);
+    const { detectFlowType } = require('../../bot/shared/utils/flow-type-detector');
+    expect(detectFlowType(responseJson)).toBe('attendance_marking');
+  });
+
+  it('carries the exact fields+formats AttendanceFlowHandler/flow-response.handler.js parse', async () => {
+    mockSession(SESSION);
+    const { textFlow } = load();
+    const definition = textFlow.getDefinition('attendance-mark');
+
+    const done = await run(textFlow, 'attendance-mark', ['2'], ATTENDANCE_CTX);
+    const { metaMessage } = await definition.onComplete(PHONE, done.answers, done.context);
+    const responseJson = JSON.parse(metaMessage.interactive.nfm_reply.response_json);
+
+    // flow_token format flow-response.handler.js splits on ':' —
+    // userId:listId:date:sessionType:encodedClassName
+    expect(responseJson.flow_token).toBe('user-7:list-1:2026-08-25:morning:Grade%203');
+    expect(responseJson.absent_students).toEqual(['s2']);
+    expect(responseJson.class_name).toBe('Grade 3');
+    expect(responseJson.date_display).toBe('2026-08-25');
+    expect(responseJson.session_type).toBe('morning');
+  });
+
+  it('"none" marks everyone present (an empty absent_students list)', async () => {
+    mockSession(SESSION);
+    const { textFlow } = load();
+    const definition = textFlow.getDefinition('attendance-mark');
+
+    const done = await run(textFlow, 'attendance-mark', ['none'], ATTENDANCE_CTX);
+    const { metaMessage } = await definition.onComplete(PHONE, done.answers, done.context);
+    const responseJson = JSON.parse(metaMessage.interactive.nfm_reply.response_json);
+    expect(responseJson.absent_students).toEqual([]);
+  });
+
+  it('onComplete rejects with a clear message when no session exists (stale/expired)', async () => {
+    mockSession(null);
+    const { textFlow } = load();
+    const definition = textFlow.getDefinition('attendance-mark');
+
+    const done = await run(textFlow, 'attendance-mark', ['none'], ATTENDANCE_CTX);
+    const outcome = await definition.onComplete(PHONE, done.answers, done.context);
+    expect(outcome.text).toMatch(/no attendance session/i);
+    expect(outcome.metaMessage).toBeUndefined();
+  });
+});
+
+describe('parseAbsentAttendanceReply', () => {
+  const { parseAbsentAttendanceReply } = require('../../bot/shared/services/messaging/text-flow-definitions');
+  const students = [{ id: 's1' }, { id: 's2' }, { id: 's3' }];
+
+  it('parses comma-separated numbers into the matching student ids', () => {
+    expect(parseAbsentAttendanceReply('2, 3', students)).toEqual(['s2', 's3']);
+  });
+
+  it('parses space-separated numbers with no commas', () => {
+    expect(parseAbsentAttendanceReply('1 3', students)).toEqual(['s1', 's3']);
+  });
+
+  it.each(['none', 'No One', 'NOBODY', 'everyone present', ''])('treats %j as everyone present', (reply) => {
+    expect(parseAbsentAttendanceReply(reply, students)).toEqual([]);
+  });
+
+  it('ignores out-of-range numbers rather than throwing', () => {
+    expect(parseAbsentAttendanceReply('1, 99', students)).toEqual(['s1']);
+  });
+});
+
+describe('attendance-mark: the fields are the ones the real handler actually reads', () => {
+  it('flow-response.handler.js + attendance-flow.handler.js reference each synthesised field name', () => {
+    // flow_token/absent_students/class_name are read in flow-response.handler.js
+    // (the flow_token split + the marking-flow dispatch); date_display/session_type
+    // are read one level down, in AttendanceFlowHandler.parseMarkingFlowResponse.
+    const combined = [
+      path.resolve(__dirname, '../../bot/shared/handlers/flow-response.handler.js'),
+      path.resolve(__dirname, '../../bot/shared/handlers/attendance-flow.handler.js'),
+    ].map((p) => fs.readFileSync(p, 'utf-8')).join('\n');
+
+    for (const field of ['absent_students', 'flow_token', 'class_name', 'date_display', 'session_type']) {
+      expect(combined).toContain(field);
+    }
   });
 });

--- a/tests/routes/attendance-marking-endpoint.test.js
+++ b/tests/routes/attendance-marking-endpoint.test.js
@@ -1,0 +1,99 @@
+/**
+ * attendance-marking-endpoint.js — the Slack/Discord modal-workaround
+ * counterpart to the WhatsApp attendance-marking Flow. Unlike
+ * attendance-setup-endpoint.js (only exercised indirectly via
+ * slack-flow-registry.test.js), this one has real branching logic (session
+ * lookup, absent/present record building) worth testing directly rather
+ * than only through a mock at the registry layer.
+ */
+
+const mockConversationService = {
+  getSessionState: jest.fn(),
+  formatClassDisplayName: jest.fn((cls) => (cls?.section ? `${cls.class_name} - ${cls.section}` : cls?.class_name)),
+};
+jest.mock('../../bot/shared/services/attendance-conversation.service', () => mockConversationService);
+jest.mock('../../bot/shared/utils/logger', () => ({ logToFile: jest.fn() }));
+
+const endpoint = require('../../bot/shared/routes/attendance-marking-endpoint');
+
+describe('handleMarkingInit', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns MARK_ABSENT with the roster from the existing tap-to-mark session', async () => {
+    mockConversationService.getSessionState.mockResolvedValue({
+      selectedClass: { class_name: 'Grade 3', section: 'A' },
+      students: [
+        { id: 's1', student_name: 'Zara Abdul' },
+        { id: 's2', student_name: 'Ahmed Khan' },
+      ],
+    });
+
+    const result = await endpoint.handleMarkingInit('u1');
+
+    expect(result.screen).toBe('MARK_ABSENT');
+    expect(result.data.class_display).toBe('Grade 3 - A');
+    expect(result.data.students).toEqual([
+      { id: 's1', title: 'Zara Abdul' },
+      { id: 's2', title: 'Ahmed Khan' },
+    ]);
+  });
+
+  it('returns an error when no session exists (modal opened stale/out of order)', async () => {
+    mockConversationService.getSessionState.mockResolvedValue(null);
+    const result = await endpoint.handleMarkingInit('u1');
+    expect(result.data.error.message).toMatch(/no attendance session/i);
+  });
+
+  it('returns an error when the session has no roster yet', async () => {
+    mockConversationService.getSessionState.mockResolvedValue({ selectedClass: {}, students: [] });
+    const result = await endpoint.handleMarkingInit('u1');
+    expect(result.data.error).toBeTruthy();
+  });
+});
+
+describe('handleMarkingExchange', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const sessionState = {
+    selectedClass: { class_name: 'Grade 3', section: 'A' },
+    selectedListId: 'list-1',
+    selectedDate: '2026-08-25',
+    sessionType: 'morning',
+    students: [
+      { id: 's1', student_name: 'Zara Abdul', father_name: null, roll_number: 1 },
+      { id: 's2', student_name: 'Ahmed Khan', father_name: null, roll_number: 2 },
+    ],
+  };
+
+  it('marks checked students absent and everyone else present', async () => {
+    mockConversationService.getSessionState.mockResolvedValue(sessionState);
+
+    const result = await endpoint.handleMarkingExchange('u1', 'MARK_ABSENT', { absent_student_ids: ['s2'] });
+
+    expect(result.screen).toBe('SUCCESS');
+    expect(result.data.records).toEqual([
+      expect.objectContaining({ studentId: 's1', status: 'present' }),
+      expect.objectContaining({ studentId: 's2', status: 'absent' }),
+    ]);
+    expect(result.data.stats).toEqual({ total: 2, present: 1, absent: 1, attendanceRate: '50.00%' });
+    expect(result.data.success_message).toContain('Grade 3 - A');
+    expect(result.data.selectedListId).toBe('list-1');
+  });
+
+  it('treats an empty absent list as everyone present', async () => {
+    mockConversationService.getSessionState.mockResolvedValue(sessionState);
+    const result = await endpoint.handleMarkingExchange('u1', 'MARK_ABSENT', { absent_student_ids: [] });
+    expect(result.data.stats).toEqual({ total: 2, present: 2, absent: 0, attendanceRate: '100%' });
+  });
+
+  it('rejects an unknown screen', async () => {
+    const result = await endpoint.handleMarkingExchange('u1', 'NOT_A_SCREEN', {});
+    expect(result.data.error).toBeTruthy();
+  });
+
+  it('errors when the session expired between opening the modal and submitting it', async () => {
+    mockConversationService.getSessionState.mockResolvedValue(null);
+    const result = await endpoint.handleMarkingExchange('u1', 'MARK_ABSENT', { absent_student_ids: [] });
+    expect(result.data.error.message).toMatch(/session expired/i);
+  });
+});

--- a/tests/routes/discord-flow-registry.test.js
+++ b/tests/routes/discord-flow-registry.test.js
@@ -24,6 +24,28 @@ jest.mock('../../bot/shared/routes/attendance-setup-endpoint', () => ({
   })),
   handleDoneAction: jest.fn(async () => ({ screen: 'SUCCESS', data: { success_message: 'Class ready with 3 students.' } })),
 }));
+jest.mock('../../bot/shared/routes/attendance-marking-endpoint', () => ({
+  handleMarkingInit: jest.fn(async () => ({
+    screen: 'MARK_ABSENT',
+    data: { class_display: 'Grade 3 - A', students: [{ id: 's1', title: 'Zara Abdul' }] },
+  })),
+  handleMarkingExchange: jest.fn(async () => ({
+    screen: 'SUCCESS',
+    data: {
+      success_message: 'Attendance Recorded — Present: 1, Absent: 0',
+      selectedClass: { class_name: 'Grade 3', section: 'A' },
+      selectedListId: 'list-1',
+      records: [{ studentId: 's1', studentName: 'Zara Abdul', status: 'present', confidence: 1 }],
+      stats: { total: 1, present: 1, absent: 0, attendanceRate: '100%' },
+    },
+  })),
+}));
+jest.mock('../../bot/shared/services/attendance-delivery.service', () => ({
+  processAndDeliver: jest.fn(async () => ({ success: true, sessionId: 'sess-1' })),
+}));
+jest.mock('../../bot/shared/services/attendance-conversation.service', () => ({
+  clearSessionState: jest.fn(async () => true),
+}));
 jest.mock('../../bot/shared/routes/exam-confirm-endpoint', () => ({
   handleExamConfirmInit: jest.fn(async () => ({ screen: 'CONFIRM_STUDENTS', data: { students: [{ id: '0', title: '1. Zara' }] } })),
   handleExamConfirmDataExchange: jest.fn(async () => ({
@@ -77,12 +99,13 @@ function fakeTrigger() {
 }
 
 describe('discord-flow-registry', () => {
-  it('ensureRegistered() registers all five renderers', () => {
+  it('ensureRegistered() registers all six renderers', () => {
     const registry = load();
     registry.ensureRegistered();
     expect(registry.get('registration')).toBeTruthy();
     expect(registry.get('settings')).toBeTruthy();
     expect(registry.get('attendance')).toBeTruthy();
+    expect(registry.get('attendance_mark')).toBeTruthy();
     expect(registry.get('exam_confirm')).toBeTruthy();
     expect(registry.get('reading_assessment')).toBeTruthy();
     expect(registry.get('nonexistent')).toBeUndefined();
@@ -185,6 +208,60 @@ describe('discord-flow-registry', () => {
       await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'ADD_STUDENT', {});
 
       expect(discordChannel.sendMessage).toHaveBeenCalledWith('discord:D0123', 'Class ready with 3 students.');
+    });
+  });
+
+  describe('attendance_mark renderer', () => {
+    it('calls handleMarkingInit with the resolved userId', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const { handleMarkingInit } = require('../../bot/shared/routes/attendance-marking-endpoint');
+
+      const renderer = registry.get('attendance_mark');
+      await renderer.startFlow(
+        { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:attendance_mark:169' },
+        fakeTrigger(),
+      );
+
+      expect(handleMarkingInit).toHaveBeenCalledWith('u1');
+    });
+
+    it('MARK_ABSENT is a one-shot screen — reaching SUCCESS calls onFinish directly, no loop/modal involved', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const discordChannel = require('../../bot/shared/services/messaging/discord-channel.service');
+      const AttendanceDeliveryService = require('../../bot/shared/services/attendance-delivery.service');
+      const AttendanceConversationService = require('../../bot/shared/services/attendance-conversation.service');
+
+      const renderer = registry.get('attendance_mark');
+      const ctx = { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:attendance_mark:169' };
+      const result = await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'MARK_ABSENT', {});
+
+      expect(result).toBe('finished');
+      expect(discordChannel.sendMessage).toHaveBeenCalledWith('discord:D0123', 'Attendance Recorded — Present: 1, Absent: 0');
+      expect(AttendanceDeliveryService.processAndDeliver).toHaveBeenCalledWith('u1', 'discord:D0123', expect.objectContaining({
+        selectedListId: 'list-1',
+        markingMethod: 'tap',
+        records: [{ studentId: 's1', studentName: 'Zara Abdul', status: 'present', confidence: 1 }],
+        summary: { present: 1, absent: 0, attendancePercentage: 100 },
+      }));
+      expect(AttendanceConversationService.clearSessionState).toHaveBeenCalledWith('u1');
+    });
+
+    it('onFinish sends an error message and still clears session state when delivery fails', async () => {
+      const registry = load();
+      registry.ensureRegistered();
+      const AttendanceDeliveryService = require('../../bot/shared/services/attendance-delivery.service');
+      AttendanceDeliveryService.processAndDeliver.mockResolvedValueOnce({ success: false, error: 'R2 upload failed' });
+      const discordChannel = require('../../bot/shared/services/messaging/discord-channel.service');
+      const AttendanceConversationService = require('../../bot/shared/services/attendance-conversation.service');
+
+      const renderer = registry.get('attendance_mark');
+      const ctx = { userId: 'u1', discordUserId: 'D0123', flowToken: 'u1:attendance_mark:169' };
+      await renderer._advance(ctx, { deferUpdate: jest.fn() }, 'MARK_ABSENT', {});
+
+      expect(discordChannel.sendMessage).toHaveBeenCalledWith('discord:D0123', expect.stringContaining('R2 upload failed'));
+      expect(AttendanceConversationService.clearSessionState).toHaveBeenCalledWith('u1');
     });
   });
 

--- a/tests/routes/discord-views-attendance-marking.test.js
+++ b/tests/routes/discord-views-attendance-marking.test.js
@@ -1,0 +1,93 @@
+/**
+ * discord-views/attendance-marking.view.js — the tap-to-mark
+ * StringSelectMenu screen mapping. No existing test file directly exercises
+ * discord-views/*'s screenToSteps/mergeScreenData pure functions (the
+ * registry test's fakeTrigger() only ever returns a generic 'some_value'
+ * selection), so this is the first to test the real chunking/merge logic on
+ * realistic data.
+ */
+
+const attendanceMarkingView = require('../../bot/shared/routes/discord-views/attendance-marking.view');
+
+describe('attendance-marking.view — screenToSteps', () => {
+  const students = [
+    { id: 's1', title: 'Zara Abdul' },
+    { id: 's2', title: 'Ahmed Khan' },
+  ];
+
+  it('MARK_ABSENT renders a single select step for a roster under the 25-option cap', () => {
+    const { steps, textFields, title } = attendanceMarkingView.screenToSteps('MARK_ABSENT', {
+      class_display: 'Grade 3 - A', students,
+    });
+
+    expect(textFields).toEqual([]); // all-enum screen — never opens a Discord Modal
+    expect(title).toBe('Mark Attendance');
+    expect(steps).toHaveLength(1);
+    expect(steps[0].fieldName).toBe('absent_students_chunk_0');
+    expect(steps[0].multi).toBe(true);
+    expect(steps[0].promptText).toContain('Grade 3 - A');
+
+    const menu = steps[0].buildMenu().toJSON();
+    expect(menu.min_values).toBe(0);
+    expect(menu.max_values).toBe(2);
+    expect(menu.options).toEqual([
+      { label: 'Zara Abdul', value: 's1' },
+      { label: 'Ahmed Khan', value: 's2' },
+    ]);
+    // unlike exam-confirm's all-pre-selected "confirmed" semantics, nothing
+    // here should be pre-selected — a selected option means ABSENT.
+    expect(menu.options.some((o) => o.default)).toBe(false);
+  });
+
+  it('chunks a 40-student roster into two sequential select steps (25-option Discord cap)', () => {
+    const bigRoster = Array.from({ length: 40 }, (_, i) => ({ id: String(i), title: `Student ${i}` }));
+    const { steps } = attendanceMarkingView.screenToSteps('MARK_ABSENT', { students: bigRoster });
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0].buildMenu().toJSON().options).toHaveLength(25);
+    expect(steps[1].buildMenu().toJSON().options).toHaveLength(15);
+    expect(steps[0].promptText).toContain('1/2');
+    expect(steps[1].promptText).toContain('2/2');
+  });
+
+  it('handles an empty roster without throwing (zero options, still one step)', () => {
+    const { steps } = attendanceMarkingView.screenToSteps('MARK_ABSENT', { students: [] });
+    expect(steps).toHaveLength(0);
+  });
+
+  it('throws for an unmapped screen', () => {
+    expect(() => attendanceMarkingView.screenToSteps('NOT_A_SCREEN', {})).toThrow(/no screen mapping/);
+  });
+});
+
+describe('attendance-marking.view — mergeScreenData', () => {
+  it('flattens and orders chunked selections by chunk index into absent_student_ids', () => {
+    const enumAnswers = {
+      absent_students_chunk_1: ['s26'],
+      absent_students_chunk_0: ['s1', 's5'],
+    };
+    expect(attendanceMarkingView.mergeScreenData('MARK_ABSENT', enumAnswers)).toEqual({
+      absent_student_ids: ['s1', 's5', 's26'],
+    });
+  });
+
+  it('defaults to an empty array when nobody is selected (everyone present)', () => {
+    expect(attendanceMarkingView.mergeScreenData('MARK_ABSENT', { absent_students_chunk_0: [] })).toEqual({
+      absent_student_ids: [],
+    });
+  });
+
+  it('returns {} for an unrecognized screen', () => {
+    expect(attendanceMarkingView.mergeScreenData('UNKNOWN', {})).toEqual({});
+  });
+});
+
+describe('attendance-marking.view — chunkStudents', () => {
+  it('splits at exactly the 25-item CHUNK_SIZE boundary', () => {
+    const roster = Array.from({ length: 26 }, (_, i) => ({ id: String(i), title: `S${i}` }));
+    const chunks = attendanceMarkingView.chunkStudents(roster);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toHaveLength(25);
+    expect(chunks[1]).toHaveLength(1);
+  });
+});

--- a/tests/routes/slack-flow-registry.test.js
+++ b/tests/routes/slack-flow-registry.test.js
@@ -29,6 +29,28 @@ jest.mock('../../bot/shared/routes/attendance-setup-endpoint', () => ({
   })),
   handleDoneAction: jest.fn(async () => ({ screen: 'SUCCESS', data: { success_message: 'Class ready with 3 students.' } })),
 }));
+jest.mock('../../bot/shared/routes/attendance-marking-endpoint', () => ({
+  handleMarkingInit: jest.fn(async () => ({
+    screen: 'MARK_ABSENT',
+    data: { class_display: 'Grade 3 - A', students: [{ id: 's1', title: 'Zara Abdul' }] },
+  })),
+  handleMarkingExchange: jest.fn(async () => ({
+    screen: 'SUCCESS',
+    data: {
+      success_message: 'Attendance Recorded — Present: 1, Absent: 0',
+      selectedClass: { class_name: 'Grade 3', section: 'A' },
+      selectedListId: 'list-1',
+      records: [{ studentId: 's1', studentName: 'Zara Abdul', status: 'present', confidence: 1 }],
+      stats: { total: 1, present: 1, absent: 0, attendanceRate: '100%' },
+    },
+  })),
+}));
+jest.mock('../../bot/shared/services/attendance-delivery.service', () => ({
+  processAndDeliver: jest.fn(async () => ({ success: true, sessionId: 'sess-1' })),
+}));
+jest.mock('../../bot/shared/services/attendance-conversation.service', () => ({
+  clearSessionState: jest.fn(async () => true),
+}));
 jest.mock('../../bot/shared/routes/exam-confirm-endpoint', () => ({
   handleExamConfirmInit: jest.fn(async () => ({
     screen: 'CONFIRM_STUDENTS',
@@ -178,7 +200,68 @@ describe('slack-flow-registry', () => {
     });
   });
 
-  describe('exam_confirm renderer', () => {
+  describe('attendance_mark renderer', () => {
+  it('is registered alongside registration/settings/attendance/exam_confirm', () => {
+    const registry = load();
+    registry.ensureRegistered();
+    expect(registry.get('attendance_mark')).toBeTruthy();
+  });
+
+  it('calls handleMarkingInit with the resolved userId on buildInitialView', async () => {
+    const registry = load();
+    registry.ensureRegistered();
+    const { handleMarkingInit } = require('../../bot/shared/routes/attendance-marking-endpoint');
+
+    const renderer = registry.get('attendance_mark');
+    await renderer.buildInitialView({ userId: 'u1', flowToken: 'u1:attendance_mark:169' });
+
+    expect(handleMarkingInit).toHaveBeenCalledWith('u1');
+  });
+
+  it('onFinish DMs the success message, then hands off to AttendanceDeliveryService with a slack:-prefixed recipient', async () => {
+    const registry = load();
+    registry.ensureRegistered();
+    const slackWebClient = require('../../bot/shared/services/messaging/slack-web-client');
+    const AttendanceDeliveryService = require('../../bot/shared/services/attendance-delivery.service');
+    const AttendanceConversationService = require('../../bot/shared/services/attendance-conversation.service');
+
+    const renderer = registry.get('attendance_mark');
+    const ctx = { userId: 'u1', flowToken: 'u1:attendance_mark:169', slackUserId: 'U0123ABC' };
+    const result = await renderer.handleSubmission(ctx, 'MARK_ABSENT', {
+      absent_students_block: { absent_students: { selected_options: [] } },
+    });
+
+    expect(result).toEqual({ response_action: 'clear' });
+    expect(slackWebClient.postMessage).toHaveBeenCalledWith('U0123ABC', 'Attendance Recorded — Present: 1, Absent: 0');
+    expect(AttendanceDeliveryService.processAndDeliver).toHaveBeenCalledWith('u1', 'slack:U0123ABC', expect.objectContaining({
+      selectedListId: 'list-1',
+      markingMethod: 'tap',
+      records: [{ studentId: 's1', studentName: 'Zara Abdul', status: 'present', confidence: 1 }],
+      summary: { present: 1, absent: 0, attendancePercentage: 100 },
+    }));
+    expect(AttendanceConversationService.clearSessionState).toHaveBeenCalledWith('u1');
+  });
+
+  it('onFinish posts an error message and still clears session state when delivery fails', async () => {
+    const registry = load();
+    registry.ensureRegistered();
+    const AttendanceDeliveryService = require('../../bot/shared/services/attendance-delivery.service');
+    AttendanceDeliveryService.processAndDeliver.mockResolvedValueOnce({ success: false, error: 'R2 upload failed' });
+    const slackWebClient = require('../../bot/shared/services/messaging/slack-web-client');
+    const AttendanceConversationService = require('../../bot/shared/services/attendance-conversation.service');
+
+    const renderer = registry.get('attendance_mark');
+    const ctx = { userId: 'u1', flowToken: 'u1:attendance_mark:169', slackUserId: 'U0123ABC' };
+    await renderer.handleSubmission(ctx, 'MARK_ABSENT', {
+      absent_students_block: { absent_students: { selected_options: [] } },
+    });
+
+    expect(slackWebClient.postMessage).toHaveBeenCalledWith('U0123ABC', expect.stringContaining('R2 upload failed'));
+    expect(AttendanceConversationService.clearSessionState).toHaveBeenCalledWith('u1');
+  });
+});
+
+describe('exam_confirm renderer', () => {
     it('calls handleExamConfirmInit with the session id passed as flowToken (not a minted token)', async () => {
       const registry = load();
       registry.ensureRegistered();

--- a/tests/routes/slack-modal-interactions-handler.test.js
+++ b/tests/routes/slack-modal-interactions-handler.test.js
@@ -180,9 +180,18 @@ describe('handleAttendanceFinish', () => {
     expect(handled).toBe(true);
     expect(handleDoneAction).toHaveBeenCalledWith('list-1', 'Grade 3 - A');
     expect(slackWebClient.postMessage).toHaveBeenCalledWith('U0123ABC', 'Class ready with 2 students.');
+    // Regression: a real success DM used to leave the stale ADD_STUDENT
+    // modal open behind it, looking broken even though the DM landed. The
+    // modal itself must now also reflect completion.
+    expect(slackWebClient.updateView).toHaveBeenCalledWith('V0123VIEW', expect.objectContaining({
+      title: expect.objectContaining({ text: 'All set!' }),
+      blocks: expect.arrayContaining([
+        expect.objectContaining({ block_id: 'success_block', text: expect.objectContaining({ text: 'Class ready with 2 students.' }) }),
+      ]),
+    }));
   });
 
-  it('reopens ADD_STUDENT with the error when handleDoneAction rejects (no students added yet)', async () => {
+  it('reopens ADD_STUDENT with the error VISIBLE when handleDoneAction rejects (no students added yet)', async () => {
     const handleDoneAction = jest.fn().mockResolvedValue({
       screen: 'ADD_STUDENT',
       data: { list_id: 'list-1', class_display: 'Grade 3 - A', heading: 'Add Student #1', error: { message: 'Please add at least one student.' } },
@@ -203,7 +212,17 @@ describe('handleAttendanceFinish', () => {
 
     expect(handled).toBe(true);
     expect(slackWebClient.postMessage).not.toHaveBeenCalled();
-    expect(slackWebClient.updateView).toHaveBeenCalledWith('V0123VIEW', expect.objectContaining({ title: expect.objectContaining({ text: 'Add Student #1' }) }));
+    // Regression: the title alone was never enough — the reopened view used
+    // to be pixel-identical to before because attendance.view.js never
+    // rendered data.error into any block, so this same title assertion
+    // passed even while the bug was live. Assert the error text itself
+    // actually appears in the re-rendered modal's blocks.
+    expect(slackWebClient.updateView).toHaveBeenCalledWith('V0123VIEW', expect.objectContaining({
+      title: expect.objectContaining({ text: 'Add Student #1' }),
+      blocks: expect.arrayContaining([
+        expect.objectContaining({ block_id: 'add_student_error_block', text: expect.objectContaining({ text: '⚠️ Please add at least one student.' }) }),
+      ]),
+    }));
   });
 
   it('does not throw if handleDoneAction itself throws', async () => {

--- a/tests/routes/slack-modal-interactions-handler.test.js
+++ b/tests/routes/slack-modal-interactions-handler.test.js
@@ -111,6 +111,23 @@ describe('handleOpenModal', () => {
     expect(handled).toBe(true);
   });
 
+  // Regression: buildInitialView returns null when the endpoint's init()
+  // itself errored (e.g. attendance_mark with no active session) — it
+  // already DMed the teacher itself in that case, so there's no view left to
+  // open. Calling openView(trigger_id, null) would be a second, spurious
+  // failure on top of the real one; this must be skipped instead.
+  it('skips openView when buildInitialView returns null (init() already handled its own error)', async () => {
+    const renderer = { buildInitialView: jest.fn().mockResolvedValue(null) };
+    const { handler, slackWebClient } = loadHandler({ renderer });
+
+    const handled = await handler.handleOpenModal({
+      trigger_id: 'trigger-999', user: { id: 'U0123ABC' }, actions: [{ action_id: 'open_modal:attendance_mark' }],
+    });
+
+    expect(handled).toBe(true);
+    expect(slackWebClient.openView).not.toHaveBeenCalled();
+  });
+
   it('exam_confirm: uses the embedded sessionId directly as flowToken, never calling buildFlowToken or getOrCreateUserByChannel', async () => {
     const renderer = { buildInitialView: jest.fn().mockResolvedValue({ type: 'modal' }) };
     const { handler, getOrCreateUserByChannel, slackWebClient, flowRegistry } = loadHandler({ renderer });

--- a/tests/routes/slack-views-attendance-exam-confirm.test.js
+++ b/tests/routes/slack-views-attendance-exam-confirm.test.js
@@ -6,6 +6,7 @@
 
 const attendanceView = require('../../bot/shared/routes/slack-views/attendance.view');
 const examConfirmView = require('../../bot/shared/routes/slack-views/exam-confirm.view');
+const attendanceMarkingView = require('../../bot/shared/routes/slack-views/attendance-marking.view');
 
 const METADATA = JSON.stringify({ kind: 'attendance', screen: 'CLASS_INFO', flowToken: 'u1:attendance:169' });
 
@@ -209,5 +210,77 @@ describe('exam-confirm.view — viewToScreenData', () => {
 describe('exam-confirm.view — FIRST_INPUT_BLOCK_ID', () => {
   it('names the checkboxes block for CONFIRM_STUDENTS', () => {
     expect(examConfirmView.FIRST_INPUT_BLOCK_ID.CONFIRM_STUDENTS).toBe('confirmed_students_block');
+  });
+});
+
+describe('attendance-marking.view — screenToView', () => {
+  const students = [
+    { id: 's1', title: 'Zara Abdul' },
+    { id: 's2', title: 'Ahmed Khan' },
+  ];
+
+  it('MARK_ABSENT renders the roster as an optional checkboxes input, nothing pre-checked', () => {
+    const view = attendanceMarkingView.screenToView('MARK_ABSENT', {
+      class_display: 'Grade 3 - A', students,
+    }, { metadata: 'meta' });
+
+    expect(view.type).toBe('modal');
+    expect(view.title.text).toBe('Grade 3 - A');
+    expect(view.submit.text).toBe('Mark Attendance');
+
+    const block = view.blocks.find((b) => b.block_id === 'absent_students_block');
+    expect(block.optional).toBe(true);
+    expect(block.element.type).toBe('checkboxes');
+    expect(block.element.options).toEqual([
+      { text: { type: 'plain_text', text: 'Zara Abdul' }, value: 's1' },
+      { text: { type: 'plain_text', text: 'Ahmed Khan' }, value: 's2' },
+    ]);
+    // unlike exam-confirm's all-pre-checked "confirmed" semantics, a checked
+    // box here means ABSENT — nobody should be pre-selected.
+    expect(block.element.initial_options).toBeUndefined();
+  });
+
+  it('does not chunk a 40-student roster — same no-cap Block Kit checkboxes element as exam-confirm', () => {
+    const bigRoster = Array.from({ length: 40 }, (_, i) => ({ id: String(i), title: `Student ${i}` }));
+    const view = attendanceMarkingView.screenToView('MARK_ABSENT', { students: bigRoster }, { metadata: 'meta' });
+    const block = view.blocks.find((b) => b.block_id === 'absent_students_block');
+    expect(block.element.options).toHaveLength(40);
+  });
+
+  it('SUCCESS renders the success_message as a submit-less confirmation screen', () => {
+    const view = attendanceMarkingView.screenToView('SUCCESS', {
+      success_message: 'Attendance Recorded — Present: 18, Absent: 2',
+    }, { metadata: 'meta' });
+
+    expect(view.submit).toBeUndefined();
+    const successBlock = view.blocks.find((b) => b.block_id === 'success_block');
+    expect(successBlock.text.text).toBe('Attendance Recorded — Present: 18, Absent: 2');
+  });
+
+  it('throws for an unmapped screen', () => {
+    expect(() => attendanceMarkingView.screenToView('NOT_A_SCREEN', {}, { metadata: 'meta' })).toThrow(/no view mapping/);
+  });
+});
+
+describe('attendance-marking.view — viewToScreenData', () => {
+  it('extracts absent_student_ids from the checkboxes selection', () => {
+    const stateValues = {
+      absent_students_block: { absent_students: { selected_options: [{ value: 's1' }] } },
+    };
+    expect(attendanceMarkingView.viewToScreenData('MARK_ABSENT', stateValues)).toEqual({ absent_student_ids: ['s1'] });
+  });
+
+  it('defaults to an empty array when nobody is checked (everyone present)', () => {
+    expect(attendanceMarkingView.viewToScreenData('MARK_ABSENT', {})).toEqual({ absent_student_ids: [] });
+  });
+
+  it('returns {} for an unrecognized screen', () => {
+    expect(attendanceMarkingView.viewToScreenData('UNKNOWN', {})).toEqual({});
+  });
+});
+
+describe('attendance-marking.view — FIRST_INPUT_BLOCK_ID', () => {
+  it('names the checkboxes block for MARK_ABSENT', () => {
+    expect(attendanceMarkingView.FIRST_INPUT_BLOCK_ID.MARK_ABSENT).toBe('absent_students_block');
   });
 });

--- a/tests/routes/slack-views-attendance-exam-confirm.test.js
+++ b/tests/routes/slack-views-attendance-exam-confirm.test.js
@@ -52,6 +52,36 @@ describe('attendance.view — screenToView', () => {
     expect(blockIds).toEqual(['first_name_block', 'last_name_block', 'attendance_finish_block']);
   });
 
+  // Regression: handleDoneAction rejects "I'm Done" with 0 students by
+  // re-returning this same ADD_STUDENT screen with data.error — but this
+  // view never rendered it, so the reopened modal looked pixel-identical to
+  // before and the rejection was invisible to the teacher.
+  it('ADD_STUDENT renders the error block when data.error is present (0-student "I\'m Done" rejection)', () => {
+    const view = attendanceView.screenToView('ADD_STUDENT', {
+      heading: 'Add Student #1',
+      error: { message: 'Please add at least one student before finishing.' },
+    }, { metadata: METADATA });
+
+    const errorBlock = view.blocks.find((b) => b.block_id === 'add_student_error_block');
+    expect(errorBlock).toBeTruthy();
+    expect(errorBlock.text.text).toBe('⚠️ Please add at least one student before finishing.');
+  });
+
+  it('ADD_STUDENT omits the error block when data.error is absent', () => {
+    const view = attendanceView.screenToView('ADD_STUDENT', { heading: 'Add Student #1' }, { metadata: METADATA });
+    expect(view.blocks.find((b) => b.block_id === 'add_student_error_block')).toBeUndefined();
+  });
+
+  it('SUCCESS renders the success_message as a closeable, submit-less confirmation screen', () => {
+    const view = attendanceView.screenToView('SUCCESS', {
+      success_message: 'Your class Grade 3 - A has been created with 3 students.',
+    }, { metadata: METADATA });
+
+    expect(view.submit).toBeUndefined();
+    const successBlock = view.blocks.find((b) => b.block_id === 'success_block');
+    expect(successBlock.text.text).toBe('Your class Grade 3 - A has been created with 3 students.');
+  });
+
   it('throws for an unmapped screen', () => {
     expect(() => attendanceView.screenToView('NOT_A_SCREEN', {}, { metadata: METADATA })).toThrow(/no view mapping/);
   });


### PR DESCRIPTION
## Summary

- **Fix Slack attendance setup**: "I'm Done" with 0 students silently did nothing instead of showing an error (`data.error` was never rendered into the modal); a successful completion left the stale form open behind the confirmation DM.
- **Add Slack tap-to-mark attendance**: a Block Kit `checkboxes` modal (no chunking needed — Slack has no documented option cap, unlike Discord). Reuses the existing `AttendanceDeliveryService` pipeline via a new channel-agnostic `attendance-marking-endpoint.js`.
- **Fix stuck attendance sessions**: saying "attendance" while already mid-flow was misread as an answer to whatever state-specific prompt was pending (e.g. the yes/edit/cancel verification check), with no way back in except explicitly typing "cancel" first. A recognized attendance trigger now restarts the session, mirroring the existing IDLE/COMPLETED path.
- **Add Discord tap-to-mark attendance**: Discord's Modal only supports text inputs, so this reuses the existing `exam-confirm.view.js` precedent — one or more `StringSelectMenu`s (chunked at 25, Discord's per-menu cap), sent as chat messages. Reuses the same channel-agnostic endpoint Slack uses.
- **Fix modal-workaround engines crashing on an `init()` error**: `attendance_mark`'s `init()` can legitimately fail (its roster depends on Redis state a prior step must have populated) — every other kind's `init()` always unconditionally succeeds, so this was a latent framework gap. On Discord this crashed *before* acking the triggering interaction ("the application didn't respond in time"); on Slack it silently failed to open a modal. Both engines now check for the error and degrade gracefully.
- **Fix attendance marking silently accepting a class with zero students**: an empty roster array is truthy, so `error || !students` let a real 0-student class (e.g. setup abandoned mid-flow) through, saving a dead-end session that surfaced later as a confusing "no session found." Now rejects with a clear, actionable message.

All six items were found and fixed via live end-to-end testing on both Slack and Discord workspaces, including one root-caused against production data (a genuine 0-student class in the live database).

## Test plan
- [x] Root suite: `node tests/run.js` — 205/205 suites, 2525 tests passing
- [x] Live-tested end-to-end on Slack: class setup (0-student rejection + success screen), tap-to-mark attendance marking, mid-flow restart
- [x] Live-tested end-to-end on Discord: tap-to-mark attendance marking (chunked select menus), the `init()` crash fix, the empty-roster fix
- [x] New/updated unit tests accompany every commit (registry-level onFinish/delivery assertions, view-layer rendering assertions against real `discord.js`/Block Kit shapes, and framework-level regression tests for the crash fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)