### PR TITLE
release: v2.1.0 — the curriculum builder + knowledge graph

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rumi-bot",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Rumi - AI Teaching Assistant for WhatsApp",
   "main": "whatsapp-bot.js",
   "scripts": {

--- a/curriculum/README.md
+++ b/curriculum/README.md
@@ -3,7 +3,7 @@
 Turn a folder of official textbook PDFs into a faithful, quality-gated **lesson-plan corpus** —
 agent-driven, plug-and-play, credential-free but for your own model key.
 
-[![Watch the walkthrough — textbooks in, lesson plans out](curriculum_film_poster.png)](https://github.com/Orenda-Project/rumi-platform/releases/download/curriculum-v1/Curriculum_Textbooks_In_Lesson_Plans_Out.mp4)
+[![Watch the walkthrough — textbooks in, lesson plans out](curriculum_film_poster.png)](https://github.com/Orenda-Project/rumi-platform/releases/download/v2.1.0/Curriculum_Textbooks_In_Lesson_Plans_Out.mp4)
 
 *A 105-second walkthrough (click to play). The curriculum, as a knowledge graph:*
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rumi-platform",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Rumi - AI Teaching Assistant for WhatsApp. Open-source platform for deploying AI-powered educational chatbots.",
   "private": true,
   "bin": {


### PR DESCRIPTION
Bumps package version to 2.1.0 and points the curriculum README walkthrough at the v2.1.0 release asset, so the curriculum drop lands as a proper semver release (following v1.0.0 → v1.2.0 → v2.0.0). The v2.1.0 GitHub Release (with the film) is cut once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)